### PR TITLE
Fix grafana datasource Jaeger URL

### DIFF
--- a/src/grafana/provisioning/datasources/jaeger.yaml
+++ b/src/grafana/provisioning/datasources/jaeger.yaml
@@ -4,6 +4,6 @@ datasources:
   - name: Jaeger
     uid: webstore-traces
     type: jaeger
-    url: http://jaeger/jaeger/ui:16686
+    url: http://jaeger:16686/jaeger/ui
     editable: true
     isDefault: false


### PR DESCRIPTION
## Changes

Fixed the datasource URL for the Jaeger within Grafana conf.
Thanks @jpkrohling for pointing that out!