### PR TITLE
prometheus: honor_labels to have the right job and instance

### DIFF
--- a/src/prometheus/prometheus-config.yaml
+++ b/src/prometheus/prometheus-config.yaml
@@ -3,6 +3,7 @@ global:
   scrape_interval: 5s
 scrape_configs:
 - job_name: otel
+  honor_labels: true
   static_configs:
   - targets:
     - 'otelcol:9464'


### PR DESCRIPTION
# Changes

OTel Collector exports `/metrics` with `job` label set. However, if we run Prometheus with `honor_labels: false` (default), it will ignore the `job` label and set it to `job=otel, exported_job=recommendation-service`.

This is literally the case for which `honor_labels` was created and it should be set to true, which will make sure that the final metrics in Prometheus will have only `job=recommendation-service`

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/