### PR TITLE
wrapper-validation-action from 1.0.6 to 1.1.0

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: gradle/wrapper-validation-action@v1.0.6
+      - uses: gradle/wrapper-validation-action@v1.1.0


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-demo/pull/1015 had some EasyCLA issues, I've closed it and sent this PR manually.