### PR TITLE
fix feature flag memory restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,7 +414,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 160M
+          memory: 200M
     restart: always
     ports:
       - "${FEATURE_FLAG_SERVICE_PORT}"     # Feature Flag Service UI


### PR DESCRIPTION
fix #556. 200M seems a reasonable upgrade. 

I could see us landing somewhere ~180M if we wanted to be extra mindful of memory allocation but it would require more testing.  