### PR TITLE
[checkoutservice] add http protocol when posting request to emailservice

### DIFF
--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -418,7 +418,7 @@ func (cs *checkoutService) sendOrderConfirmation(ctx context.Context, email stri
 		return fmt.Errorf("failed to marshal order to JSON: %+v", err)
 	}
 
-	resp, err := otelhttp.Post(ctx, cs.emailSvcAddr+"/send_order_confirmation", "application/json", bytes.NewBuffer(emailServicePayload))
+	resp, err := otelhttp.Post(ctx, "http://"+cs.emailSvcAddr+"/send_order_confirmation", "application/json", bytes.NewBuffer(emailServicePayload))
 	if err != nil {
 		return fmt.Errorf("failed POST to email service: %+v", err)
 	}


### PR DESCRIPTION
The checkoutservice meets one error in its logs 

```
{"message":"failed to send order confirmation to \"someone@example.com\": failed POST to email service: Post \"emailservice:8080/send_order_confirmation\": unsupported protocol scheme \"emailservice\"","severity":"warning","timestamp":"2022-10-31T11:58:16.477407728Z"}
```

I fix this error by adding http protocol when posting request to emailservice
