### PR TITLE
[chore] - update dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,12 +38,13 @@ src/frontend/cypress/screenshots
 src/shippingservice/target/
 
 # Ignore copied/generated protobuf files
+/src/accountingservice/genproto/
 /src/cartservice/src/protos/
 /src/checkoutservice/genproto/
 /src/featureflagservice/proto/
 /src/featureflagservice/src/ffs_demo_pb.erl
 /src/featureflagservice/src/ffs_service_*.erl
-/src/featureflagservice/src/hipstershop_*.erl
+/src/featureflagservice/src/oteldemo_*.erl
 /src/frontend/pb/
 /src/frontend/protos/
 /src/paymentservice/demo.proto

--- a/ide-gen-proto.sh
+++ b/ide-gen-proto.sh
@@ -2,7 +2,7 @@
 
 # This script is used to generate protobuf files for all services.
 # Useful to ensure code can compile without Docker, and provide hints for IDEs.
-# Several dev tools including: cargo, protoc, python grpc_tools.protoc, and rebar3 may be required to run this script.
+# Several dev tools including: cargo, protoc, python grpcio-tools, and rebar3 may be required to run this script.
 
 base_dir=$(pwd)
 


### PR DESCRIPTION
# Changes

Updates `.gitignore` with:
- Use `oteldemo` namespace for generated protobuf files in Elixir
- Adds accountingservice generated protobuf files

Mentions use of proper Python package to use dev tooling in `ide-gen-proto.sh`
