### PR TITLE
Update README to mention that the emailservice is HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This repo is a work in progress. If you'd like to help, check out our
 ## Architecture
 
 **Online Boutique** is composed of microservices written in different programming
-languages that talk to each other over gRPC and HTTP; and a load generator which uses
-[Locust](https://locust.io/) to fake user traffic.
+languages that talk to each other over gRPC and HTTP; and a load generator which
+uses [Locust](https://locust.io/) to fake user traffic.
 
 ```mermaid
 graph TD

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repo is a work in progress. If you'd like to help, check out our
 ## Architecture
 
 **Online Boutique** is composed of microservices written in different programming
-languages that talk to each other over gRPC. Plus one Load Generator which uses
+languages that talk to each other over gRPC and HTTP; and a load generator which uses
 [Locust](https://locust.io/) to fake user traffic.
 
 ```mermaid
@@ -57,7 +57,7 @@ loadgenerator -->|HTTP| frontend
 checkoutservice --> cartservice --> cache
 checkoutservice --> productcatalogservice
 checkoutservice --> currencyservice
-checkoutservice --> emailservice
+checkoutservice -->|HTTP| emailservice
 checkoutservice --> paymentservice
 checkoutservice --> shippingservice
 


### PR DESCRIPTION
## Changes

Clearly not an urgent PR, but I happened to notice that it didn't
mention that we have an HTTP service. I updated the docs to mention
that, and annotated the (quite nice) mermaid graph with the `HTTP`
annotation as well.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
