### PR TITLE
Fix TraceTest after IBM/sarama upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ release.
   ([#1085](https://github.com/open-telemetry/opentelemetry-demo/pull/1085))
 * [cartservice] Support for logs
   ([#1086](https://github.com/open-telemetry/opentelemetry-demo/pull/1086))
+* [TraceTests] Update span attributes to align with new IBM/sarama instrumentation
+  ([#1096](https://github.com/open-telemetry/opentelemetry-demo/pull/1096))
 
 ## 1.4.0
 

--- a/test/tracetesting/checkout-service/place-order.yaml
+++ b/test/tracetesting/checkout-service/place-order.yaml
@@ -45,6 +45,6 @@ spec:
     assertions:
     - attr:rpc.grpc.status_code = 0
   - name: It sends an order to be processed asyncronously
-    selector: span[tracetest.span.type="messaging" name="orders send" messaging.system="kafka" messaging.destination="orders" messaging.destination_kind="topic" messaging.operation="send"]
+    selector: span[tracetest.span.type="messaging" name="orders publish" messaging.system="kafka" messaging.destination.name="orders" messaging.destination.kind="topic" messaging.operation="publish"]
     assertions:
-    - attr:messaging.destination = "orders"
+    - attr:messaging.destination.name = "orders"

--- a/test/tracetesting/frontend-service/06-checking-out-cart.yaml
+++ b/test/tracetesting/frontend-service/06-checking-out-cart.yaml
@@ -59,12 +59,12 @@ spec:
     - attr:rpc.grpc.status_code = 0
     - attr:tracetest.selected_spans.count >= 1
   - name: The order was sent to be processed asyncronously
-    selector: span[tracetest.span.type="messaging" name="orders send" messaging.system="kafka" messaging.destination="orders" messaging.destination_kind="topic" messaging.operation="send"]
+    selector: span[tracetest.span.type="messaging" name="orders publish" messaging.system="kafka" messaging.destination.name="orders" messaging.destination.kind="topic" messaging.operation="publish"]
     assertions:
-    - attr:messaging.destination = "orders"
+    - attr:messaging.destination.name = "orders"
   - name: The order was sent to accountability
     # captures the span emitted by Kafka instrumentation for Go
-    selector: span[tracetest.span.type="messaging" name="orders receive" messaging.system="kafka" messaging.destination="orders" messaging.destination_kind="topic" messaging.operation="receive"]
+    selector: span[tracetest.span.type="messaging" name="orders receive" messaging.system="kafka" messaging.destination.name="orders" messaging.destination.kind="topic" messaging.operation="receive"]
     assertions:
     - attr:name = "orders receive"
   - name: The order was sent to fraud detection team


### PR DESCRIPTION
# Changes

Fix: #1091.
After #1083 being merged, some attributes for the Kafka spans have changed and the TraceTests needed to be adapted.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] ~~Appropriate documentation updates in the [docs][]~~
* [x] ~~Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
