### PR TITLE
finish removing docfx check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,20 +42,6 @@ jobs:
     - name: run misspell
       run: make misspell
 
-#  docfx:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v3
-#    - uses: actions/setup-dotnet@v1
-#      with:
-#        dotnet-version: 6.0.x
-#
-#    - name: install docfx
-#      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
-#
-#    - name: run docfx
-#      run: docfx build --dry-run
-
   markdownlinkcheck:
     name: markdownlinkcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

This finishes removing the docfx check we had. It was commented out in #385 

A bonus side effect will be removing this GitHub beta warning in our PR code views.
![Screen Shot 2022-10-13 at 10 19 42 PM](https://user-images.githubusercontent.com/1296118/195747081-d13d3bf6-2411-4065-9243-bfed5c3b64f1.png)
