### PR TITLE
Reduce rust trace verbosity.

### DIFF
--- a/src/shippingservice/Cargo.toml
+++ b/src/shippingservice/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.17"
 simplelog = "0.12"
 reqwest-middleware = "0.2.0"
 reqwest-tracing = { version = "0.4.0", features = ["opentelemetry_0_18"] }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_info"] }
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = "0.3"
 


### PR DESCRIPTION
# Changes

In 1.2, the new tracing crates for reqwest used the default subscriber, which picks up everything from `trace` level on up. Thanks to the tireless efforts of the rust community, this means we get spans and span events for quite literally everything! While great for detailed inspection of performance, not so great for our purposes. This PR reduces the verbosity at build time to something reasonable (`info`), giving us our http client spans without murdering our poor jaeger instances.
