### PR TITLE
Update dockerfile for adservice to use different base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,3 +200,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#693](https://github.com/open-telemetry/opentelemetry-demo/pull/693))
 * Reduce spans generated from quote service
 ([#702](https://github.com/open-telemetry/opentelemetry-demo/pull/702))
+* Update dockerfile for adservice to use different base images
+([#705](https://github.com/open-telemetry/opentelemetry-demo/pull/705))

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gradle:7-jdk17 AS builder
+FROM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /usr/src/app/
 
+COPY ./src/adservice/gradlew* ./src/adservice/settings.gradle* ./src/adservice/build.gradle .
+COPY ./src/adservice/gradle ./gradle
+
+RUN ./gradlew
+RUN ./gradlew downloadRepos
+
 COPY ./src/adservice/ ./
 COPY ./pb/ ./proto
-RUN gradle downloadRepos
-RUN gradle installDist -PprotoSourceDir=./proto
+RUN ./gradlew installDist -PprotoSourceDir=./proto
 
 # -----------------------------------------------------------------------------
 

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,26 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jdk AS builder
+FROM gradle:7-jdk17 AS builder
 
 WORKDIR /usr/src/app/
 
 COPY ./src/adservice/ ./
 COPY ./pb/ ./proto
-RUN ./gradlew downloadRepos
-RUN ./gradlew installDist -PprotoSourceDir=./proto
+RUN gradle downloadRepos
+RUN gradle installDist -PprotoSourceDir=./proto
 
 # -----------------------------------------------------------------------------
 
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jre
 
 ARG version=1.19.1
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/ ./
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
-RUN chmod 644 /app/opentelemetry-javaagent.jar
-ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /usr/src/app/opentelemetry-javaagent.jar
+RUN chmod 644 /usr/src/app/opentelemetry-javaagent.jar
+ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
 
 EXPOSE ${AD_SERVICE_PORT}
 ENTRYPOINT [ "./build/install/hipstershop/bin/AdService" ]


### PR DESCRIPTION
# Changes

Minor change for the adservice: Similar to frauddetectionservice this makes use of the gradle image to save some time downloading gradle (since both use the same gradle image then this even saves some extra time downloading the image). It also replaces the jdk with a jre image for the final image, saves some ~190MB (518 down to 328)
