### PR TITLE
[frontend] add address to IProductCheckout type

### DIFF
--- a/src/frontend/pages/cart/checkout/[orderId]/index.tsx
+++ b/src/frontend/pages/cart/checkout/[orderId]/index.tsx
@@ -31,7 +31,7 @@ const Checkout: NextPage = () => {
                 <CheckoutItem
                   key={checkoutItem.item.productId}
                   checkoutItem={checkoutItem}
-                  address={shippingAddress!}
+                  address={shippingAddress}
                 />
               ))}
             </S.ItemList>

--- a/src/frontend/types/Cart.ts
+++ b/src/frontend/types/Cart.ts
@@ -1,4 +1,4 @@
-import { Cart, OrderItem, OrderResult, Product } from '../protos/demo';
+import {Address, Cart, OrderItem, OrderResult, Product} from '../protos/demo';
 
 export interface IProductCartItem {
   productId: string;
@@ -12,6 +12,7 @@ export interface IProductCheckoutItem extends OrderItem {
 
 export interface IProductCheckout extends OrderResult {
   items: IProductCheckoutItem[];
+  shippingAddress: Address;
 }
 
 export interface IProductCart extends Cart {


### PR DESCRIPTION
This change benefits IDEs so they can properly detect and find type declarations. It adds `shippingAddress` to the `IProductType` type so that code in the cart checkout order page can properly detect the declaration.