### PR TITLE
Update featureflagservice environment defaults

### DIFF
--- a/src/featureflagservice/config/config.exs
+++ b/src/featureflagservice/config/config.exs
@@ -7,6 +7,13 @@
 # General application configuration
 import Config
 
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :logger,
+  level: :debug
+
 config :featureflagservice,
   ecto_repos: [Featureflagservice.Repo]
 
@@ -28,12 +35,6 @@ config :esbuild,
   ]
 
 # Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
-
-config :logger,
-  level: :debug
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/src/featureflagservice/config/runtime.exs
+++ b/src/featureflagservice/config/runtime.exs
@@ -4,7 +4,7 @@ if System.get_env("PHX_SERVER") do
   config :featureflagservice, FeatureflagserviceWeb.Endpoint, server: true
 end
 
-grpc_port = String.to_integer(System.get_env("FEATURE_FLAG_GRPC_SERVICE_PORT"))
+grpc_port = String.to_integer(System.get_env("FEATURE_FLAG_GRPC_SERVICE_PORT") || "50053")
 
 config :grpcbox,
   servers: [
@@ -39,15 +39,14 @@ if config_env() == :prod do
   # want to use a different value for prod and you most likely don't want
   # to check this value into version control, so we use an environment
   # variable instead.
+  #
+  # A default value is provided to simplify the creation of new demos, but
+  # this practice should not be used in actual user-facing applications.
   secret_key_base =
-    System.get_env("SECRET_KEY_BASE") ||
-      raise """
-      environment variable SECRET_KEY_BASE is missing.
-      You can generate one by calling: mix phx.gen.secret
-      """
+    System.get_env("SECRET_KEY_BASE") || "GH1AJrEOJEVmzyUE+5kgz2cfBEOg5qPBlTYVive++6s/QS0BE3xjNoRCd7xI3zSv" 
 
   host = System.get_env("PHX_HOST") || "localhost"
-  port = String.to_integer(System.get_env("FEATURE_FLAG_SERVICE_PORT"))
+  port = String.to_integer(System.get_env("FEATURE_FLAG_SERVICE_PORT") || "8081")
 
   config :featureflagservice, FeatureflagserviceWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],


### PR DESCRIPTION
The feature flag service won't start unless certain environment
variables are set. For ease of set up, this provides default
values. In the case of ports, these defaults match those
in .env

Perhaps in a future update the helm installation could automatically
generate a secret to use for the `SECRET_KEY_BASE` variable.

When combined with https://github.com/open-telemetry/opentelemetry-helm-charts/pull/344, fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/343
