### PR TITLE
Render shipping cost nanos in emailservice

### DIFF
--- a/src/emailservice/views/confirmation.erb
+++ b/src/emailservice/views/confirmation.erb
@@ -32,7 +32,7 @@
     <p><%= order.order_id %></p>
     <h3>Shipping</h3>
     <p><%= order.shipping_tracking_id %></p>
-    <p><%= order.shipping_cost.units %>.<%= order.shipping_cost %> <%= order.shipping_cost.currency_code %></p>
+    <p><%= order.shipping_cost.units %>.<%= order.shipping_cost.nanos %> <%= order.shipping_cost.currency_code %></p>
     <p><%= order.shipping_address.street_address_1 %>, <%= order.shipping_address.street_address_2 %>, <%= order.shipping_address.city %>, <%= order.shipping_address.country %> <%= order.shipping_address.zip_code %></p>
     <h3>Items</h3>
     <table style="width:100%">


### PR DESCRIPTION
## Changes

The template used for the confirmation email in the emailservice did not render the nanos of the shipping cost. This commit adds them, so the rendering of shipping cost and item cost (lower in the template) is equivalent.

This is a minor fix.
