### PR TITLE
[chore] use absolute path for yamllint

### DIFF
--- a/.yamlignore
+++ b/.yamlignore
@@ -1,1 +1,1 @@
-kubernetes/opentelemetry-demo.yaml
+/kubernetes/opentelemetry-demo.yaml


### PR DESCRIPTION
Use an absolute path for yamllint ignore to unblock #791 
