### PR TITLE
Reduce initial run time

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # compose
-IMAGE_VERSION=v0.3.4
+IMAGE_VERSION=v0.3.4-alpha
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 
 # Collector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#331](https://github.com/open-telemetry/opentelemetry-demo/pull/331))
 * Add span events to shipping service
 ([#344](https://github.com/open-telemetry/opentelemetry-demo/pull/344))
+* Improve initial run time, without a build
+([#362](https://github.com/open-telemetry/opentelemetry-demo/pull/362))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,10 +52,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/adservice/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-adservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-adservice
     ports:
       - "${AD_SERVICE_PORT}"
     environment:
@@ -74,10 +72,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/cartservice/src/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-cartservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-cartservice
     ports:
       - "${CART_SERVICE_PORT}"
     environment:
@@ -98,10 +94,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/checkoutservice/Dockerfile
-      #cache_from:
-      #  - ${IMAGE_NAME}:${IMAGE_VERSION}-checkoutservice
-      #cache_to:
-      #  - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-checkoutservice
     ports:
       - "${CHECKOUT_SERVICE_PORT}"
     environment:
@@ -130,10 +124,8 @@ services:
     container_name: currency-service
     build:
       context: ./src/currencyservice
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-currencyservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-currencyservice
       args:
         - GRPC_VERSION=1.46.0
         - OPENTELEMETRY_VERSION=1.5.0
@@ -153,10 +145,8 @@ services:
     container_name: email-service
     build:
       context: ./src/emailservice
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-emailservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-emailservice
     ports:
       - "${EMAIL_SERVICE_PORT}"
     environment:
@@ -175,10 +165,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/frontend/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-frontend
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-frontend
     ports:
       - "${FRONTEND_PORT}:${FRONTEND_PORT}"
     environment:
@@ -258,10 +246,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/paymentservice/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-paymentservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-paymentservice
     ports:
       - "${PAYMENT_SERVICE_PORT}"
     environment:
@@ -279,10 +265,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/productcatalogservice/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-productcatalogservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-productcatalogservice
     ports:
       - "${PRODUCT_CATALOG_SERVICE_PORT}"
     environment:
@@ -301,10 +285,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/recommendationservice/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-recommendationservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-recommendationservice
     ports:
       - "${RECOMMENDATION_SERVICE_PORT}"
     depends_on:
@@ -325,10 +307,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/shippingservice/Dockerfile
-      #cache_from:
-      #  - ${IMAGE_NAME}:${IMAGE_VERSION}-shippingservice
-      #cache_to:
-      #  - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-shippingservice
     ports:
       - "${SHIPPING_SERVICE_PORT}"
     environment:
@@ -345,10 +325,8 @@ services:
     container_name: feature-flag-service
     build:
       context: ./src/featureflagservice
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-featureflagservice
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-featureflagservice
     ports:
       - "${FEATURE_FLAG_SERVICE_PORT}:${FEATURE_FLAG_SERVICE_PORT}"     # Feature Flag Service UI
       - "${FEATURE_FLAG_GRPC_SERVICE_PORT}"                             # Feature Flag Service gRPC API
@@ -385,10 +363,8 @@ services:
     build:
       context: ./
       dockerfile: ./src/loadgenerator/Dockerfile
-      # cache_from:
-      #   - ${IMAGE_NAME}:${IMAGE_VERSION}-loadgenerator
-      # cache_to:
-      #   - inline # see https://github.com/moby/buildkit#export-cache
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-loadgenerator
     ports:
       - "${LOCUST_WEB_PORT}:${LOCUST_WEB_PORT}"
     environment:

--- a/docs/docker_deployment.md
+++ b/docs/docker_deployment.md
@@ -34,12 +34,14 @@ cd opentelemetry-demo/
 
 ## Run Docker Compose
 
-- Start the demo (it can take ~20min the first time the command is executed as
-all the container images will be built):
+- Start the demo:
 
 ```shell
-docker compose up
+docker compose up --no-build
 ```
+
+**Note:** removing the `--no-build` command line option will re-build from main.
+It may take more than 20 minutes to build if used in this mode.
 
 ## Verify the Webstore & the Telemetry
 

--- a/docs/docker_deployment.md
+++ b/docs/docker_deployment.md
@@ -40,8 +40,10 @@ cd opentelemetry-demo/
 docker compose up --no-build
 ```
 
-**Note:** removing the `--no-build` command line option will re-build from main.
-It may take more than 20 minutes to build if used in this mode.
+**Note:** The `--no-build` flag is used to fetch released docker images from
+[ghcr](http://ghcr.io/open-telemetry/demo) instead of building from source.
+Removing the `--no-build` command line option will rebuild all images from
+source. It may take more than 20 minutes to build if the flag is omitted.
 
 ## Verify the Webstore & the Telemetry
 


### PR DESCRIPTION
References #252 and Fixes #349

## Changes

This change makes it so people can go from git clone to seeing telemetry in under 2 minutes.

Makes use of docker image cache when running the application. This does not reduce build times. This change uses cache to reference existing images allowing users to run `docker compose up --no-build` and get a running demo application in about 90 seconds.

Building from main is still an initial 20 min ordeal for those that want to use the very latest.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
