### PR TITLE
Remove redundant components from collector config

### DIFF
--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -7,10 +7,6 @@ receivers:
           allowed_origins:
             - "http://*"
             - "https://*"
-  otlp/spanmetrics:
-    protocols:
-      grpc:
-        endpoint: "localhost:65535"
 
 exporters:
   otlp:
@@ -20,7 +16,6 @@ exporters:
   logging:
   prometheus:
     endpoint: "otelcol:9464"
-
 
 processors:
   batch:
@@ -36,7 +31,4 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheus, logging]
-    metrics/spanmetrics:
-      receivers: [otlp/spanmetrics]
       exporters: [prometheus, logging]


### PR DESCRIPTION
`metrics/spanmetrics` pipeline is not being used. Removing it along with unused `otlp/spanmetrics` receiver.
