### PR TITLE
Revert "Update .env for 0.6.1 release"

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # compose
-IMAGE_VERSION=v0.6.1-beta
+IMAGE_VERSION=v0.6.0-beta
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 
 # Collector


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-demo#496

Until we get the `0.6.1-beta` images up, we need to revert back to the prior version, else `docker compose up --no-build` will fail.