### PR TITLE
Postgres health check should have explicit username/db passed in

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,7 +375,7 @@ services:
       - POSTGRES_PASSWORD=ffs
     logging: *logging
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -d ffs -U ffs"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
PG logs were being spammed with "Fatal: role "root" does not exist". This appears to have been caused by the `pg_isready` health check command. Per https://github.com/peter-evans/docker-compose-healthcheck/pull/17, adding an explicit username/db to the command solves it.