### PR TITLE
chore: add OTEL_COLLECTOR_PORT env for frontendproxy to support 1.4 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ release.
   ([#938](https://github.com/open-telemetry/opentelemetry-demo/pull/938))
 * [shippingservice] Update Rust dependencies and add TelemetryResourceDetector
   ([#972](https://github.com/open-telemetry/opentelemetry-demo/pull/972))
+* Add OTEL_COLLECTOR_PORT env for frontendproxy to support 1.4 image
+  ([#981](https://github.com/open-telemetry/opentelemetry-demo/pull/981))
 
 ## 1.4.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -254,7 +254,10 @@ services:
       - JAEGER_SERVICE_PORT
       - JAEGER_SERVICE_HOST
       - OTEL_COLLECTOR_HOST
-      - OTEL_COLLECTOR_PORT
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
+      # Deprecated
+      - OTEL_COLLECTOR_PORT=${OTEL_COLLECTOR_PORT_GRPC}
       - ENVOY_PORT
     depends_on:
       frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,6 +344,8 @@ services:
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP
+      # Deprecated
+      - OTEL_COLLECTOR_PORT=${OTEL_COLLECTOR_PORT_GRPC}
       - ENVOY_PORT
     depends_on:
       frontend:

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -7864,6 +7864,9 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_PORT_HTTP
             value: "4318"
+          # Deprecated
+          - name: OTEL_COLLECTOR_PORT
+            value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_RESOURCE_ATTRIBUTES


### PR DESCRIPTION
# Changes

Since #938 we has rename OTEL_COLLECTOR_PORT to OTEL_COLLECTOR_PORT_GRPC, this make our docker-compose.yml incompatiple with https://ghcr.io/open-telemetry/demo:1.4-frontendproxy publish image. This cause new user that try to setup with `docker compose up --no-build` fail to start.

This PR introduce back OTEL_COLLECTOR_PORT but only in 
- docker-compose.yml
- docker-compose.minimal.yml
- kubernetes/opentelemetry-demo.yaml

This should fixes #971

We should remove these env after 1.5 is release

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

