### PR TITLE
fixed typo in AppDynamics name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We welcome any vendor to fork the project to demonstrate their services and
 adding a link below. The community is committed to maintaining the project and
 keeping it up to date for you.
 
-- [Appdynamics](https://www.appdynamics.com/blog/cloud/how-to-observe-opentelemetry-demo-app-in-appdynamics-cloud/)
+- [AppDynamics](https://www.appdynamics.com/blog/cloud/how-to-observe-opentelemetry-demo-app-in-appdynamics-cloud/)
 - [Aspecto](https://github.com/aspecto-io/opentelemetry-demo)
 - [Datadog](https://github.com/DataDog/opentelemetry-demo)
 - [Dynatrace](https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-demo/pull/591#discussion_r1026745185

## Changes

changed Appdynamics to AppDynamics (correct name) in vendor list.

