### PR TITLE
Ensure all http.server.duration metrics have the same description

### DIFF
--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -23,6 +23,12 @@ processors:
   batch:
   spanmetrics:
     metrics_exporter: prometheus
+  # temporary measure until description is fixed in .NET
+  transform:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(description, "Measures the duration of inbound HTTP requests") where name == "http.server.duration"
 
 service:
   pipelines:
@@ -32,5 +38,5 @@ service:
       exporters: [logging, otlp]
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [transform, batch]
       exporters: [prometheus, logging]


### PR DESCRIPTION
# Changes

Temporarily add a transform processor to ensure that all `http.server.duration` metrics have the same description before being exported by Prometheus.  Fixes #737.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
