### PR TITLE
Update Image version to fix docker image tag

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # compose
-IMAGE_VERSION=0.1.0
+IMAGE_VERSION=0.3.1-alpha
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 
 # Collector


### PR DESCRIPTION
Fixes- Docker image tag issue. We have updated 0.1.0 image when we released 0.3.0 .

We need to further investigate why/how 0.2.0-alpha release didn't have same issue. 

<img width="787" alt="image" src="https://user-images.githubusercontent.com/2471669/185666114-4e4b6a02-7e12-4158-8c20-4627a8cfab42.png">

