### PR TITLE
[featureflag] - exclude erlang/elixir build artifacts in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # All documents to be used in spell check.
-ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)
+ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path '*/node_modules/*' -not -path '*/_build/*' -not -path '*/deps/*' | sort)
 PWD := $(shell pwd)
 
 TOOLS_DIR := ./internal/tools


### PR DESCRIPTION
## Changes

When working with the Erlang/Elixir feature flag service, the developer may encounter an error on some make commands. 
This PR Excludes the `_build` and `deps` build artifact folders from `ALL_DOCS` in Makefile. Allows developers to run `make markdownlint` without getting errors on 3rd party readme files downloaded from the Elixir toolchain.

