### PR TITLE
[prometheus] fix prometheus scrape bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -648,7 +648,7 @@ services:
 
   # Prometheus
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.34.0
+    image: quay.io/prometheus/prometheus:v2.43.0
     container_name: prometheus
     command:
       - --web.console.templates=/etc/prometheus/consoles


### PR DESCRIPTION
# Changes

For now, `prometheus` service starts with exemplar-storage feature, which has bugs in v2.34.0 version, caused the manually added metric `app.ads.ad_requests` in service `adService` can not be scraped successfully. 

The error detail in prometheus [target status page](http://127.0.0.1:9090/targets?search=), 

| metric name app_ads_ad_requests does not support exemplars

![image](https://user-images.githubusercontent.com/11855957/230545049-2735d375-2ea3-403c-bc95-7757f1ec9376.png)

This is known [issue](https://github.com/prometheus-net/prometheus-net/issues/407) in prometheus community  and be  resolved in [pr](https://github.com/prometheus/prometheus/pull/11984), which is release in v2.43.0

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]

[docs]: https://opentelemetry.io/docs/demo/
