### PR TITLE
Add TelemetryHub to vendor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ keeping it up to date for you.
 - [New Relic](https://github.com/newrelic/opentelemetry-demo)
 - [Splunk](https://github.com/signalfx/opentelemetry-demo)
 - [Sumo Logic](https://github.com/SumoLogic/opentelemetry-demo)
+- [TelemetryHub](https://github.com/TelemetryHub/opentelemetry-demo/tree/telemetryhub-backend)
 - [Uptrace](https://github.com/uptrace/uptrace/tree/master/example/opentelemetry-demo)
 
 ## Contributing


### PR DESCRIPTION
# Changes

Add TelemetryHub to the vendor list.

## Merge Requirements

This is just a README change; I do not believe the following are necessary:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs](../docs/) folder

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).
