### PR TITLE
Add aspecto fork to demos list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ We welcome any vendor to fork the project to demonstrate their services and
 adding a link below. The community is committed to maintaining the project and
 keeping it up to date for you.
 
+- [Aspecto](https://github.com/aspecto-io/opentelemetry-demo)
 - [Datadog](https://github.com/DataDog/opentelemetry-demo)
 - [Dynatrace](https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/)
 - [Helios](https://otelsandbox.gethelios.dev)


### PR DESCRIPTION
Adding aspecto to the list of vendors.
We forked the repo and added instructions on how to configure it to send traces to aspecto

Thank you :)