### PR TITLE
fix: update frontendproxy's env  for minimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ release.
   ([#938](https://github.com/open-telemetry/opentelemetry-demo/pull/938))
 * [shippingservice] Update Rust dependencies and add TelemetryResourceDetector
   ([#972](https://github.com/open-telemetry/opentelemetry-demo/pull/972))
+* Update frontendproxy's env for minimal
+  ([#983](https://github.com/open-telemetry/opentelemetry-demo/pull/983))
 
 ## 1.4.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -254,7 +254,8 @@ services:
       - JAEGER_SERVICE_PORT
       - JAEGER_SERVICE_HOST
       - OTEL_COLLECTOR_HOST
-      - OTEL_COLLECTOR_PORT
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
       - ENVOY_PORT
     depends_on:
       frontend:


### PR DESCRIPTION
# Changes

New frontendproxy's code use a new set of variable OTEL_COLLECTOR_PORT_GRPC & OTEL_COLLECTOR_PORT_HTTP to replace the old OTEL_COLLECTOR_PORT. But we miss update this in docker-compose.minimal.yml setup

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]
