### PR TITLE
[currencyservice] Create multiple build jobs to optimize build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#512](https://github.com/open-telemetry/opentelemetry-demo/pull/512))
 * Replaced PHP-CLI to PHP-Apache for a more realistic service
 ([#563](https://github.com/open-telemetry/opentelemetry-demo/pull/563))
+* Optimize currencyservice build time with parallel build jobs
+([#569](https://github.com/open-telemetry/opentelemetry-demo/pull/569))

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -35,12 +35,12 @@ RUN git clone --shallow-submodules --depth 1 --recurse-submodules -b v${GRPC_VER
     -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
     -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
     ../.. \
-  && make -j2 \
+  && make -j$(nproc || sysctl -n hw.ncpu || echo 1) \
   && make install \
   && cd ../../.. \
   && rm -rf grpc
 
-# install opentelemetry
+# Install OpenTelemetry
 RUN git clone https://github.com/open-telemetry/opentelemetry-cpp \
     && cd opentelemetry-cpp/ \
     && git checkout tags/v${OPENTELEMETRY_VERSION} -b v${OPENTELEMETRY_VERSION} \


### PR DESCRIPTION
## Changes

Create multiple build jobs to run the currency service build in parallel and optimize build time. 

Different commands are needed to find the number of available CPU cores per OS.
`make -j$(nproc || sysctl -n hw.ncpu || echo 1)`
- Uses `nproc` on Linux
- Uses `sysctl -n hw.ncpu` on macOS
- Uses 1 core for others

## Background

Currency service had the longest build time among the Demo App services.

Rough build time improvements with this change:

- Linux, docker (Ryzen 5 5600G): 1000 s -> 400 s.
- macOS, docker desktop (M1 Pro): 750 s -> 450 s.

Measured with:
`docker compose build currencyservice --no-cache`

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
