### PR TITLE
emailservice: remove explicit `PORT` env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - "${EMAIL_SERVICE_PORT}:${EMAIL_SERVICE_PORT}"
     environment:
       - APP_ENV=production
-      - PORT=${EMAIL_SERVICE_PORT}
+      - EMAIL_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://otelcol:4318/v1/traces
       - OTEL_RESOURCE_ATTRIBUTES=service.name=emailservice
     depends_on:

--- a/src/emailservice/email_server.rb
+++ b/src/emailservice/email_server.rb
@@ -6,6 +6,8 @@ require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"
 require "opentelemetry/instrumentation/sinatra"
 
+set :port, ENV["EMAIL_SERVICE_PORT"]
+
 OpenTelemetry::SDK.configure do |c|
   c.use "OpenTelemetry::Instrumentation::Sinatra"
 end


### PR DESCRIPTION
## Changes

This is a follow-up to #248, which in turn was resolving: https://github.com/open-telemetry/opentelemetry-demo/pull/242#discussion_r933603430

The ruby app is relying on convention, and by convention a `PORT` env
varable will determine which port the `puma` webserver actually listens
on. So - we don't need to set it explicitly in the compose file, but
that means we need to set it elsewhere somehow.

I tried a few hacks with the dockerfile:
- Trying to pass `PORT=$EMAIL_SERVICE_PORT`
- Trying to pass `-p $EMAIL_SERVICE_PORT` in the command

But those didn't work and I gave up. So instead we just set it directly
in the sinatra app ourselves. (Please don't ask me how that actually
gets set down all the way through sinatra -> rack -> puma, because
truthfully I do not know: rack-based servers are basically magic).

We can see that it works:

```
@ahayworth ➜ /workspaces/opentelemetry-demo-webstore (ahayworth/emailservice-port-things ✗) $ git grep EMAIL_SERVICE_P
ORT
.env:EMAIL_SERVICE_PORT=6060
```

```
@ahayworth ➜ /workspaces/opentelemetry-demo-webstore (ahayworth/emailservice-port-things ✗) $ docker-compose up --build emailservice
email-service            | == Sinatra (v2.2.0) has taken the stage on 6060 for production with backup from Puma
email-service            | I, [2022-08-03T13:08:27.643291 #1]  INFO -- : Instrumentation: OpenTelemetry::Instrumentation::Sinatra was successfully installed with the following options {}
email-service            | Puma starting in single mode...
email-service            | * Puma version: 5.6.4 (ruby 3.1.2-p20) ("Birdie's Version")
email-service            | *  Min threads: 0
email-service            | *  Max threads: 5
email-service            | *  Environment: production
email-service            | *          PID: 1
email-service            | * Listening on http://0.0.0.0:6060
email-service            | Use Ctrl-C to stop
```

cc @mic-max
