### PR TITLE
[currencyservice] Fix OTel C++ build and update OTel version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
   ([#878](https://github.com/open-telemetry/opentelemetry-demo/pull/878))
 * [kafka] remove KRaft mode support workarounds
   ([#880](https://github.com/open-telemetry/opentelemetry-demo/pull/880))
+* [currencyservice] Fix OTel C++ build and update OTel version to 1.9.0
+  ([#886](https://github.com/open-telemetry/opentelemetry-demo/pull/886))
 
 ## 1.4.0
 

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,14 +19,16 @@ FROM alpine as builder
 RUN apk update
 RUN apk add git cmake make g++ grpc-dev re2-dev protobuf-dev c-ares-dev
 
-ARG OPENTELEMETRY_CPP_VERSION=1.8.2
+ARG OPENTELEMETRY_CPP_VERSION=1.9.0
 
 RUN git clone https://github.com/open-telemetry/opentelemetry-cpp \
 	&& cd opentelemetry-cpp/ \
     	&& git checkout tags/v${OPENTELEMETRY_CPP_VERSION} -b v${OPENTELEMETRY_CPP_VERSION} \
 	&& mkdir build \
 	&& cd build \
-	&& cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=ON \
+	&& cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+				-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
+				-DWITH_EXAMPLES=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=ON \
 	&& make -j$(nproc || sysctl -n hw.ncpu || echo 1) install && cd ../.. && rm -rf opentelemetry-cpp
 
 COPY . /currencyservice


### PR DESCRIPTION
# Changes

Fix #885.
Added `-DCMAKE_CXX_STANDARD=17` to the `cmake` command and updated OTel version to `1.9.0`

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
