### PR TITLE
cartservice - fix proto file path to build independently

### DIFF
--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\..\pb\demo.proto" GrpcServices="Both" />
+    <Protobuf Include="..\..\..\pb\*.proto" GrpcServices="Both" />
   </ItemGroup>
 </Project>

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="**\*.proto" GrpcServices="Both" />
+    <Protobuf Include="..\..\..\pb\demo.proto" GrpcServices="Both" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Change the path to the proto file in the csproj, without which we cannot build/run the cartservice independently.