### PR TITLE
[jaeger] limit memory usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     container_name: jaeger
+    command:
+      - "--memory.max-traces"
+      - "10000"
     ports:
       - "16686:16686"                    # Jaeger UI
       - "14250"                          # Jaeger model.proto endpoint


### PR DESCRIPTION
## Changes

Sets max traces in memory to the most recent 10000. This gives about 40-45 minutes of usage data before being maxed out. Memory consumption for this load is approximately 211 MiB