### PR TITLE
[collector] replace Jaeger to OTLP exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,3 +113,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#339](https://github.com/open-telemetry/opentelemetry-demo/pull/339))
 * Added basic metrics support for recommendation service (Python)
 ([#416](https://github.com/open-telemetry/opentelemetry-demo/pull/416))
+* Replaced the Jaeger exporter to the OTLP exporter in the OTel Collector
+([#435](https://github.com/open-telemetry/opentelemetry-demo/pull/435))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"                    # Jaeger UI
-      - "14250"                          # Jaeger model.proto endpoint
       - "4317"                           # OTLP gRPC default port
       - "4318"                           # OTLP HTTP default port
     logging: *logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     ports:
       - "16686:16686"                    # Jaeger UI
       - "4317"                           # OTLP gRPC default port
-      - "4318"                           # OTLP HTTP default port
     logging: *logging
 
   # Collector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,18 @@ services:
     command:
       - "--memory.max-traces"
       - "10000"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"                    # Jaeger UI
       - "14250"                          # Jaeger model.proto endpoint
+      - "4317"                           # OTLP gRPC default port
+      - "4318"                           # OTLP HTTP default port
     logging: *logging
 
   # Collector
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.56.0
+    image: otel/opentelemetry-collector-contrib:0.61.0
     container_name: otel-col
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
     volumes:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -12,8 +12,8 @@ receivers:
         endpoint: "localhost:65535"
 
 exporters:
-  jaeger:
-    endpoint: "jaeger:14250"
+  otlp:
+    endpoint: "jaeger:4317"
     tls:
       insecure: true
   logging:
@@ -31,7 +31,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [spanmetrics, batch]
-      exporters: [logging, jaeger]
+      exporters: [logging, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
Fixes #424.

## Changes

Jaeger has officially switched to recommend OTLP as the ingestion protocol. OpenTelemetry spec might consider aligning this effort https://github.com/open-telemetry/opentelemetry-specification/pull/2858.

This PR replaces the Jaeger exporter to the OTLP exporter.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
