### PR TITLE
[loadgenerator] fix memory leak

### DIFF
--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -215,10 +215,8 @@ class WebsiteUser(HttpUser):
 
     @task(3)
     def get_recommendations(self):
-        user = str(uuid.uuid1())
         params = {
             "productIds": [random.choice(products)],
-            "sessionId": user,
         }
         self.client.get("/api/recommendations/", params=params)
 


### PR DESCRIPTION
## Changes

Removes the `sessionId` populated as a UUID from `get_recommendations`. Since this request is a GET, and Locust keeps stats on each unique URL, adding a UUID to each one was bloating the internal stats from Locust.
