### PR TITLE
[quoteservice] Replace php-cli to php-apache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#513](https://github.com/open-telemetry/opentelemetry-demo/pull/513))
 * Added frontend instrumentation exporter custom url
 ([#512](https://github.com/open-telemetry/opentelemetry-demo/pull/512))
+* Replaced PHP-CLI to PHP-Apache for a more realistic service
+([#563](https://github.com/open-telemetry/opentelemetry-demo/pull/563))

--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.4.1 AS build
+FROM composer:2.4 AS build
 
 WORKDIR /tmp/
 COPY ./src/quoteservice/composer.json .
@@ -11,17 +11,17 @@ RUN composer install \
     --no-dev \
     --prefer-dist
 
-FROM php:8.1-cli
-
-# install GRPC (required for the OTel exporter)
-# RUN apt-get -y update && apt install -y --no-install-recommends zlib1g-dev && \
-#    pecl install grpc protobuf-3.21.5 && \
-#    docker-php-ext-enable grpc protobuf
+FROM php:8.1-apache
 
 WORKDIR /var/www
-COPY --from=build /tmp/vendor/ /var/www/vendor/
+COPY --from=build /tmp/vendor/ ./vendor/
 COPY ./src/quoteservice/ /var/www
+
+ENV APACHE_DOCUMENT_ROOT /var/www/public
+RUN sed -ri -e 's|/var/www/html|${APACHE_DOCUMENT_ROOT}|g' /etc/apache2/sites-available/*.conf
+RUN a2enmod rewrite
 
 EXPOSE ${QUOTE_SERVICE_PORT}
 
-ENTRYPOINT php -S 0.0.0.0:${QUOTE_SERVICE_PORT} -t public
+ENTRYPOINT sed -i "s/80/${QUOTE_SERVICE_PORT}/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf \
+           && apache2-foreground

--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -20,6 +20,7 @@ COPY ./src/quoteservice/ /var/www
 ENV APACHE_DOCUMENT_ROOT /var/www/public
 RUN sed -ri -e 's|/var/www/html|${APACHE_DOCUMENT_ROOT}|g' /etc/apache2/sites-available/*.conf
 RUN a2enmod rewrite
+RUN echo "ServerName quoteservice" >> /etc/apache2/apache2.conf
 
 EXPOSE ${QUOTE_SERVICE_PORT}
 

--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -13,6 +13,8 @@ RUN composer install \
 
 FROM php:8.1-apache
 
+RUN docker-php-ext-install opcache
+
 WORKDIR /var/www
 COPY --from=build /tmp/vendor/ ./vendor/
 COPY ./src/quoteservice/ /var/www

--- a/src/quoteservice/Dockerfile
+++ b/src/quoteservice/Dockerfile
@@ -24,4 +24,4 @@ RUN a2enmod rewrite
 EXPOSE ${QUOTE_SERVICE_PORT}
 
 ENTRYPOINT sed -i "s/80/${QUOTE_SERVICE_PORT}/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf \
-           && apache2-foreground
+&& apache2-foreground

--- a/src/quoteservice/public/.htaccess
+++ b/src/quoteservice/public/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]


### PR DESCRIPTION
## Changes

PHP-CLI is a PHP built-in server and should not be used in production, more info here: https://www.php.net/manual/en/features.commandline.webserver.php#features.commandline.webserver.
In order to have a service that users can relate to real life services, I've updated the QuoteService to make use of PHP-Apache.

I've also added OPcache in order to improve the PHP performance: https://www.php.net/manual/en/intro.opcache.php

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
