### PR TITLE
[chore] update kubernetes manifest

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 
 
 # Images
-IMAGE_VERSION=1.4.0-beta
+IMAGE_VERSION=1.4.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 
 # Demo Platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ release.
 
 ## Unreleased
 
+* [chore] use `otel-demo` namespace for generated kubernetes manifests
+  ([#848](https://github.com/open-telemetry/opentelemetry-demo/pull/848))
+
+## 1.4.0
+
 * [cart] use 60m TTL for cart entries in redis
   ([#779](https://github.com/open-telemetry/opentelemetry-demo/pull/779))
 * spanmetrics dashboard service&operation rates & latencies

--- a/Makefile
+++ b/Makefile
@@ -103,4 +103,4 @@ generate-protobuf:
 generate-kubernetes-manifests:
 	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 	helm repo update
-	helm template opentelemetry-demo open-telemetry/opentelemetry-demo | sed '/helm.sh\/chart\:/d' | sed '/helm.sh\/hook/d' | sed '/managed-by\: Helm/d' > kubernetes/opentelemetry-demo.yaml
+	helm template opentelemetry-demo open-telemetry/opentelemetry-demo --namespace otel-demo | sed '/helm.sh\/chart\:/d' | sed '/helm.sh\/hook/d' | sed '/managed-by\: Helm/d' > kubernetes/opentelemetry-demo.yaml

--- a/Makefile
+++ b/Makefile
@@ -103,4 +103,6 @@ generate-protobuf:
 generate-kubernetes-manifests:
 	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 	helm repo update
-	helm template opentelemetry-demo open-telemetry/opentelemetry-demo --namespace otel-demo | sed '/helm.sh\/chart\:/d' | sed '/helm.sh\/hook/d' | sed '/managed-by\: Helm/d' > kubernetes/opentelemetry-demo.yaml
+	echo "# Copyright The OpenTelemetry Authors" > kubernetes/opentelemetry-demo.yaml
+	echo "# SPDX-License-Identifier: Apache-2.0" >> kubernetes/opentelemetry-demo.yaml
+	helm template opentelemetry-demo open-telemetry/opentelemetry-demo --namespace otel-demo | sed '/helm.sh\/chart\:/d' | sed '/helm.sh\/hook/d' | sed '/managed-by\: Helm/d' >> kubernetes/opentelemetry-demo.yaml

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -1,3 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/serviceaccount.yaml
 apiVersion: v1

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -1,5 +1,3 @@
-# Copyright The OpenTelemetry Authors
-# SPDX-License-Identifier: Apache-2.0
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/serviceaccount.yaml
 apiVersion: v1
@@ -8,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
   name: opentelemetry-demo-grafana
   namespace: otel-demo
 ---
@@ -20,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/component: all-in-one
 ---
 # Source: opentelemetry-demo/charts/opentelemetry-collector/templates/serviceaccount.yaml
@@ -31,7 +29,7 @@ metadata:
   labels:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
 ---
 # Source: opentelemetry-demo/charts/prometheus/templates/serviceaccount.yaml
 apiVersion: v1
@@ -41,7 +39,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
   namespace: otel-demo
@@ -54,9 +52,11 @@ kind: ServiceAccount
 metadata:
   name: opentelemetry-demo
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/secret.yaml
@@ -68,7 +68,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 type: Opaque
 data:
   admin-user: "YWRtaW4="
@@ -84,7 +84,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 data:
   grafana.ini: |
     [analytics]
@@ -150,9 +150,11 @@ metadata:
   labels:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
 data:
   relay: |
+    connectors:
+      spanmetrics: null
     exporters:
       logging: {}
       otlp:
@@ -170,12 +172,21 @@ data:
         size_in_percentage: 40
     processors:
       batch: {}
+      filter/ottl:
+        error_mode: ignore
+        metrics:
+          metric:
+          - name == "queueSize"
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      spanmetrics:
-        metrics_exporter: prometheus
+      transform:
+        metric_statements:
+        - context: metric
+          statements:
+          - set(description, "Measures the duration of inbound HTTP requests") where name
+            == "http.server.duration"
     receivers:
       jaeger:
         protocols:
@@ -194,7 +205,7 @@ data:
               allowed_origins:
               - http://*
               - https://*
-            endpoint: ${MY_POD_IP}:4318
+            endpoint: 127.0.0.1:4318
       prometheus:
         config:
           scrape_configs:
@@ -224,17 +235,19 @@ data:
           - logging
           processors:
           - memory_limiter
+          - filter/ottl
+          - transform
           - batch
           receivers:
           - otlp
-          - prometheus
+          - spanmetrics
         traces:
           exporters:
           - otlp
           - logging
+          - spanmetrics
           processors:
           - memory_limiter
-          - spanmetrics
           - batch
           receivers:
           - otlp
@@ -252,7 +265,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
   namespace: otel-demo
@@ -295,13 +308,15 @@ kind: ConfigMap
 metadata:
   name: opentelemetry-demo-grafana-dashboards
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 data:
+  
   demo-dashboard.json: |
-    
     {
       "annotations": {
         "list": [
@@ -998,9 +1013,2233 @@ data:
       "version": 1,
       "weekStart": ""
     }
-    
+  opentelemetry-collector-data-flow.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "otelcol metrics dashboard",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 6,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 8,
+          "panels": [],
+          "title": "Process",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Otel Collector Instance",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 0,
+            "y": 1
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "count(count(otelcol_process_cpu_seconds{service_instance_id=~\".*\"}) by (service_instance_id))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Instance",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_process_cpu_seconds",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 1
+          },
+          "id": 24,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(rate(otelcol_process_cpu_seconds{}[$__rate_interval])*100) by (instance)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cpu",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Memory Rss\navg(otelcol_process_memory_rss{}) by (instance)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 6,
+            "y": 1
+          },
+          "id": 38,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(otelcol_process_memory_rss{}) by (instance)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Memory",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 4,
+            "w": 15,
+            "x": 9,
+            "y": 1
+          },
+          "id": 32,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "## Opentelemetry Collector Data Ingress/Egress\n\n`service_version:` ${service_version}\n\n`opentelemetry collector:` contrib\n\n",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.1.0",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 10,
+          "panels": [],
+          "title": "Trace Pipeline",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "(avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range]))) / avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))) ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 3,
+            "x": 0,
+            "y": 6
+          },
+          "id": 55,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "export"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "acc"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "(avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range]))) / avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))) ",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Export Ratio",
+          "transformations": [],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 21,
+            "x": 3,
+            "y": 6
+          },
+          "id": 4,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(label_join(\n(rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"\", \"transport\", \"receiver\")\n, \"title\", \"\", \"transport\", \"receiver\")\n\nor\n\nlabel_replace(label_replace(\nsum by(service_name) (rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"processor\", \"dummynode\", \"\")\n, \"title\", \"processor\", \"dummynode\", \"\")\n\nor\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n, \"id\", \"$0\", \"processor\", \".*\")\n, \"title\", \"$0\", \"processor\", \".*\")\n\nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_spans{}[$__interval]))\n, \"id\", \"exporter\", \"dummynode\", \"\")\n, \"title\", \"exporter\", \"dummynode\", \"\")\n        \nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_spans{}[$__interval]))\n, \"id\", \"$0\", \"exporter\", \".*\")\n, \"title\", \"$0\", \"exporter\", \".*\")",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_join(\n(rate(otelcol_receiver_accepted_spans{}[$__interval]))\n\n ,\"source\",\"\",\"transport\",\"receiver\")\n,\"target\",\"processor\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\n  or\n\n  label_join(\nlabel_replace(label_replace(\n  (rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n ,\"source\",\"processor\",\"\",\"\")\n,\"target\",\"$0\",\"processor\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\n  label_join(\nlabel_replace(label_replace(\n    (rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n ,\"source\",\"$0\",\"processor\",\".*\")\n,\"target\",\"exporter\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\n  label_join(\nlabel_replace(label_replace(\n   (rate(otelcol_exporter_sent_spans{}[$__interval]))\n ,\"source\",\"exporter\",\"\",\"\")\n,\"target\",\"$0\",\"exporter\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\n",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Spans Accepted by Receiver and Transport",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 3,
+            "y": 17
+          },
+          "id": 12,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_spans{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Accepted",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Spans Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 8,
+            "y": 17
+          },
+          "id": 13,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_spans{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Batch Processed",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 11,
+            "y": 17
+          },
+          "id": 15,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_processor_batch_batch_send_size_sum{}[$__rate_interval]))  by (processor)",
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Batch",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 16,
+            "y": 17
+          },
+          "id": 14,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_spans{}[$__interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 17
+          },
+          "id": 30,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_spans{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sent",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 3,
+            "y": 22
+          },
+          "id": 17,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_spans{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Refused",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Spans Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 8,
+            "y": 22
+          },
+          "id": 18,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_spans{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 16,
+            "y": 22
+          },
+          "id": 19,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_spans{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter\notelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 19,
+            "y": 22
+          },
+          "id": 20,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_spans{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 22,
+          "panels": [],
+          "title": "Metrics Pipeline",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range]))) versus avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range])))",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 3,
+            "x": 0,
+            "y": 26
+          },
+          "id": 54,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/.*/",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "export"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "acc"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "( avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range]))) /avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range]))))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Export Ratio",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "percent",
+                "binary": {
+                  "left": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[3600s])))",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[3600s])))"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )": true,
+                  "Time": true,
+                  "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[3600s])))": true,
+                  "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[3600s])))": true,
+                  "{instance=\"otelcol:9464\", job=\"otel\"}": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Time": "",
+                  "percent": "Percent",
+                  "{exporter=\"logging\", instance=\"otelcol:8888\", job=\"otel-collector\", service_instance_id=\"fbfa720a-ebf9-45c8-a79a-9d3b6021a663\", service_name=\"otelcol-contrib\", service_version=\"0.70.0\"}": ""
+                }
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Metrics Signalling Pipelines",
+          "gridPos": {
+            "h": 11,
+            "w": 21,
+            "x": 3,
+            "y": 26
+          },
+          "id": 25,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "\nlabel_join(label_join(\n(rate(otelcol_receiver_accepted_metric_points{}[$__interval]))\n, \"id\", \"\", \"transport\", \"receiver\")\n, \"title\", \"\", \"transport\", \"receiver\")\n\nor\n\nlabel_replace(label_replace(\nsum by(service_name) (rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"processor\", \"dummynode\", \"\")\n, \"title\", \"processor\", \"dummynode\", \"\")\n\n\n\nor\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n, \"id\", \"$0\", \"processor\", \".*\")\n, \"title\", \"$0\", \"processor\", \".*\")\n\n\n\n\n\nor\nlabel_replace(label_replace(\nsum (rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n, \"id\", \"exporter\", \"dummynode\", \"\")\n, \"title\", \"exporter\", \"dummynode\", \"\")\n\nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n, \"id\", \"$0\", \"exporter\", \".*\")\n, \"title\", \"$0\", \"exporter\", \".*\")",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_join(\n(rate(otelcol_receiver_accepted_metric_points{}[$__interval]))\n\n,\"source\",\"\",\"transport\",\"receiver\")\n,\"target\",\"processor\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\n\nor\n\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n,\"source\",\"processor\",\"\",\"\")\n,\"target\",\"$0\",\"processor\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\n\n\n\n\nor\n\n\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n,\"source\",\"$0\",\"processor\",\".*\")\n,\"target\",\"exporter\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n,\"source\",\"exporter\",\"\",\"\")\n,\"target\",\"$0\",\"exporter\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_receiver_accepted_metric_points",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 3,
+            "y": 37
+          },
+          "id": 26,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_metric_points{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Accepted",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_receiver_accepted_metric_points\nTotal Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 8,
+            "y": 37
+          },
+          "id": 27,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_metric_points{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 11,
+            "y": 37
+          },
+          "id": 28,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_processor_batch_batch_send_size_sum{}[$__rate_interval]))  by (processor)",
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Batch",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Export ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 16,
+            "y": 37
+          },
+          "id": 29,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_metric_points{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 37
+          },
+          "id": 16,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_metric_points{}[$__rate_interval])) by (exporter) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sent",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 3,
+            "y": 42
+          },
+          "id": 47,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Refused",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Refused \nsum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 8,
+            "y": 42
+          },
+          "id": 48,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Failed Export ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 16,
+            "y": 42
+          },
+          "id": 49,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_metric_points{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter\notelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 19,
+            "y": 42
+          },
+          "id": 50,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_metric_points{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 35,
+          "panels": [],
+          "title": "Prometheus Scrape",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol prometheus exporter 9464 export rate versus prometheus scrape metrics",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 0,
+            "y": 46
+          },
+          "id": 53,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/.*/",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "(sum_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/ count_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/(5*30)) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "accepted"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[$__rate_interval])) )",
+              "format": "time_series",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exported/Scraped",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "percent",
+                "binary": {
+                  "left": "{instance=\"otelcol:9464\", job=\"otel\"}",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )": true,
+                  "Time": true,
+                  "{instance=\"otelcol:9464\", job=\"otel\"}": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "percent": "Percent"
+                }
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 3,
+            "y": 46
+          },
+          "id": 37,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])/(5*30)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{job}}/{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Samples Scraped",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "scrape_samples_scraped{job!=\"\"}\nTotal Samples Scraped",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 8,
+            "y": 46
+          },
+          "id": 42,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])/(5*30)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Total",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "{instance=\"otelcol:9464\", job=\"otel\"}",
+                    "{instance=\"otelcol:8888\", job=\"otel-collector\"}"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 11,
+            "y": 46
+          },
+          "id": 41,
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_replace(label_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"}) by (instance)\n, \"id\", \"$0\", \"instance\", \".*\")\n, \"title\", \"$0\", \"instance\", \".*\")\n,\"mainstat\",\"\",\"\",\"\")\n\nor \n\nlabel_replace(label_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"})\n, \"id\", \"prometheus\", \"\", \"\")\n, \"title\", \"prometheus\", \"\", \"\")\n,\"mainstat\",\"\",\"\",\"\")\n",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"}) by (instance)\n,\"source\",\"$0\",\"instance\",\".*\")\n,\"target\",\"prometheus\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 19,
+            "y": 46
+          },
+          "id": 52,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "\n \n## Prometheus Config\n\n`evaluation_interval:` 30s\n\n`scrape_interval:` 5s",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.1.0",
+          "type": "text"
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "0.70.0",
+              "value": "0.70.0"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(sum(otelcol_process_uptime{}) by (service_version))\n",
+            "hide": 2,
+            "includeAll": false,
+            "label": "service_version",
+            "multi": true,
+            "name": "service_version",
+            "options": [],
+            "query": {
+              "query": "query_result(sum(otelcol_process_uptime{}) by (service_version))\n",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "/.*service_version=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Opentelemetry Collector Data Flow",
+      "uid": "rl5_tea4k",
+      "version": 2,
+      "weekStart": ""
+    }
   opentelemetry-collector.json: |
