### PR TITLE
[cartservice] Update OTel .NET to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ release.
   ([#935](https://github.com/open-telemetry/opentelemetry-demo/pull/935))
 * [cartservice] update service to .NET 7
   ([#942](https://github.com/open-telemetry/opentelemetry-demo/pull/942))
+* [cartservice] update .NET package to 1.5.1 release
+  ([#935](https://github.com/open-telemetry/opentelemetry-demo/pull/957))
 
 ## 1.4.0
 

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:7.0.304 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0.305 AS builder
 
 WORKDIR /usr/src/app/
 
@@ -31,7 +31,7 @@ RUN \
 # -----------------------------------------------------------------------------
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0.7-alpine3.17
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0.8-alpine3.17
 
 WORKDIR /usr/src/app/
 COPY --from=builder /cartservice/ ./

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.53.0" />
-    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.53.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.54.0" />
+    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.54.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.0-beta.1" />

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.7" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.54.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
# Changes

[cartservice] Update OTel .NET to 1.5.1 + opportunistic update of other dependencies + docker images

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
