### PR TITLE
Add Grafana Labs' fork as a vendor fork to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ keeping it up to date for you.
 - [Coralogix](https://coralogix.com/blog/configure-otel-demo-send-telemetry-data-coralogix)
 - [Datadog](https://github.com/DataDog/opentelemetry-demo)
 - [Dynatrace](https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/)
+- [Grafana Labs](https://github.com/grafana/opentelemetry-demo)
 - [Helios](https://otelsandbox.gethelios.dev)
 - [Honeycomb.io](https://github.com/honeycombio/opentelemetry-demo)
 - [Lightstep](https://github.com/lightstep/opentelemetry-demo)


### PR DESCRIPTION
# Changes

Add Grafana Labs' fork as a vendor fork to README

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).
