### PR TITLE
[Cart] Added instrumentation for Asp.Net Core (http server)

### DIFF
--- a/docs/metric_service_features.md
+++ b/docs/metric_service_features.md
@@ -9,7 +9,7 @@ Emoji Legend
 | Service         | Language        | Instrumentation Libraries | Manual Metric Creation | Collector Agent Metric Transformation | Push Metrics   | SLO Metrics    | Multiple Manual Metric Instruments |
 |-----------------|-----------------|---------------------------|------------------------|---------------------------------------|----------------|----------------|------------------------------------|
 | Ad              | Java            | :construction:            | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
-| Cart            | .NET            | :construction:            | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
+| Cart            | .NET            | :100:                     | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Checkout        | Go              | :construction:            | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Currency        | C++             | :construction:            | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Email           | Ruby            | :construction:            | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -53,7 +53,7 @@ public class Startup
         services.AddOpenTelemetryMetrics(builder =>
             builder.AddRuntimeInstrumentation()
                    .AddAspNetCoreInstrumentation()
-                    .AddOtlpExporter());
+                   .AddOtlpExporter());
 
         services.AddGrpc();
         services.AddGrpcHealthChecks()

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -52,6 +52,7 @@ public class Startup
 
             services.AddOpenTelemetryMetrics(builder =>
                 builder.AddRuntimeInstrumentation()
+                       .AddAspNetCoreInstrumentation()
                        .AddOtlpExporter());
 
         services.AddGrpc();

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using cartservice.cartstore;
 using cartservice.services;
-using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 
 namespace cartservice;
 

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using cartservice.cartstore;
 using cartservice.services;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
 
 namespace cartservice;
 
@@ -48,6 +49,10 @@ public class Startup
             .AddGrpcClientInstrumentation()
             .AddHttpClientInstrumentation()
             .AddOtlpExporter());
+
+            services.AddOpenTelemetryMetrics(builder =>
+                builder.AddRuntimeInstrumentation()
+                       .AddOtlpExporter());
 
         services.AddGrpc();
         services.AddGrpcHealthChecks()

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -52,7 +52,7 @@ public class Startup
 
         services.AddOpenTelemetryMetrics(builder =>
             builder.AddRuntimeInstrumentation()
-                    .AddAspNetCoreInstrumentation()
+                   .AddAspNetCoreInstrumentation()
                     .AddOtlpExporter());
 
         services.AddGrpc();

--- a/src/cartservice/src/Startup.cs
+++ b/src/cartservice/src/Startup.cs
@@ -50,10 +50,10 @@ public class Startup
             .AddHttpClientInstrumentation()
             .AddOtlpExporter());
 
-            services.AddOpenTelemetryMetrics(builder =>
-                builder.AddRuntimeInstrumentation()
-                       .AddAspNetCoreInstrumentation()
-                       .AddOtlpExporter());
+        services.AddOpenTelemetryMetrics(builder =>
+            builder.AddRuntimeInstrumentation()
+                    .AddAspNetCoreInstrumentation()
+                    .AddOtlpExporter());
 
         services.AddGrpc();
         services.AddGrpcHealthChecks()

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.44.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.46.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />

--- a/src/cartservice/src/cartstore/RedisCartStore.cs
+++ b/src/cartservice/src/cartstore/RedisCartStore.cs
@@ -101,7 +101,7 @@ namespace cartservice.cartstore
                 redis.ConnectionRestored += (o, e) =>
                 {
                     isRedisConnectionOpened = true;
-                    Console.WriteLine("Connection to redis was restored successfully");
+                    Console.WriteLine("Connection to redis was restored successfully.");
                 };
                 redis.ConnectionFailed += (o, e) =>
                 {

--- a/src/cartservice/src/cartstore/RedisCartStore.cs
+++ b/src/cartservice/src/cartstore/RedisCartStore.cs
@@ -101,7 +101,7 @@ namespace cartservice.cartstore
                 redis.ConnectionRestored += (o, e) =>
                 {
                     isRedisConnectionOpened = true;
-                    Console.WriteLine("Connection to redis was retored successfully");
+                    Console.WriteLine("Connection to redis was restored successfully");
                 };
                 redis.ConnectionFailed += (o, e) =>
                 {


### PR DESCRIPTION
Also updated version from 1.3.0 to 1.3.1 as 1.3.0 was deprecated due to vulnerability.
See metrics:
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/5232798/193165305-f511f0ac-c506-45e6-83fa-37408fae1508.png">