### PR TITLE
fix(featureflagservice): use proper root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ release.
   ([#797](https://github.com/open-telemetry/opentelemetry-demo/pull/797))
 * Fixed shipping update in the frontend UI when number of products in cart changes
   ([#799](https://github.com/open-telemetry/opentelemetry-demo/pull/799))
+* [featureflag] fix root path
+  ([#808](https://github.com/open-telemetry/opentelemetry-demo/pull/799))
 
 ## v0.1.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,6 @@ services:
       - OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
       - OTEL_SERVICE_NAME=featureflagservice
       - DATABASE_URL=ecto://ffs:ffs@ffs_postgres:5432/ffs
-      - FEATURE_FLAG_SERVICE_PATH_ROOT="/feature"
     healthcheck:
       test: ["CMD", "curl", "-H", "baggage: synthetic_request=true", "-f", "http://localhost:${FEATURE_FLAG_SERVICE_PORT}"]
     depends_on:

--- a/src/featureflagservice/config/config.exs
+++ b/src/featureflagservice/config/config.exs
@@ -26,7 +26,7 @@ config :featureflagservice,
 
 # Configures the endpoint
 config :featureflagservice, FeatureflagserviceWeb.Endpoint,
-  url: [host: "localhost", path: "/feature"],
+  url: [host: "localhost", path: "/"],
   render_errors: [view: FeatureflagserviceWeb.ErrorView, accepts: ~w(html json), layout: false],
   pubsub_server: Featureflagservice.PubSub,
   live_view: [signing_salt: "T88WPl/Q"]

--- a/src/featureflagservice/lib/featureflagservice_web/templates/layout/root.html.heex
+++ b/src/featureflagservice/lib/featureflagservice_web/templates/layout/root.html.heex
@@ -34,7 +34,7 @@
             <li><%= link "New feature flag", to: Routes.feature_flag_path(@conn, :new) %></li>
           </ul>
         </nav>
-        <a href="/feature" class="button">
+        <a href="/" class="button">
           Feature Flags
         </a>
       </section>


### PR DESCRIPTION
# Changes

`/feature` was used as `root path` which was causing service dysfunction.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
