### PR TITLE
rename proto package from hipstershop to oteldemo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ release.
 
 ## Unreleased
 
+* [docs] Drop docs folder as step in migration to OTel website
+([#729](https://github.com/open-telemetry/opentelemetry-demo/issues/729))
+* rename proto package from hipstershop to oteldemo
+([#740](https://github.com/open-telemetry/opentelemetry-demo/pull/740))
+
+## v0.1.0
+
 * The initial code base is donated from a
 [fork](https://github.com/julianocosta89/opentelemetry-microservices-demo) of
 the [Google microservices
@@ -19,6 +26,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#82](https://github.com/open-telemetry/opentelemetry-demo/pull/82))
 * Rewrote shipping service in Rust
 ([#35](https://github.com/open-telemetry/opentelemetry-demo/issues/35))
+
+## v0.2.0
+
 * Added feature flag service implementation
 ([#141](https://github.com/open-telemetry/opentelemetry-demo/pull/141))
 * Added additional attributes to productcatalog service
@@ -35,6 +45,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#164](https://github.com/open-telemetry/opentelemetry-demo/pull/164))
 * Added Grafana service and enhanced metric experience
 ([#175](https://github.com/open-telemetry/opentelemetry-demo/pull/175))
+
+## v0.3.0
+
 * Enhanced cart service attributes
 ([#183](https://github.com/open-telemetry/opentelemetry-demo/pull/183))
 * Re-implemented currency service using C++
@@ -87,12 +100,18 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#332](https://github.com/open-telemetry/opentelemetry-demo/pull/332))
 * Add `synthetic_request=true` baggage to load generator requests
 ([#331](https://github.com/open-telemetry/opentelemetry-demo/pull/331))
+
+## v0.4.0
+
 * Add span events to shipping service
 ([#344](https://github.com/open-telemetry/opentelemetry-demo/pull/344))
 * Add PHP quote service
 ([#345](https://github.com/open-telemetry/opentelemetry-demo/pull/345))
 * Improve initial run time, without a build
 ([#362](https://github.com/open-telemetry/opentelemetry-demo/pull/362))
+
+## v0.5.0
+
 * Add custom span and custom span attributes for Feature Flag Service
 ([#371](https://github.com/open-telemetry/opentelemetry-demo/pull/371))
 * Change Cart Service to be async
@@ -111,6 +130,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#409](https://github.com/open-telemetry/opentelemetry-demo/pull/409))
 * Added hero scenario metric to Checkout Service on cache leak
 ([#339](https://github.com/open-telemetry/opentelemetry-demo/pull/339))
+
+## v0.6.0-beta
+
 * Added basic metrics support for recommendation service (Python)
 ([#416](https://github.com/open-telemetry/opentelemetry-demo/pull/416))
 * Added metrics auto-instrumentation + minor metrics refactor for recommendation
@@ -118,12 +140,18 @@ significant modifications will be credited to OpenTelemetry Authors.
  [#432](https://github.com/open-telemetry/opentelemetry-demo/pull/432)
 * Replaced the Jaeger exporter to the OTLP exporter in the OTel Collector
 ([#435](https://github.com/open-telemetry/opentelemetry-demo/pull/435))
+
+## v0.6.1-beta
+
 * Set resource memory limits for all services
 ([#460](https://github.com/open-telemetry/opentelemetry-demo/pull/460))
 * Added cache scenario to recommendation service
 ([#455](https://github.com/open-telemetry/opentelemetry-demo/pull/455))
 * Update cartservice Dockerfile to support ARM64
 ([#439](https://github.com/open-telemetry/opentelemetry-demo/pull/439))
+
+## v0.7.0-beta
+
 * Update shippingservice to add resource data to spans
 ([#504](https://github.com/open-telemetry/opentelemetry-demo/pull/504))
 * Add Envoy as reverse proxy for all user-facing services
@@ -132,6 +160,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#513](https://github.com/open-telemetry/opentelemetry-demo/pull/513))
 * Added frontend instrumentation exporter custom url
 ([#512](https://github.com/open-telemetry/opentelemetry-demo/pull/512))
+
+## v1.1.0
+
 * Replaced PHP-CLI to PHP-Apache for a more realistic service
 ([#563](https://github.com/open-telemetry/opentelemetry-demo/pull/563))
 * Optimize currencyservice build time with parallel build jobs
@@ -140,6 +171,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#536](https://github.com/open-telemetry/opentelemetry-demo/pull/536))
 * Add basic metrics support for payment service
 ([#583](https://github.com/open-telemetry/opentelemetry-demo/pull/583))
+
+## 1.2.0
+
 * Change ZipCode data type from int to string
 ([#587](https://github.com/open-telemetry/opentelemetry-demo/pull/587))
 * Pass product's `categories` as an input for the Ad service
@@ -154,6 +188,9 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#613](https://github.com/open-telemetry/opentelemetry-demo/pull/613))
 * Build Kafka image
 ([#617](https://github.com/open-telemetry/opentelemetry-demo/pull/617))
+
+## 1.3.0
+
 * Use `frontend-web` as service name for browser/web requests
 ([#628](https://github.com/open-telemetry/opentelemetry-demo/pull/628))
 * Update `quoteservice` to use opentelemetry-php beta release
@@ -212,7 +249,5 @@ significant modifications will be credited to OpenTelemetry Authors.
 ([#705](https://github.com/open-telemetry/opentelemetry-demo/pull/705))
 * Enable exemplar support in the metrics exporter, Prometheus, and Grafana
 ([#704](https://github.com/open-telemetry/opentelemetry-demo/pull/704))
-* [docs] Drop docs folder as step in migration to OTel website
-([#729](https://github.com/open-telemetry/opentelemetry-demo/issues/729))
 * Add cross-compilation for shipping service
 ([#715](https://github.com/open-telemetry/opentelemetry-demo/issues/715))

--- a/pb/demo.proto
+++ b/pb/demo.proto
@@ -16,9 +16,9 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
-package hipstershop;
+package oteldemo;
 
-option go_package = "genproto/hipstershop";
+option go_package = "genproto/oteldemo";
 
 // -----------------Cart service-----------------
 

--- a/src/accountingservice/kafka/consumer.go
+++ b/src/accountingservice/kafka/consumer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/open-telemetry/opentelemetry-demo/src/accountingservice/genproto/hipstershop"
+	"github.com/open-telemetry/opentelemetry-demo/src/accountingservice/genproto/oteldemo"
 
 	"github.com/Shopify/sarama"
 	"github.com/sirupsen/logrus"
@@ -57,7 +57,7 @@ func (g *groupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim s
 	for {
 		select {
 		case message := <-claim.Messages():
-			orderResult := hipstershop.OrderResult{}
+			orderResult := oteldemo.OrderResult{}
 			err := proto.Unmarshal(message.Value, &orderResult)
 			if err != nil {
 				return err

--- a/src/adservice/README.md
+++ b/src/adservice/README.md
@@ -14,14 +14,14 @@ To build Ad Service, run:
 ```
 
 It will create an executable script
-`src/adservice/build/install/hipstershop/bin/AdService`.
+`src/adservice/build/install/oteldemo/bin/AdService`.
 
 To run the Ad Service:
 
 ```sh
 export AD_SERVICE_PORT=8080
 export FEATURE_FLAG_GRPC_SERVICE_ADDR=featureflagservice:50053
-./build/install/hipstershop/bin/AdService
+./build/install/oteldemo/bin/AdService
 ```
 
 ### Upgrading Gradle

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -106,9 +106,9 @@ googleJavaFormat {
 sourceSets {
     main {
         java {
-            srcDirs 'hipstershop'
-            srcDirs 'build/generated/source/proto/main/java/hipstershop'
-            srcDirs 'build/generated/source/proto/main/grpc/hipstershop'
+            srcDirs 'oteldemo'
+            srcDirs 'build/generated/source/proto/main/java/oteldemo'
+            srcDirs 'build/generated/source/proto/main/grpc/oteldemo'
         }
     }
 }
@@ -125,7 +125,7 @@ task downloadRepos(type: Copy) {
 }
 
 task adService(type: CreateStartScripts) {
-    mainClass.set('hipstershop.AdService')
+    mainClass.set('oteldemo.AdService')
     applicationName = 'AdService'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath

--- a/src/adservice/src/main/java/oteldemo/AdService.java
+++ b/src/adservice/src/main/java/oteldemo/AdService.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package hipstershop;
+package oteldemo;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
-import hipstershop.Demo.Ad;
-import hipstershop.Demo.AdRequest;
-import hipstershop.Demo.AdResponse;
-import hipstershop.Demo.GetFlagResponse;
-import hipstershop.FeatureFlagServiceGrpc.FeatureFlagServiceBlockingStub;
+import oteldemo.Demo.Ad;
+import oteldemo.Demo.AdRequest;
+import oteldemo.Demo.AdResponse;
+import oteldemo.Demo.GetFlagResponse;
+import oteldemo.FeatureFlagServiceGrpc.FeatureFlagServiceBlockingStub;
 import io.grpc.*;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.protobuf.services.*;
@@ -130,7 +130,7 @@ public final class AdService {
     RANDOM
   }
 
-  private static class AdServiceImpl extends hipstershop.AdServiceGrpc.AdServiceImplBase {
+  private static class AdServiceImpl extends oteldemo.AdServiceGrpc.AdServiceImplBase {
 
     private static final String ADSERVICE_FAIL_FEATURE_FLAG = "adServiceFailure";
 
@@ -212,7 +212,7 @@ public final class AdService {
 
       GetFlagResponse response =
           featureFlagServiceStub.getFlag(
-              hipstershop.Demo.GetFlagRequest.newBuilder()
+              oteldemo.Demo.GetFlagRequest.newBuilder()
                   .setName(ADSERVICE_FAIL_FEATURE_FLAG)
                   .build());
       return response.getFlag().getEnabled();

--- a/src/cartservice/src/cartstore/ICartStore.cs
+++ b/src/cartservice/src/cartstore/ICartStore.cs
@@ -23,7 +23,7 @@ namespace cartservice.cartstore
         Task AddItemAsync(string userId, string productId, int quantity);
         Task EmptyCartAsync(string userId);
 
-        Task<Hipstershop.Cart> GetCartAsync(string userId);
+        Task<Oteldemo.Cart> GetCartAsync(string userId);
 
         bool Ping();
     }

--- a/src/cartservice/src/cartstore/LocalCartStore.cs
+++ b/src/cartservice/src/cartstore/LocalCartStore.cs
@@ -23,8 +23,8 @@ namespace cartservice.cartstore
     internal class LocalCartStore : ICartStore
     {
         // Maps between user and their cart
-        private ConcurrentDictionary<string, Hipstershop.Cart> userCartItems = new ConcurrentDictionary<string, Hipstershop.Cart>();
-        private readonly Hipstershop.Cart emptyCart = new Hipstershop.Cart();
+        private ConcurrentDictionary<string, Oteldemo.Cart> userCartItems = new ConcurrentDictionary<string, Oteldemo.Cart>();
+        private readonly Oteldemo.Cart emptyCart = new Oteldemo.Cart();
 
         public Task InitializeAsync()
         {
@@ -36,10 +36,10 @@ namespace cartservice.cartstore
         public Task AddItemAsync(string userId, string productId, int quantity)
         {
             Console.WriteLine($"AddItemAsync called with userId={userId}, productId={productId}, quantity={quantity}");
-            var newCart = new Hipstershop.Cart
+            var newCart = new Oteldemo.Cart
                 {
                     UserId = userId,
-                    Items = { new Hipstershop.CartItem { ProductId = productId, Quantity = quantity } }
+                    Items = { new Oteldemo.CartItem { ProductId = productId, Quantity = quantity } }
                 };
             userCartItems.AddOrUpdate(userId, newCart,
             (k, exVal) =>
@@ -52,7 +52,7 @@ namespace cartservice.cartstore
                 }
                 else
                 {
-                    exVal.Items.Add(new Hipstershop.CartItem { ProductId = productId, Quantity = quantity });
+                    exVal.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
                 }
 
                 return exVal;
@@ -67,14 +67,14 @@ namespace cartservice.cartstore
             eventTags.Add("userId", userId);
             Activity.Current?.AddEvent(new ActivityEvent("EmptyCartAsync called.", default, eventTags));
 
-            userCartItems[userId] = new Hipstershop.Cart();
+            userCartItems[userId] = new Oteldemo.Cart();
             return Task.CompletedTask;
         }
 
-        public Task<Hipstershop.Cart> GetCartAsync(string userId)
+        public Task<Oteldemo.Cart> GetCartAsync(string userId)
         {
             Console.WriteLine($"GetCartAsync called with userId={userId}");
-            Hipstershop.Cart cart = null;
+            Oteldemo.Cart cart = null;
             if (!userCartItems.TryGetValue(userId, out cart))
             {
                 Console.WriteLine($"No carts for user {userId}");

--- a/src/cartservice/src/cartstore/RedisCartStore.cs
+++ b/src/cartservice/src/cartstore/RedisCartStore.cs
@@ -38,7 +38,7 @@ namespace cartservice.cartstore
         public RedisCartStore(string redisAddress)
         {
             // Serialize empty cart into byte array.
-            var cart = new Hipstershop.Cart();
+            var cart = new Oteldemo.Cart();
             emptyCartBytes = cart.ToByteArray();
             connectionString = $"{redisAddress},ssl=false,allowAdmin=true,abortConnect=false";
 
@@ -126,20 +126,20 @@ namespace cartservice.cartstore
                 // Access the cart from the cache
                 var value = await db.HashGetAsync(userId, CART_FIELD_NAME);
 
-                Hipstershop.Cart cart;
+                Oteldemo.Cart cart;
                 if (value.IsNull)
                 {
-                    cart = new Hipstershop.Cart();
+                    cart = new Oteldemo.Cart();
                     cart.UserId = userId;
-                    cart.Items.Add(new Hipstershop.CartItem { ProductId = productId, Quantity = quantity });
+                    cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
                 }
                 else
                 {
-                    cart = Hipstershop.Cart.Parser.ParseFrom(value);
+                    cart = Oteldemo.Cart.Parser.ParseFrom(value);
                     var existingItem = cart.Items.SingleOrDefault(i => i.ProductId == productId);
                     if (existingItem == null)
                     {
-                        cart.Items.Add(new Hipstershop.CartItem { ProductId = productId, Quantity = quantity });
+                        cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
                     }
                     else
                     {
@@ -173,7 +173,7 @@ namespace cartservice.cartstore
             }
         }
 
-        public async Task<Hipstershop.Cart> GetCartAsync(string userId)
+        public async Task<Oteldemo.Cart> GetCartAsync(string userId)
         {
             Console.WriteLine($"GetCartAsync called with userId={userId}");
 
@@ -188,11 +188,11 @@ namespace cartservice.cartstore
 
                 if (!value.IsNull)
                 {
-                    return Hipstershop.Cart.Parser.ParseFrom(value);
+                    return Oteldemo.Cart.Parser.ParseFrom(value);
                 }
 
                 // We decided to return empty cart in cases when user wasn't in the cache before
-                return new Hipstershop.Cart();
+                return new Oteldemo.Cart();
             }
             catch (Exception ex)
             {

--- a/src/cartservice/src/services/CartService.cs
+++ b/src/cartservice/src/services/CartService.cs
@@ -16,11 +16,11 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Grpc.Core;
 using cartservice.cartstore;
-using Hipstershop;
+using Oteldemo;
 
 namespace cartservice.services
 {
-    public class CartService : Hipstershop.CartService.CartServiceBase
+    public class CartService : Oteldemo.CartService.CartServiceBase
     {
         private readonly static Empty Empty = new Empty();
         private readonly ICartStore _cartStore;

--- a/src/cartservice/tests/CartServiceTests.cs
+++ b/src/cartservice/tests/CartServiceTests.cs
@@ -15,12 +15,12 @@
 using System;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
-using Hipstershop;
+using Oteldemo;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using static Hipstershop.CartService;
+using static Oteldemo.CartService;
 
 namespace cartservice.tests
 {

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -51,7 +51,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/hipstershop"
+	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/oteldemo"
 	"github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/kafka"
 	"github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/money"
 )

--- a/src/checkoutservice/money/money.go
+++ b/src/checkoutservice/money/money.go
@@ -17,7 +17,7 @@ package money
 import (
 	"errors"
 
-	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/hipstershop"
+	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/oteldemo"
 )
 
 const (

--- a/src/checkoutservice/money/money_test.go
+++ b/src/checkoutservice/money/money_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/hipstershop"
+	pb "github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/genproto/oteldemo"
 )
 
 func mmc(u int64, n int32, c string) *pb.Money { return &pb.Money{Units: u, Nanos: n, CurrencyCode: c} }

--- a/src/currencyservice/proto/demo.proto
+++ b/src/currencyservice/proto/demo.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package hipstershop;
+package oteldemo;
 
 // -----------------Cart service-----------------
 

--- a/src/currencyservice/src/server.cpp
+++ b/src/currencyservice/src/server.cpp
@@ -32,10 +32,10 @@
 
 using namespace std;
 
-using hipstershop::Empty;
-using hipstershop::GetSupportedCurrenciesResponse;
-using hipstershop::CurrencyConversionRequest;
-using hipstershop::Money;
+using oteldemo::Empty;
+using oteldemo::GetSupportedCurrenciesResponse;
+using oteldemo::CurrencyConversionRequest;
+using oteldemo::Money;
 
 using grpc::Status;
 using grpc::ServerContext;
@@ -98,7 +98,7 @@ class HealthServer final : public grpc::health::v1::Health::Service
   }
 };
 
-class CurrencyService final : public hipstershop::CurrencyService::Service
+class CurrencyService final : public oteldemo::CurrencyService::Service
 {
   Status GetSupportedCurrencies(ServerContext* context,
   	const Empty* request,

--- a/src/featureflagservice/config/runtime.exs
+++ b/src/featureflagservice/config/runtime.exs
@@ -12,7 +12,7 @@ config :grpcbox,
       :grpc_opts => %{
         :service_protos => [:ffs_demo_pb],
         :unary_interceptor => {:otel_grpcbox_interceptor, :unary},
-        :services => %{:"hipstershop.FeatureFlagService" => :ffs_service}
+        :services => %{:"oteldemo.FeatureFlagService" => :ffs_service}
       },
       :listen_opts => %{:port => grpc_port}
     }

--- a/src/featureflagservice/rebar.config
+++ b/src/featureflagservice/rebar.config
@@ -6,7 +6,7 @@
 {deps, []}.
 
 {grpc, [{protos, ["proto"]},
-        {service_modules, [{'hipstershop.FeatureFlagService', "ffs_service"},
+        {service_modules, [{'oteldemo.FeatureFlagService', "ffs_service"},
                            {'grpc.health.v1.Health', "grpcbox_health"},
                            {'grpc.reflection.v1alpha.ServerReflection', "grpcbox_reflection"}]},
         {gpb_opts, [{descriptor, true},

--- a/src/frauddetectionservice/src/main/kotlin/frauddetectionservice/main.kt
+++ b/src/frauddetectionservice/src/main/kotlin/frauddetectionservice/main.kt
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig.*
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import hipstershop.Demo.*
+import oteldemo.Demo.*
 import java.time.Duration.ofMillis
 import java.util.Properties
 import kotlin.system.exitProcess

--- a/src/paymentservice/index.js
+++ b/src/paymentservice/index.js
@@ -48,14 +48,14 @@ async function closeGracefully(signal) {
   process.kill(process.pid, signal)
 }
 
-const hipsterShopPackage = grpc.loadPackageDefinition(protoLoader.loadSync('demo.proto'))
+const otelDemoPackage = grpc.loadPackageDefinition(protoLoader.loadSync('demo.proto'))
 const server = new grpc.Server()
 
 server.addService(health.service, new health.Implementation({
   '': health.servingStatus.SERVING
 }))
 
-server.addService(hipsterShopPackage.hipstershop.PaymentService.service, { charge: chargeServiceHandler })
+server.addService(otelDemoPackage.oteldemo.PaymentService.service, { charge: chargeServiceHandler })
 
 server.bindAsync(`0.0.0.0:${process.env['PAYMENT_SERVICE_PORT']}`, grpc.ServerCredentials.createInsecure(), (err, port) => {
   if (err) {

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
-	pb "github.com/opentelemetry/opentelemetry-demo/src/productcatalogservice/genproto/hipstershop"
+	pb "github.com/opentelemetry/opentelemetry-demo/src/productcatalogservice/genproto/oteldemo"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"

--- a/src/shippingservice/src/shipping_service.rs
+++ b/src/shippingservice/src/shipping_service.rs
@@ -20,7 +20,7 @@ const RPC_GRPC_STATUS_CODE_OK: i64 = 0;
 const RPC_GRPC_STATUS_CODE_UNKNOWN: i64 = 2;
 
 pub mod shop {
-    tonic::include_proto!("hipstershop"); // The string specified here must match the proto package name
+    tonic::include_proto!("oteldemo"); // The string specified here must match the proto package name
 }
 
 #[derive(Debug, Default)]
@@ -67,7 +67,7 @@ impl ShippingService for ShippingServer {
         // (although now everything is assumed to be the same price)
         // check out the create_quote_from_count method to see how we use the span created here
         let tracer = global::tracer("shippingservice");
-        let mut span = tracer.span_builder("hipstershop.ShippingService/GetQuote").with_kind(SpanKind::Server).start_with_context(&tracer, &parent_cx);
+        let mut span = tracer.span_builder("oteldemo.ShippingService/GetQuote").with_kind(SpanKind::Server).start_with_context(&tracer, &parent_cx);
         span.set_attribute(semcov::trace::RPC_SYSTEM.string(RPC_SYSTEM_GRPC));
 
         span.add_event("Processing get quote request".to_string(), vec![]);
@@ -106,7 +106,7 @@ impl ShippingService for ShippingServer {
         // we'll create a span and associated events all in this function.
         let tracer = global::tracer("shippingservice");
         let mut span = tracer
-            .span_builder("hipstershop.ShippingService/ShipOrder").with_kind(SpanKind::Server).start_with_context(&tracer, &parent_cx);
+            .span_builder("oteldemo.ShippingService/ShipOrder").with_kind(SpanKind::Server).start_with_context(&tracer, &parent_cx);
         span.set_attribute(semcov::trace::RPC_SYSTEM.string(RPC_SYSTEM_GRPC));
 
         span.add_event("Processing shipping order request".to_string(), vec![]);

--- a/test/test.js
+++ b/test/test.js
@@ -67,17 +67,17 @@ const {
 } = process.env;
 
 test.before(() => {
-  const hipstershop = grpc.loadPackageDefinition(
+  const oteldemo = grpc.loadPackageDefinition(
     protoLoader.loadSync("./demo.proto")
-  ).hipstershop;
+  ).oteldemo;
 
-  const adClient = new hipstershop.AdService(
+  const adClient = new oteldemo.AdService(
     AD_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
   adsGet = promisify(adClient.getAds).bind(adClient);
 
-  const cartClient = new hipstershop.CartService(
+  const cartClient = new oteldemo.CartService(
     CART_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
@@ -85,13 +85,13 @@ test.before(() => {
   cartGet = promisify(cartClient.getCart).bind(cartClient);
   cartEmpty = promisify(cartClient.emptyCart).bind(cartClient);
 
-  const checkoutClient = new hipstershop.CheckoutService(
+  const checkoutClient = new oteldemo.CheckoutService(
     CHECKOUT_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
   checkoutOrder = promisify(checkoutClient.placeOrder).bind(checkoutClient);
 
-  const currencyClient = new hipstershop.CurrencyService(
+  const currencyClient = new oteldemo.CurrencyService(
     CURRENCY_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
@@ -100,13 +100,13 @@ test.before(() => {
   );
   currencyConvert = promisify(currencyClient.convert).bind(currencyClient);
 
-  const paymentClient = new hipstershop.PaymentService(
+  const paymentClient = new oteldemo.PaymentService(
     PAYMENT_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
   charge = promisify(paymentClient.charge).bind(paymentClient);
 
-  const productCatalogClient = new hipstershop.ProductCatalogService(
+  const productCatalogClient = new oteldemo.ProductCatalogService(
     PRODUCT_CATALOG_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
@@ -120,7 +120,7 @@ test.before(() => {
     productCatalogClient
   );
 
-  const recommendationClient = new hipstershop.RecommendationService(
+  const recommendationClient = new oteldemo.RecommendationService(
     RECOMMENDATION_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );
@@ -128,7 +128,7 @@ test.before(() => {
     recommendationClient
   );
 
-  const shippingClient = new hipstershop.ShippingService(
+  const shippingClient = new oteldemo.ShippingService(
     SHIPPING_SERVICE_ADDR,
     grpc.credentials.createInsecure()
   );


### PR DESCRIPTION
# Changes

Renames the proto definition package to oteldemo. Wanted to see how much work was involved here, open to alternative names. Figured oteldemo was short and to the point :)

Fixes #638

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
