### PR TITLE
[chore] use yamllint 1.3.0

### DIFF
--- a/.yamlignore
+++ b/.yamlignore
@@ -1,1 +1,1 @@
-/kubernetes/opentelemetry-demo.yaml
+kubernetes/opentelemetry-demo.yaml

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ markdownlint:
 .PHONY: install-yamllint
 install-yamllint:
     # Using a venv is recommended
-	pip install -U yamllint~=1.26.1
+	pip install -U yamllint~=1.30.0
 
 .PHONY: yamllint
 yamllint:


### PR DESCRIPTION
In the never-ending quest to get #791 to pass yamllint checks

Turns out that locally on my system, I have `yamllint` installed with brew, which grabs the latest version (currently 1.30.0). The GH check (via our Makefile) installs this using pip, which specifies version 1.26.3.  We use a yamllint config option of `ignore-from-file`, which was introduced in 1.28.0, and hence that's why it wasn't working.

This PR updates the yamllint version to the latest version (1.30.0)
