### PR TITLE
featureflagservice: add healthcheck to postgres dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,8 @@ services:
       - OTEL_SERVICE_NAME=featureflagservice
       - DATABASE_URL=ecto://ffs:ffs@ffs_postgres:5432/ffs
     depends_on:
-      - ffs_postgres
+      ffs_postgres:
+        condition: service_healthy
     logging: *logging
 
   ffs_postgres:
@@ -327,6 +328,11 @@ services:
       - POSTGRES_DB=ffs
       - POSTGRES_PASSWORD=ffs
     logging: *logging
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # LoadGenerator
   loadgenerator:


### PR DESCRIPTION
This should fix the issue where the FeatureFlagService migrations fail because postgres isn't actually "ready" it is only "started". 

Instead of depending only on the postgres container being started it now depends on it being healthy too.

A problem is that `condition: service_healthy` is not in the compose v3 docs (only v2). But it does seem that it might be working.

If it doesn't work in v3 I'd argue we should switch to v2. Unless there are features from v3 being used (I don't see any) then use of v2 (specifically `version: '2.4'`) makes sense. My understanding is that v3 isn't really an update to compose v2 but that they can be thought of as separate, where v3 is meant for Swarm use.