### PR TITLE
Fix metric feature table for the Checkout service (partial rollback)

### DIFF
--- a/docs/metric_service_features.md
+++ b/docs/metric_service_features.md
@@ -10,7 +10,7 @@ Emoji Legend
 |-----------------|-----------------|----------------------|------------------------|---------------------------------------|----------------|----------------|------------------------------------|
 | Ad              | Java            | :100:                | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Cart            | .NET            | :100:                | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
-| Checkout        | Go              | :100:                | :100:                  | :construction:                        | :construction: | :construction: | :construction:                     |
+| Checkout        | Go              | :100:                | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Currency        | C++             | :construction:       | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Email           | Ruby            | :construction:       | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |
 | Feature Flag    | Erlang / Elixir | :construction:       | :construction:         | :construction:                        | :construction: | :construction: | :construction:                     |


### PR DESCRIPTION
## Changes

- The metric feature table was recently updated with #412 to set manual metric creation for the Checkout service. This is not the case, the service doesn’t have manual metrics.
