### PR TITLE
[chore] fix licenses for sh files

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -19,7 +19,12 @@
       "# Copyright The OpenTelemetry Authors",
       "# SPDX-License-Identifier: Apache-2.0"
     ],
-    "**/*.{ex,exs,rb,yaml,yml,sh,yamllint}": [
+    "**/*.sh": [
+      "#!/bin/sh",
+      "# Copyright The OpenTelemetry Authors",
+      "# SPDX-License-Identifier: Apache-2.0"
+    ],
+    "**/*.{ex,exs,rb,yaml,yml,yamllint}": [
       "# Copyright The OpenTelemetry Authors",
       "# SPDX-License-Identifier: Apache-2.0"
     ],

--- a/ide-gen-proto.sh
+++ b/ide-gen-proto.sh
@@ -1,6 +1,6 @@
+#!/bin/sh
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/sh
 
 
 # This script is used to generate protobuf files for all services.


### PR DESCRIPTION
Allows shebang for script files to be specified ahead of comments. Without this, we violate shellcheck [SC1128](https://github.com/koalaman/shellcheck/wiki/SC1128)