### PR TITLE
Fix processid(pid) for currencyservice

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -56,4 +56,4 @@ RUN cd /currencyservice \
     && mkdir -p build && cd build \
     && cmake .. && make -j install
 
-ENTRYPOINT currencyservice ${CURRENCY_SERVICE_PORT}
+ENTRYPOINT ["/usr/local/bin/currencyservice", "${CURRENCY_SERVICE_PORT}"]


### PR DESCRIPTION
Fixes #.

## Changes

`currencyservice` is running under shell with pid>1 inside container. Which makes it difficult to send signals using `docker kill` command. Changed to run it as pid=1 so it can get catch the TERM/INT signal through `docker kill` command.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
