### PR TITLE
[chore] update for mac m2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ tls_certificate_check and bump to OTP-25
 ([#756](https://github.com/open-telemetry/opentelemetry-demo/pull/756))
 * Bump up OTEL Java Agent version to 1.23.0
 ([#757](https://github.com/open-telemetry/opentelemetry-demo/pull/757))
+* [chore] update for Mac M2 architecture
+([#764](https://github.com/open-telemetry/opentelemetry-demo/pull/764))
 
 ## v0.1.0
 

--- a/src/adservice/src/main/java/oteldemo/AdService.java
+++ b/src/adservice/src/main/java/oteldemo/AdService.java
@@ -90,7 +90,7 @@ public final class AdService {
                     new IllegalStateException(
                         "environment vars: FEATURE_FLAG_GRPC_SERVICE_ADDR must not be null"));
     FeatureFlagServiceBlockingStub featureFlagServiceStub =
-        FeatureFlagServiceGrpc.newBlockingStub(
+        oteldemo.FeatureFlagServiceGrpc.newBlockingStub(
             ManagedChannelBuilder.forTarget(featureFlagServiceAddr).usePlaintext().build());
 
     server =

--- a/src/emailservice/Gemfile.lock
+++ b/src/emailservice/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   net-smtp (~> 0.3)

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -1,5 +1,5 @@
 grpcio-health-checking==1.43.0
-grpcio==1.43.0
+grpcio==1.51.3
 opentelemetry-distro==0.36b0
 opentelemetry-exporter-otlp-proto-grpc==1.15.0
 python-dotenv==0.21.0


### PR DESCRIPTION
# Changes

Minor updates to work with Mac M2 architectures.

- adservice/AdService.java - IntelliJ gave an error without the package prefix.
- emailservice/Gemfile.lock - Add arm64-darwin-22
- recommendationservice/requirements.txt - grpcio update required to work with M2 [[ref](https://github.com/grpc/grpc/issues/30182)]


* [x] `CHANGELOG.md` updated to document new feature additions
