### PR TITLE
Add resource detectors to cart service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,3 +167,4 @@ significant modifications will be credited to OpenTelemetry Authors.
 * Add Jaeger-SPM-Config
 ([#655](https://github.com/open-telemetry/opentelemetry-demo/pull/655))
 * Add resource detectors to cart service
+([#663](https://github.com/open-telemetry/opentelemetry-demo/pull/663))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,3 +166,4 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#648](https://github.com/open-telemetry/opentelemetry-demo/pull/648))
 * Add Jaeger-SPM-Config
 ([#655](https://github.com/open-telemetry/opentelemetry-demo/pull/655))
+* Add resource detectors to cart service

--- a/docs/services/cartservice.md
+++ b/docs/services/cartservice.md
@@ -20,7 +20,11 @@ of the exporter and resource attributes is performed through environment variabl
 
 ```cs
 services.AddOpenTelemetryTracing((builder) => builder
-    .ConfigureResource(r => r.AddTelemetrySdk())
+    .ConfigureResource(r => r
+        .AddTelemetrySdk()
+        .AddEnvironmentVariableDetector()
+        .AddDetector(new DockerResourceDetector())
+    )
     .AddRedisInstrumentation(
         cartStore.GetConnection(),
         options => options.SetVerboseDatabaseStatements = true)
@@ -70,7 +74,11 @@ instrumentation libraries, exporters, etc.
 
 ```cs
 services.AddOpenTelemetryMetrics(builder => builder
-    .ConfigureResource(r => r.AddTelemetrySdk())
+    .ConfigureResource(r => r
+        .AddTelemetrySdk()
+        .AddEnvironmentVariableDetector()
+        .AddDetector(new DockerResourceDetector())
+    )
     .AddRuntimeInstrumentation()
     .AddAspNetCoreInstrumentation()
     .AddOtlpExporter());

--- a/src/cartservice/src/Program.cs
+++ b/src/cartservice/src/Program.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Extensions.Docker.Resources;
 using OpenTelemetry.Trace;
 using cartservice.services;
 using Microsoft.AspNetCore.Http;
@@ -42,7 +43,11 @@ Console.WriteLine("Initialization completed");
 builder.Services.AddSingleton<ICartStore>(cartStore);
 
 builder.Services.AddOpenTelemetryTracing((builder) => builder
-    .ConfigureResource(r => r.AddTelemetrySdk())
+    .ConfigureResource(r => r
+        .AddTelemetrySdk()
+        .AddEnvironmentVariableDetector()
+        .AddDetector(new DockerResourceDetector())
+    )
     .AddRedisInstrumentation(
         cartStore.GetConnection(),
         options => options.SetVerboseDatabaseStatements = true)
@@ -52,7 +57,11 @@ builder.Services.AddOpenTelemetryTracing((builder) => builder
     .AddOtlpExporter());
 
 builder.Services.AddOpenTelemetryMetrics(builder => builder
-    .ConfigureResource(r => r.AddTelemetrySdk())
+    .ConfigureResource(r => r
+        .AddTelemetrySdk()
+        .AddEnvironmentVariableDetector()
+        .AddDetector(new DockerResourceDetector())
+    )
     .AddRuntimeInstrumentation()
     .AddAspNetCoreInstrumentation()
     .AddOtlpExporter());

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.44.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.46.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Docker" Version="1.0.0-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />


### PR DESCRIPTION
# Changes

Resource detection for cart service, right now it is only the container.id because it looks like no other resource detectors exist for .NET (yet)

<img width="809" alt="Screenshot 2022-12-28 at 12 16 06" src="https://user-images.githubusercontent.com/1519757/209803919-29984f26-3865-4de5-9bb3-71a1ed4893f8.png">

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs](../docs/) folder

