### PR TITLE
Add runtime metrics to cartservice

### DIFF
--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using cartservice.cartstore;
 using cartservice.services;
-using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 
 namespace cartservice;
 

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using cartservice.cartstore;
 using cartservice.services;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
 
 namespace cartservice;
 
@@ -48,6 +49,10 @@ public class Startup
             .AddGrpcClientInstrumentation()
             .AddHttpClientInstrumentation()
             .AddOtlpExporter());
+
+            services.AddOpenTelemetryMetrics(builder =>
+                builder.AddRuntimeInstrumentation()
+                       .AddOtlpExporter());
 
         services.AddGrpc();
         services.AddGrpcHealthChecks()

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-demo/issues/177
Adds .NETs runtime instrumentation metric to the cart service. Dashboards will follow in future PR. Also will add more instrumentations (http) in next PR.

Example metric:
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/5232798/193151162-ef1e5936-cf04-4865-bf54-4961e46f47fa.png">
