### PR TITLE
Fix link to the docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,8 @@ For new features contributions please make sure you have completed the following
 essential items:
 
 * [ ] `CHANGELOG.md` updated to document new feature additions
-* [ ] Appropriate documentation updates in the [docs](../docs/) folder
+* [ ] Appropriate documentation updates in the
+[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs) folder
 
 Maintainers will not merge until the above have been completed. If you're unsure
 which docs need to be changed ping the


### PR DESCRIPTION
# Changes

For some reason the link to docs is not working:
* [ ] Appropriate documentation updates in the [docs](../docs/) folder

I've updated the template to use the link of the docs page itself, instead of a reference to it.