### PR TITLE
[cartservice] Replace Log API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,3 +136,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#563](https://github.com/open-telemetry/opentelemetry-demo/pull/563))
 * Optimize currencyservice build time with parallel build jobs
 ([#569](https://github.com/open-telemetry/opentelemetry-demo/pull/569))
+* Replaced console log statement as opentelemetry API log statement for cartservice
+([#570])(https://github.com/open-telemetry/opentelemetry-demo/pull/570))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,4 +137,4 @@ significant modifications will be credited to OpenTelemetry Authors.
 * Optimize currencyservice build time with parallel build jobs
 ([#569](https://github.com/open-telemetry/opentelemetry-demo/pull/569))
 * Replaced console log statement as opentelemetry API log statement for cartservice
-([#570])(https://github.com/open-telemetry/opentelemetry-demo/pull/570))
+([#571])(https://github.com/open-telemetry/opentelemetry-demo/pull/571))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,4 +137,4 @@ significant modifications will be credited to OpenTelemetry Authors.
 * Optimize currencyservice build time with parallel build jobs
 ([#569](https://github.com/open-telemetry/opentelemetry-demo/pull/569))
 * Replaced console log statement as opentelemetry API log statement for cartservice
-([#571])(https://github.com/open-telemetry/opentelemetry-demo/pull/571))
+([#571](https://github.com/open-telemetry/opentelemetry-demo/pull/571))

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -8,13 +8,15 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.44.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.46.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-beta.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #.

https://github.com/open-telemetry/opentelemetry-demo/issues/223

## Changes

I have replace Console log statement  as Opentelemetry log API for cartservice

In previous version, the log results is 
```
GetCartAsync called with userId=576b61d0-8e82-43d0-a18e-03cafc026f27
```

In current version, the log results is 
```

Resource associated with LogRecord:
service.name: cartservice
k8s.namespace.name: hipster
k8s.node.name: 33.33.33.115
k8s.pod.name: cartservice-v1-586479447c-w9bw2

LogRecord.Timestamp:               2022-11-12T11:28:32.1971300Z
LogRecord.TraceId:                 383b76b135a51cbd1a10753999de1df4
LogRecord.SpanId:                  c372930bd099f82d
LogRecord.TraceFlags:              Recorded
LogRecord.CategoryName:            cartservice.cartstore.RedisCartStore
LogRecord.LogLevel:                Information
LogRecord.FormattedMessage:        GetCartAsync called with userId=576b61d0-8e82-43d0-a18e-03cafc026f27
LogRecord.State (Key:Value):
    userId: 576b61d0-8e82-43d0-a18e-03cafc026f27
    OriginalFormat (a.k.a Body): GetCartAsync called with userId={userId}
```

