### PR TITLE
Fix shipping cost update when new item is added to cart 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
 ([#795](https://github.com/open-telemetry/opentelemetry-demo/pull/795))
 * Add logs for Ad service and Recommendation service
 ([#796](https://github.com/open-telemetry/opentelemetry-demo/pull/796))
+* Fixed shipping update in the frontend UI when number of products in cart changes
+([#799](https://github.com/open-telemetry/opentelemetry-demo/pull/799))
 
 ## v0.1.0
 

--- a/src/frontend/components/CartItems/CartItems.tsx
+++ b/src/frontend/components/CartItems/CartItems.tsx
@@ -36,7 +36,9 @@ const CartItems = ({ productList, shouldShowPrice = true }: IProps) => {
     country: 'United States',
     zipCode: '94043',
   };
-  const { data: shippingConst = { units: 0, currencyCode: 'USD', nanos: 0 } } = useQuery('shipping', () =>
+
+  const { data: shippingConst = { units: 0, currencyCode: 'USD', nanos: 0 } } = useQuery(['shipping',
+      productList, selectedCurrency, address], () =>
     ApiGateway.getShippingCost(productList, selectedCurrency, address)
   );
 


### PR DESCRIPTION
# Changes

This fixes the shipping cost update when any parameters (like list of products) for the shipping API call change.

The `react-query` component needs a unique key to know whether to make a network call or use cached data. The query parameters are used as a unique key. This is documented [here](https://react-query-v3.tanstack.com/guides/query-keys#if-your-query-function-depends-on-a-variable-include-it-in-your-query-key).

The original bug is listed in https://github.com/open-telemetry/opentelemetry-demo/issues/327