### PR TITLE
fix diagram: services speak to featureflag server not its ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ checkoutservice --> currencyservice
 checkoutservice --> emailservice
 checkoutservice --> paymentservice
 checkoutservice --> shippingservice
-checkoutservice --> |evalFlag| featureflagfeservice
+checkoutservice --> |evalFlag| featureflagbeservice
 
 frontend --> adservice
 frontend --> cartservice
@@ -182,9 +182,9 @@ frontend --> checkoutservice
 frontend --> currencyservice
 frontend --> recommendationservice --> productcatalogservice
 frontend --> shippingservice
-frontend --> |evalFlag| featureflagfeservice
+frontend --> |evalFlag| featureflagbeservice
 
-productcatalogservice --> |evalFlag| featureflagfeservice
+productcatalogservice --> |evalFlag| featureflagbeservice
 
 featureflagbeservice(Flag Server):::erlang
 featureflagfeservice(Flag UI/API):::erlang


### PR DESCRIPTION
The UI is for a user to create/edit/toggle flags, services like the CheckoutService talk to the feature flag (grpc) server.