### PR TITLE
Exit featureflagservice startup script if migrations fail

### DIFF
--- a/src/featureflagservice/rel/overlays/bin/server
+++ b/src/featureflagservice/rel/overlays/bin/server
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
 
-./featureflagservice eval Featureflagservice.Release.migrate
+./featureflagservice eval Featureflagservice.Release.migrate || { echo "Database setup or migrations failed."; exit 1; }
 
 PHX_SERVER=true exec ./featureflagservice start


### PR DESCRIPTION
Fixes #398 .

## Changes

Changes the startup shell script for the feature flag service to exit with a failure code if the migration command fails. This causes the pod to be automatically restarted in Kubernetes. In my tests, it always restarts once before successfully connecting to the database.