### PR TITLE
[frontend] fix local development instructions and dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
       - currencyservice
       - otelcol
       - productcatalogservice
+      - quoteservice
       - recommendationservice
       - shippingservice
     logging: *logging

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -39,4 +39,4 @@ USER nextjs
 ENV PORT 8080
 EXPOSE ${PORT}
 
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT npm start

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -16,8 +16,7 @@ frontend client by going to <http://localhost:8080/>.
 Currently, the easiest way to run the frontend for local development is to execute
 
 ```shell
-  docker compose run --service-ports -e NODE_ENV=development
-  --volume $(pwd)/src/frontend:/app --volume $(pwd)/pb:/app/pb frontend sh
+docker compose run --service-ports -e NODE_ENV=development --volume $(pwd)/src/frontend:/app --volume $(pwd)/pb:/app/pb --user node --entrypoint sh frontend
 ```
 
 from the root folder.


### PR DESCRIPTION
Fixes #407 .

## Changes

When moving from `CMD` to `ENTRYPOINT` we forgot to update the instructions for the frontend local development.
Also, the `quoteservice`was added as a dependency of `frontend` to avoid errors during local development.
