### PR TITLE
Update go version to use go otel metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#362](https://github.com/open-telemetry/opentelemetry-demo/pull/362))
 * Add custom span and custom span attributes for Feature Flag Service
 ([#371](https://github.com/open-telemetry/opentelemetry-demo/pull/371))
+* Update Checkout Service Go version to 1.19 once OTel Go Metrics require 1.18+
+([#406](https://github.com/open-telemetry/opentelemetry-demo/pull/406))

--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.7-alpine AS builder
+FROM golang:1.19.2-alpine AS builder
 RUN apk add build-base protoc
 WORKDIR /usr/src/app/
 
@@ -20,8 +20,8 @@ WORKDIR /usr/src/app/
 COPY ./src/checkoutservice/ ./
 COPY ./pb/ ./proto/
 RUN go mod download
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
-RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
 # Build executable
 RUN protoc -I ./proto/ ./proto/demo.proto --go_out=./ --go-grpc_out=./

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-demo/src/checkoutservice
 
-go 1.17
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
Towards #339.

## Changes

In order to be able to use OTel Go Metrics we need Go version 1.18+.
Updated Go version and adjusted installation of protoc.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
