### PR TITLE
remove docfx check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,19 +42,19 @@ jobs:
     - name: run misspell
       run: make misspell
 
-  docfx:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
-    - name: install docfx
-      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
-
-    - name: run docfx
-      run: docfx build --dry-run
+#  docfx:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v3
+#    - uses: actions/setup-dotnet@v1
+#      with:
+#        dotnet-version: 6.0.x
+#
+#    - name: install docfx
+#      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
+#
+#    - name: run docfx
+#      run: docfx build --dry-run
 
   markdownlinkcheck:
     name: markdownlinkcheck


### PR DESCRIPTION
docfx is failing on relative links to folders. We require these types of links for our service docs.

Per the SIG meeting on 9/26, we determined that the docfx checks were providing no value-add and should be removed.  This PR comments out the check (we can remove it completely on a subsequent PR)