-    
     {
       "__inputs": [
         {
@@ -2555,6 +4794,1010 @@ data:
       "uid": "BKf2sowmj",
       "version": 7
     }
+  spanmetrics-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Spanmetrics way of demo application view.",
+      "author": {
+        "name": "devrimdemiroz"
+        },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 24,
+          "panels": [],
+          "title": "Service Level - Throughput and Latencies",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 64
+                  },
+                  {
+                    "color": "orange",
+                    "value": 128
+                  },
+                  {
+                    "color": "red",
+                    "value": 256
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 20,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "interval": "5m",
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.50, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{service_name}}-quantile_0.50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.95, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,service_name)))",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{le}} - {{service_name}}",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.99, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile99",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.999, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile999",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Top 3x3 - Service Latency - quantile95",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "super-light-blue",
+                    "value": 1
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 2
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 4,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,sum by (service_name) (rate(calls{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])))",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{service_name}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Services Mean Rate over Range",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-reds"
+              },
+              "decimals": 4,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 15,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,sum(rate(calls{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (service_name))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{service_name}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Services Mean ERROR Rate over Range",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 14,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "span_names Level - Throughput",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "bRate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlYlRd"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "eRate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-RdYlGr"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error Rate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 663
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 667
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Service"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": null
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "id": 22,
+          "interval": "5m",
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "exemplar": false,
+              "expr": "topk(7, sum(rate(calls{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name)) ",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "Rate"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "exemplar": false,
+              "expr": "topk(7, sum(rate(calls{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name))",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "Error Rate"
+            }
+          ],
+          "title": "Top 7 span_names and Errors  (APM Table)",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "span_name"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value #Error Rate": "Error Rate",
+                  "Value #Rate": "Rate",
+                  "service_name 1": "Rate in Service",
+                  "service_name 2": "Error Rate in Service"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "bRate",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Rate"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "eRate",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Error Rate"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Error Rate": true,
+                  "Rate": true,
+                  "bRate": false
+                },
+                "indexByName": {
+                  "Error Rate": 4,
+                  "Error Rate in Service": 6,
+                  "Rate": 1,
+                  "Rate in Service": 5,
+                  "bRate": 2,
+                  "eRate": 3,
+                  "span_name": 0
+                },
+                "renameByName": {
+                  "Rate in Service": "Service",
+                  "bRate": "Rate",
+                  "eRate": "Error Rate",
+                  "span_name": "span_name Name"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Rate"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 20,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "span_name Level - Latencies",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 64
+                  },
+                  {
+                    "color": "orange",
+                    "value": 128
+                  },
+                  {
+                    "color": "red",
+                    "value": 256
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 25,
+          "interval": "5m",
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.50, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{service_name}}-quantile_0.50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.95, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,span_name)))",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{span_name}}",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.99, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile99",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.999, sum(rate(duration_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile999",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Top 3x3 - span_name Latency - quantile95",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 10,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7, sum by (span_name,service_name)(increase(duration_sum{service_name=~\"${service}\", span_name=~\"$span_name\"}[5m]) / increase(duration_count{service_name=~\"${service}\",span_name=~\"$span_name\"}[5m\n])))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{span_name}} [{{service_name}}]",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Highest Endpoint Latencies  Mean Over Range ",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 47
+          },
+          "id": 16,
+          "interval": "5m",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "logmin",
+                "max",
+                "delta"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "topk(7,sum by (span_name,service_name)(increase(duration_sum{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval]) / increase(duration_count{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "[{{service_name}}]  {{span_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Latencies Over Range ",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "5m",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(count by (service_name)(count_over_time(calls[$__range])))",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "service",
+            "options": [],
+            "query": {
+              "query": "query_result(count by (service_name)(count_over_time(calls[$__range])))",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "/.*service_name=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(sum ({__name__=~\".*calls\",service_name=~\"$service\"})  by (span_name))",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "span_name",
+            "options": [],
+            "query": {
+              "query": "query_result(sum ({__name__=~\".*calls\",service_name=~\"$service\"})  by (span_name))",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "/.*span_name=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Spanmetrics Demo Dashboard",
+      "uid": "W2gX2zHVk48",
+      "version": 1,
+      "weekStart": ""
+    }
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/clusterrole.yaml
 kind: ClusterRole
@@ -2563,7 +5806,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
   name: opentelemetry-demo-grafana-clusterrole
 rules: []
 ---
@@ -2575,7 +5818,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
 rules:
@@ -2617,7 +5860,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-demo-grafana
@@ -2635,7 +5878,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
 subjects:
@@ -2656,7 +5899,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 rules: []
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/rolebinding.yaml
@@ -2668,7 +5911,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -2687,7 +5930,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 spec:
   type: ClusterIP
   ports:
@@ -2707,7 +5950,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/component: service-agent
 spec:
   clusterIP: None
@@ -2740,7 +5983,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/component: service-collector
 spec:
   clusterIP: None
@@ -2776,7 +6019,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/component: service-query
 spec:
   clusterIP: None
@@ -2800,7 +6043,7 @@ metadata:
   labels:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     component: standalone-collector
 spec:
   type: ClusterIP
@@ -2852,7 +6095,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
   namespace: otel-demo
@@ -2875,21 +6118,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-adservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-adservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-adservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: opentelemetry-demo-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -2897,21 +6141,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-cartservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-cartservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-cartservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: opentelemetry-demo-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -2919,21 +6164,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-checkoutservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-checkoutservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-checkoutservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: opentelemetry-demo-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -2941,21 +6187,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-currencyservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-currencyservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-currencyservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: opentelemetry-demo-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -2963,21 +6210,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-emailservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-emailservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-emailservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: opentelemetry-demo-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -2985,10 +6233,12 @@ kind: Service
 metadata:
   name: opentelemetry-demo-featureflagservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-featureflagservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-featureflagservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -3000,9 +6250,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: opentelemetry-demo-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3010,10 +6259,12 @@ kind: Service
 metadata:
   name: opentelemetry-demo-ffspostgres
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-ffspostgres
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-ffspostgres
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -3022,9 +6273,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: opentelemetry-demo-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3032,21 +6282,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-frontend
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-frontend
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-frontend
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: opentelemetry-demo-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3054,21 +6305,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-frontendproxy
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-frontendproxy
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-frontendproxy
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: opentelemetry-demo-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3076,10 +6328,12 @@ kind: Service
 metadata:
   name: opentelemetry-demo-kafka
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-kafka
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-kafka
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -3091,9 +6345,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: opentelemetry-demo-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3101,21 +6354,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-loadgenerator
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-loadgenerator
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-loadgenerator
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: opentelemetry-demo-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3123,21 +6377,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-paymentservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-paymentservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-paymentservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: opentelemetry-demo-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3145,21 +6400,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-productcatalogservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3167,21 +6423,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-quoteservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-quoteservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-quoteservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: opentelemetry-demo-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3189,21 +6446,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-recommendationservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-recommendationservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-recommendationservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: opentelemetry-demo-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3211,10 +6469,12 @@ kind: Service
 metadata:
   name: opentelemetry-demo-redis
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-redis
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-redis
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -3223,9 +6483,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: opentelemetry-demo-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -3233,21 +6492,22 @@ kind: Service
 metadata:
   name: opentelemetry-demo-shippingservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-shippingservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-shippingservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: opentelemetry-demo-shippingservice
 ---
 # Source: opentelemetry-demo/charts/grafana/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3258,7 +6518,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -3274,10 +6534,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: opentelemetry-demo
       annotations:
-        checksum/config: a05fde81589f12bdd8a83af5c745d118806dea711344efe6425490b1b5d14e6a
+        checksum/config: 46e9428a9c36c5c45a84485e747d9911e5d9cc320ac4bec997c39688cfda1b43
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: b80a547fcea5fdd0e6831574f85763d75999fe4b231daf12dbe0d475c518726b
+        checksum/secret: 168eac9549c1155906143bae680e232ce7a8acecd06af6a8ca9d6088db7473f2
     spec:
       
       serviceAccountName: opentelemetry-demo-grafana
@@ -3289,7 +6549,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.3.8"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -3351,7 +6611,7 @@ spec:
               port: 3000
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
       volumes:
         - name: config
           configMap:
@@ -3370,7 +6630,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
     prometheus.io/scrape: "true"
@@ -3405,7 +6665,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.39.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -3467,7 +6727,7 @@ metadata:
   labels:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -3481,7 +6741,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9047ab7c8478a0e6a1fa4cb8ecd936922c90b2ea731c2bfada2ec403d66182eb
+        checksum/config: f656fcfa8e308a9922ba2be0799513a217a25722c2abc9855ea3e09d534fa89c
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -3500,9 +6760,10 @@ spec:
           command:
             - /otelcol-contrib
             - --config=/conf/relay.yaml
+            - --feature-gates=service.connectors
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.72.0"
+          image: "otel/opentelemetry-collector-contrib:0.75.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact
@@ -3567,7 +6828,7 @@ metadata:
     component: "server"
     app: prometheus
     release: opentelemetry-demo
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: opentelemetry-demo-prometheus-server
   namespace: otel-demo
@@ -3587,7 +6848,7 @@ spec:
         component: "server"
         app: prometheus
         release: opentelemetry-demo
-        chart: prometheus-19.7.2
+        chart: prometheus-20.2.0
         heritage: Helm
     spec:
       enableServiceLinks: true
@@ -3595,7 +6856,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.41.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d
@@ -3656,28 +6917,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-accountingservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-accountingservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-accountingservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: opentelemetry-demo-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-accountingservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: opentelemetry-demo-accountingservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -3707,17 +6971,25 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'opentelemetry-demo-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
               memory: 20Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -3725,28 +6997,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-adservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-adservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-adservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: opentelemetry-demo-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-adservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: opentelemetry-demo-adservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -3780,12 +7055,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'opentelemetry-demo-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -3798,28 +7077,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-cartservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-cartservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-cartservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: opentelemetry-demo-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-cartservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: opentelemetry-demo-cartservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -3853,19 +7135,29 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'opentelemetry-demo-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
               memory: 160Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-redis 6379; do echo waiting
+            for redis; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -3873,28 +7165,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-checkoutservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-checkoutservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-checkoutservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: opentelemetry-demo-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-checkoutservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: opentelemetry-demo-checkoutservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -3928,29 +7223,39 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'opentelemetry-demo-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'opentelemetry-demo-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://opentelemetry-demo-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'opentelemetry-demo-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'opentelemetry-demo-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'opentelemetry-demo-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://opentelemetry-demo-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'opentelemetry-demo-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
               memory: 20Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -3958,28 +7263,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-currencyservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-currencyservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-currencyservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: opentelemetry-demo-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-currencyservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: opentelemetry-demo-currencyservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4013,12 +7321,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4031,28 +7339,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-emailservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-emailservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-emailservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: opentelemetry-demo-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-emailservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: opentelemetry-demo-emailservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4086,16 +7397,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4108,28 +7417,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-featureflagservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-featureflagservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-featureflagservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: opentelemetry-demo-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-featureflagservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: opentelemetry-demo-featureflagservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4165,16 +7477,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@opentelemetry-demo-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4186,6 +7500,14 @@ spec:
               port: 8081
             initialDelaySeconds: 30
             periodSeconds: 10
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-ffspostgres 5432; do echo
+            waiting for ffspostgres; sleep 2; done
+          image: busybox:latest
+          name: wait-for-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -4193,23 +7515,26 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-ffspostgres
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-ffspostgres
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-ffspostgres
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: opentelemetry-demo-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-ffspostgres
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: opentelemetry-demo-ffspostgres
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
@@ -4248,11 +7573,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
@@ -4270,28 +7597,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-frauddetectionservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-frauddetectionservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: opentelemetry-demo-frauddetectionservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -4321,17 +7651,25 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'opentelemetry-demo-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
               memory: 200Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -4339,28 +7677,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-frontend
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-frontend
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-frontend
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: opentelemetry-demo-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-frontend
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: opentelemetry-demo-frontend
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4394,6 +7735,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -4414,8 +7759,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://localhost:4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -4423,6 +7766,10 @@ spec:
           resources:
             limits:
               memory: 200Mi
+          securityContext:
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -4430,28 +7777,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-frontendproxy
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-frontendproxy
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-frontendproxy
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: opentelemetry-demo-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-frontendproxy
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: opentelemetry-demo-frontendproxy
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4485,6 +7835,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -4509,8 +7863,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4527,28 +7879,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-kafka
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-kafka
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-kafka
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: opentelemetry-demo-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-kafka
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: opentelemetry-demo-kafka
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4557,17 +7912,46 @@ spec:
           - containerPort: 9093
             name: controller
           env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: OTEL_K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: OTEL_K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: OTEL_K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://opentelemetry-demo-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
-            value: -Xmx400M -Xms400M
+            value: -Xmx200M -Xms200M
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
-              memory: 750Mi
+              memory: 500Mi
           securityContext:
             runAsGroup: 1000
             runAsNonRoot: true
@@ -4579,28 +7963,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-loadgenerator
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-loadgenerator
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-loadgenerator
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: opentelemetry-demo-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-loadgenerator
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: opentelemetry-demo-loadgenerator
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4634,8 +8021,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: FRONTEND_ADDR
-            value: 'opentelemetry-demo-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -4643,7 +8030,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://opentelemetry-demo-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -4652,8 +8039,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4666,28 +8051,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-paymentservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-paymentservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-paymentservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: opentelemetry-demo-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-paymentservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: opentelemetry-demo-paymentservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4721,15 +8109,21 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
               memory: 120Mi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -4737,28 +8131,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-productcatalogservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: opentelemetry-demo-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-productcatalogservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4792,14 +8189,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'opentelemetry-demo-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4812,28 +8209,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-quoteservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-quoteservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-quoteservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: opentelemetry-demo-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-quoteservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: opentelemetry-demo-quoteservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4867,12 +8267,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4889,28 +8291,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-recommendationservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-recommendationservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-recommendationservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: opentelemetry-demo-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-recommendationservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: opentelemetry-demo-recommendationservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -4944,18 +8349,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'opentelemetry-demo-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'opentelemetry-demo-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'opentelemetry-demo-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'opentelemetry-demo-productcatalogservice:8080'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -4968,23 +8375,26 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-redis
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-redis
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-redis
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: opentelemetry-demo-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-redis
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: opentelemetry-demo-redis
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
@@ -5023,6 +8433,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -5039,28 +8451,31 @@ kind: Deployment
 metadata:
   name: opentelemetry-demo-shippingservice
   labels:
-    app.kubernetes.io/name: opentelemetry-demo
+    
+    opentelemetry.io/name: opentelemetry-demo-shippingservice
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/name: opentelemetry-demo-shippingservice
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: opentelemetry-demo
-      app.kubernetes.io/instance: opentelemetry-demo
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: opentelemetry-demo-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: opentelemetry-demo
+        
+        opentelemetry.io/name: opentelemetry-demo-shippingservice
         app.kubernetes.io/instance: opentelemetry-demo
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: opentelemetry-demo-shippingservice
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.1-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.4.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -5094,14 +8509,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'opentelemetry-demo-otelcol'
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://opentelemetry-demo-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -5115,7 +8530,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
   name: opentelemetry-demo-grafana-test
   namespace: otel-demo
   annotations:
@@ -5130,7 +8545,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
 data:
   run.sh: |-
     @test "Test Health" {
@@ -5148,7 +8563,7 @@ metadata:
   labels:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
   annotations:
   namespace: otel-demo
 spec:


### PR DESCRIPTION
With a Helm chart released for 1.4 of the demo, this is an output of that release. Also forces the namespace to be `otel-demo` and when combined with a docs change will fix #840

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs](https://github.com/open-telemetry/opentelemetry.io/pull/2611)

