### PR TITLE
Adds caveats to current exemplar support in the demo architecture

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -628,7 +628,7 @@ services:
 
   # OpenTelemetry Collector
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.69.0
+    image: otel/opentelemetry-collector-contrib:0.70.0
     container_name: otel-col
     deploy:
       resources:

--- a/docs/demo_features.md
+++ b/docs/demo_features.md
@@ -17,7 +17,7 @@ be added as the relevant SDKs are released.
   Collector](https://opentelemetry.io/docs/collector/getting-started)**: all
   services are instrumented and sending the generated traces and metrics to the
   OpenTelemetry Collector via gRPC. The received traces are then exported to the
-  logs and to Jaeger; received metrics and exemplars are exported to logs and Prometheus.
+  logs and to Jaeger; received metrics and exemplars* are exported to logs and Prometheus.
 - **[Jaeger](https://www.jaegertracing.io)**: all generated traces are being
   sent to Jaeger.
 - **Synthetic Load Generation**: the application demo comes with a background
@@ -30,3 +30,7 @@ be added as the relevant SDKs are released.
 - **[Envoy](https://www.envoyproxy.io/)**: Envoy is used as a reverse proxy for
   user-facing web interfaces such as the frontend, load generator, and feature
   flag service.
+
+_\*Only exemplars attached to histograms are currently exported to Prometheus.
+See [issue in the collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18201)
+for details._


### PR DESCRIPTION
# Changes

Adds caveats to current exemplar support in the demo architecture
Also, updates collector version: exemplars for the latency histogram produced by the span  metrics processor are now getting exported for all services and endpoints, not just the first one in the metric family.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the
[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs) folder

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).
