### PR TITLE
Fixes #696, Downgrades OTP

### DIFF
--- a/src/featureflagservice/Dockerfile
+++ b/src/featureflagservice/Dockerfile
@@ -12,9 +12,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.3-erlang-25.0-debian-bullseye-20210902-slim
 #
-ARG ELIXIR_VERSION=1.14.2
-ARG OTP_VERSION=25.1.2
-ARG DEBIAN_VERSION=bullseye-20221004-slim
+ARG ELIXIR_VERSION=1.13.3
+ARG OTP_VERSION=23.0
+ARG DEBIAN_VERSION=bullseye-20210902-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
# Changes

I tested v1.1-v1.2.1 on M1 and x86/Linux. I was able to recreate issue #696 on all versions that included OTP 25.