### PR TITLE
[chore] fix generate protobuf for TypeScript

### DIFF
--- a/ide-gen-proto.sh
+++ b/ide-gen-proto.sh
@@ -57,6 +57,8 @@ gen_proto_ts() {
   echo "Generating Typescript protobuf files for $1"
   cd "$base_dir"/src/"$1" || return
   cp -r "$base_dir"/pb .
+  mkdir -p ./protos
+  protoc -I ./pb  --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=esModuleInterop=true --ts_proto_out=./protos --ts_proto_opt=outputServices=grpc-js demo.proto
   cd "$base_dir" || return
 }
 


### PR DESCRIPTION
Previously `make generate-protobuf` only copied the demo.proto file but did not generate the protobuf classes required for IDEs to resolve imports. This adds the command to generate the protobuf classes.
