### PR TITLE
[currency] - remove baggage processing

### DIFF
--- a/src/currencyservice/src/server.cpp
+++ b/src/currencyservice/src/server.cpp
@@ -93,20 +93,6 @@ class CurrencyService final : public hipstershop::CurrencyService::Service
   	const Empty* request,
   	GetSupportedCurrenciesResponse* response) override
   {
-    // Read baggage from client context
-    auto clientContext = context->client_metadata();
-    auto range = clientContext.equal_range("baggage");
-    std::vector<std::string> baggageLists;
-    for (auto i = range.first; i != range.second; ++i)
-    {
-      baggageLists.emplace_back(std::string(i->second.data()));
-    }
-    std::vector<opentelemetry::nostd::shared_ptr<Baggage>> baggages(baggageLists.size());
-    for (int i = 0; i < baggageLists.size(); i++) {
-      auto baggage = Baggage::FromHeader(baggageLists[i]);
-      baggages[i] = baggage;
-    }
-
     StartSpanOptions options;
     options.kind = SpanKind::kServer;
     GrpcServerCarrier carrier(context);
@@ -126,16 +112,6 @@ class CurrencyService final : public hipstershop::CurrencyService::Service
                                       options);
     auto scope = get_tracer("currencyservice")->WithActiveSpan(span);
 
-    for (auto& baggage : baggages) {
-      // Set the key value pairs from baggage to Span Attributes
-      baggage->GetAllEntries([&span](opentelemetry::nostd::string_view key,
-          opentelemetry::nostd::string_view value) {
-        span->SetAttribute(key, value);
-        return true;
-      });
-    }
-
-    // Fetch and parse whatever HTTP headers we can from the gRPC request.
     span->AddEvent("Processing supported currencies request");
 
     for (auto &code : currency_conversion) {
@@ -177,20 +153,6 @@ class CurrencyService final : public hipstershop::CurrencyService::Service
   	const CurrencyConversionRequest* request,
   	Money* response) override
   {
-    // Read baggage from client context
-    auto clientContext = context->client_metadata();
-    auto range = clientContext.equal_range("baggage");
-    std::vector<std::string> baggageLists;
-    for (auto i = range.first; i != range.second; ++i)
-    {
-      baggageLists.emplace_back(std::string(i->second.data()));
-    }
-    std::vector<opentelemetry::nostd::shared_ptr<Baggage>> baggages(baggageLists.size());
-    for (int i = 0; i < baggageLists.size(); i++) {
-      auto baggage = Baggage::FromHeader(baggageLists[i]);
-      baggages[i] = baggage;
-    }
-
     StartSpanOptions options;
     options.kind = SpanKind::kServer;
     GrpcServerCarrier carrier(context);
@@ -210,15 +172,6 @@ class CurrencyService final : public hipstershop::CurrencyService::Service
                                       options);
     auto scope = get_tracer("currencyservice")->WithActiveSpan(span);
 
-    for (auto& baggage : baggages) {
-      // Set the key value pairs from baggage to Span Attributes
-      baggage->GetAllEntries([&span](opentelemetry::nostd::string_view key,
-          opentelemetry::nostd::string_view value) {
-        span->SetAttribute(key, value);
-        return true;
-      });
-    }
-    // Fetch and parse whatever HTTP headers we can from the gRPC request.
     span->AddEvent("Processing currency conversion request");
 
     try {


### PR DESCRIPTION
## Changes

Removes baggage processing from the currency service. Previously it would take all items from baggage and emit them as a span, which is not the desired behavior.
