### PR TITLE
Update trace based tests run script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ run-tests:
 	docker compose run traceBasedTests
 
 run-tracetesting:
-	docker compose run traceBasedTests
+	docker compose run traceBasedTests ${SERVICES_TO_TEST}
 
 .PHONY: generate-protobuf
 generate-protobuf:

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,38 @@
 # Service Testing
 
-Testing gRPC services as black boxes.
+There are two ways to test the service APIs on this demo:
+1. Using AVA to do black box testing, calling the gRPC services and validating its direct response
+2. Using Trace-based tests that call each service and validate the emitted traces and the direct response 
 
+## Testing gRPC services as black boxes.
+
+To run the entire test suite as a blackbox you need just to run the command:
+```sh
+docker compose run integrationTests
+```
+
+Now if you want the tests for a specific service:
 1. Start the services you want to test with `docker compose up --build <service>`
-1. Run `npm install`
-1. Run `npm test` or `npx ava --match='<pattern>'` to match test names
+2. Run `npm install`
+3. Run `npm test` or `npx ava --match='<pattern>'` to match test names
+
+## Testing services with Trace-based tests
+
+To run the entire test suite of trace-based tests you can run the command:
+```sh
+make run-tracetesting
+#or
+docker compose run traceBasedTests
+```
+
+To run tests for specific services, you can pass the name of the service as a parameter (using the folder names located [here](./tracetesting/)):
+```sh
+make run-tracetesting SERVICES_TO_TEST="service-1 service-2 ..." 
+#or
+docker compose run traceBasedTests "service-1 service-2 ..." 
+```
+
+For instance, if you need to run the tests for `ad-service` and `payment-service`, you can run it with:
+```sh
+make run-tracetesting SERVICES_TO_TEST="ad-service payment-service" 
+```

--- a/test/tracetesting/Dockerfile
+++ b/test/tracetesting/Dockerfile
@@ -14,4 +14,4 @@ COPY ./pb ./pb
 
 WORKDIR /app/test/tracetesting
 
-CMD ["/bin/sh", "/app/test/tracetesting/run.bash"]
+CMD ["/bin/bash", "/app/test/tracetesting/run.bash"]

--- a/test/tracetesting/Dockerfile
+++ b/test/tracetesting/Dockerfile
@@ -14,4 +14,4 @@ COPY ./pb ./pb
 
 WORKDIR /app/test/tracetesting
 
-CMD ["/bin/bash", "/app/test/tracetesting/run.bash"]
+ENTRYPOINT ["/bin/bash", "/app/test/tracetesting/run.bash"]

--- a/test/tracetesting/run.bash
+++ b/test/tracetesting/run.bash
@@ -47,11 +47,25 @@ EOF
 
 run_tracetest() {
   service_name=$1
-  test_file=./$service_name/all.yaml
+  transaction_file=./$service_name/all.yaml
 
-  tracetest --config ./cli-config.yml test run --definition $test_file --environment ./tracetesting-env.yaml --wait-for-result
+  tracetest --config ./cli-config.yml run transaction --file $transaction_file --environment ./tracetesting-env.yaml
   return $?
 }
+
+ALL_SERVICES=("ad-service" "cart-service" "currency-service" "checkout-service" "frontend-service" "email-service" "payment-service" "product-catalog-service" "recommendation-service" "shipping-service")
+CHOSEN_SERVICES=()
+
+while [[ $# -gt 0 ]]; do
+  CHOSEN_SERVICES+=("$1")
+  shift
+done
+
+if [ ${#CHOSEN_SERVICES[@]} -eq 0 ]; then
+  for service in "${ALL_SERVICES[@]}"; do
+    CHOSEN_SERVICES+=("$service")  
+  done
+fi
 
 check_if_tracetest_is_installed
 create_env_file
@@ -62,17 +76,11 @@ EXIT_STATUS=0
 
 echo ""
 echo "Running trace-based tests..."
+echo ""
 
-run_tracetest ad-service || EXIT_STATUS=$?
-run_tracetest cart-service || EXIT_STATUS=$?
-run_tracetest currency-service || EXIT_STATUS=$?
-run_tracetest checkout-service || EXIT_STATUS=$?
-run_tracetest frontend-service || EXIT_STATUS=$?
-run_tracetest email-service || EXIT_STATUS=$?
-run_tracetest payment-service || EXIT_STATUS=$?
-run_tracetest product-catalog-service || EXIT_STATUS=$?
-run_tracetest recommendation-service || EXIT_STATUS=$?
-run_tracetest shipping-service || EXIT_STATUS=$?
+for service in "${CHOSEN_SERVICES[@]}"; do
+  run_tracetest $service || EXIT_STATUS=$?
+done
 
 echo ""
 echo "Tests done! Exit code: $EXIT_STATUS"


### PR DESCRIPTION
# Changes

On this PR, we are updating the trace-based tests script to allow users to run the tests for specific services, through the command:
```sh
make run-tracetesting SERVICES_TO_TEST="ad-service payment-service" 
#or
docker compose run traceBasedTests "ad-service payment-service" 
```

Also, I'm updating the `README.md` inside `tests` to document these changes.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
