### PR TITLE
[Product Catalog Service] add reflection register for grpcurl debug

### DIFF
--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -17,13 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"os"
-	"strings"
-	"sync"
-	"time"
-
 	pb "github.com/opentelemetry/opentelemetry-demo/src/productcatalogservice/genproto/hipstershop"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -31,6 +24,12 @@ import (
 	"go.opentelemetry.io/otel/metric/global"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -47,6 +46,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 )
 
@@ -147,6 +147,8 @@ func main() {
 		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
 		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor()),
 	)
+
+	reflection.Register(srv)
 
 	pb.RegisterProductCatalogServiceServer(srv, svc)
 	healthpb.RegisterHealthServer(srv, svc)


### PR DESCRIPTION
# Changes

I want to debug `grpc` method in `productcatalog service`, But I got error:
![wecom-temp-27346-4f01f0953b7a3a8fbfc4361d8c56a0f9](https://user-images.githubusercontent.com/12468337/217199997-3f256634-dd72-4159-8a71-713b863b46a5.png)

after with this PR enhancement:
![wecom-temp-23548-87bdeb86b604adc7c1a61093b6615181](https://user-images.githubusercontent.com/12468337/217200176-dd401a13-ea5d-4aae-ad09-5db388e25667.png)


## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
