### PR TITLE
[cartservice] - Use ConfigureResource

### DIFF
--- a/src/cartservice/src/Program.cs
+++ b/src/cartservice/src/Program.cs
@@ -33,15 +33,15 @@ builder.Services.AddSingleton<ICartStore>(cartStore);
 
 // see https://opentelemetry.io/docs/instrumentation/net/getting-started/
 
-var appResourceBuilder = ResourceBuilder
-    .CreateDefault()
-    .AddTelemetrySdk()
-    .AddEnvironmentVariableDetector()
-    .AddDetector(new ContainerResourceDetector());
+Action<ResourceBuilder> appResourceBuilder =
+    resource => resource
+        .AddTelemetrySdk()
+        .AddEnvironmentVariableDetector()
+        .AddDetector(new ContainerResourceDetector());
 
 builder.Services.AddOpenTelemetry()
+    .ConfigureResource(appResourceBuilder)
     .WithTracing(builder => builder
-        .SetResourceBuilder(appResourceBuilder)
         .AddRedisInstrumentation(
             cartStore.GetConnection(),
             options => options.SetVerboseDatabaseStatements = true)
@@ -50,7 +50,6 @@ builder.Services.AddOpenTelemetry()
         .AddHttpClientInstrumentation()
         .AddOtlpExporter())
     .WithMetrics(builder => builder
-        .SetResourceBuilder(appResourceBuilder)
         .AddRuntimeInstrumentation()
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());


### PR DESCRIPTION
# Changes

After #835 got merged, I saw that we could get rid of `.SetResourceBuilder(appResourceBuilder)` which is being used twice (Tracing and Metrics), in favor of `ConfigureResource`.

## Merge Requirements

I already have an opened PR to update the cartservice docs, I can update it, whenever this gets merged:
https://github.com/open-telemetry/opentelemetry.io/pull/2607
