### PR TITLE
Send traces to gcp

### DIFF
--- a/my-values-file.yaml
+++ b/my-values-file.yaml
@@ -1,0 +1,18 @@
+opentelemetry-collector:
+  config:
+    exporters:
+      googlecloud:
+    processors:
+      resourcedetection/gcp:
+        detectors: [env, gcp]
+        timeout: 2s
+        override: false
+    service:
+      pipelines:
+        traces:
+          exporters:
+            - googlecloud
+          processors:
+            - memory_limiter
+            - batch
+            - resourcedetection/gcp


### PR DESCRIPTION
Installed in a k8s cluster with  
```sh
helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
helm install my-otel-demo open-telemetry/opentelemetry-demo --values my-values-file.yaml
```

Sends traces to google cloud trace