### PR TITLE
[chore] add build-and-push env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ next-env.d.ts
 vendor/
 composer.lock
 .venv
+.dockerhub.env
+.ghcr.env
 
 src/frontend/cypress/videos
 src/frontend/cypress/screenshots


### PR DESCRIPTION
Adds `.dockerhub.env` and `.ghcr.env` to gitignore

These are meant to be used as part of the release process or local dev.
