### PR TITLE
[email] remove email body from log

### DIFF
--- a/src/emailservice/email_server.rb
+++ b/src/emailservice/email_server.rb
@@ -38,9 +38,10 @@ def send_email(data)
       from:     "noreply@example.com",
       subject:  "Your confirmation email",
       body:     erb(:confirmation, locals: { order: data.order }),
-      via:      :logger
+      via:      :test
     )
     span.set_attribute("app.email.recipient", data.email)
+    puts "Order confirmation email sent to: #{data.email}"
   end
   # manually created spans need to be ended
   # in Ruby, the method `in_span` ends it automatically


### PR DESCRIPTION
## Changes

This PR is meant to help clean up the log output when doing a `docker compose up`. The email service adds an entry for the entire contents of the order confirmation email, creating unnecessary noise in the logs.

- removes email body from log output