### PR TITLE
use ENTRYPOINT instead of CMD in Dockerfile

### DIFF
--- a/src/featureflagservice/Dockerfile
+++ b/src/featureflagservice/Dockerfile
@@ -92,4 +92,4 @@ COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/featureflagse
 
 USER nobody
 
-CMD ["/app/bin/server"]
+ENTRYPOINT ["/app/bin/server"]

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -39,4 +39,4 @@ USER nextjs
 ENV PORT 8080
 EXPOSE ${PORT}
 
-CMD ["npm", "start"]
+ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
## Changes

- Use ENTRYPOINT consistently in Dockerfile for all services
