### PR TITLE
bumping protobuf extension

### DIFF
--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -8,13 +8,14 @@ RUN composer install \
     --no-interaction \
     --no-plugins \
     --no-scripts \
+    --no-dev \
     --prefer-dist
 
 FROM php:8.1-cli
 
 # install GRPC (required for the OTel exporter)
 RUN apt-get -y update && apt install -y --no-install-recommends zlib1g-dev && \
-    pecl install grpc protobuf && \
+    pecl install grpc protobuf-3.21.5 && \
     docker-php-ext-enable grpc protobuf
 
 WORKDIR /var/www


### PR DESCRIPTION
## Changes

pecl is installing an older version of protobuf by default, that does not work in php8.1. Force it to 3.21.5
