### PR TITLE
Add Helios to the list of demos featuring Online Boutique

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ keeping it up to date for you.
 
 - [Datadog](https://github.com/DataDog/opentelemetry-demo)
 - [Dynatrace](https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/)
+- [Helios](https://otelsandbox.gethelios.dev)
 - [Honeycomb.io](https://github.com/honeycombio/opentelemetry-demo)
 - [Lightstep](https://github.com/lightstep/opentelemetry-demo)
 - [New Relic](https://github.com/newrelic/opentelemetry-demo)


### PR DESCRIPTION
## Changes

- Add Helios to the main README, to the list of demos featuring Online Boutique