### PR TITLE
Remove unimplemented feature flag: shippingFailure

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -8,4 +8,3 @@ feature flags.
 | Feature Flag            | Service(s)      | Description                                                               |
 |-------------------------|-----------------|---------------------------------------------------------------------------|
 | `productCatalogFailure` | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z` |
-| `shippingFailure`       | Shipping        | Induce very long latency when shipping outside of USA                     |

--- a/src/featureflagservice/priv/repo/migrations/20220524172636_create_featureflags.exs
+++ b/src/featureflagservice/priv/repo/migrations/20220524172636_create_featureflags.exs
@@ -21,14 +21,9 @@ defmodule Featureflagservice.Repo.Migrations.CreateFeatureflags do
       description: "Fail product catalog service on a specific product",
       enabled: false})
 
-    repo().insert(%Featureflagservice.FeatureFlags.FeatureFlag{
-      name: "shippingFailure",
-      description: "Fail shipping service when shipping a product to a non-USA address",
-      enabled: false})
   end
 
   defp execute_down do
     repo().delete(%Featureflagservice.FeatureFlags.FeatureFlag{name: "productCatalogFailure"})
-    repo().delete(%Featureflagservice.FeatureFlags.FeatureFlag{name: "shippingFailure"})
   end
 end


### PR DESCRIPTION
## Changes

Removal of shippingFailure feature flag, which is not implemented (doesn’t do anything).
