### PR TITLE
Add component owners for adservice Java app

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,0 +1,6 @@
+# this file is used by .github/workflows/assign-reviewers.yml
+components:
+  src/adservice:
+    - jack-berg
+    - mateuszrzeszutek
+    - trask

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,18 @@
+# assigns reviewers to pull requests in a similar way as CODEOWNERS, but doesn't require reviewers
+# to have write access to the repository
+# see .github/component_owners.yaml for the list of components and their owners
+name: Assign reviewers
+
+on:
+  # pull_request_target is needed instead of just pull_request
+  # because repository write permission is needed to assign reviewers
+  pull_request_target:
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dyladan/component-owners@main
+        with:
+          # using this action to request review only (not assignment)
+          assign-owners: false


### PR DESCRIPTION
This would allow @jack-berg @mateuszrzeszutek and me to get pinged on any PRs that touch the Java app so we can help review. @dyladan's component-owners github action is being used in a few other otel repos already: https://github.com/search?q=org%3Aopen-telemetry+dyladan%2Fcomponent-owners&type=code