### PR TITLE
[chore] - fix image version

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Images
-IMAGE_VERSION=v1.3.0
+IMAGE_VERSION=1.3.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 
 # Demo Platform


### PR DESCRIPTION
Remove the `v` prefix from the image version. We now publish images without this prefix.

Without this `docker compose build` will not work.
