### PR TITLE
(otelcol): metrics filter and transform

### DIFF
--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -30,10 +30,6 @@ processors:
           statements:
             # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-java/issues/4834
             - set(description, "") where name == "queueSize"
-            # FIXME: remove when these 2 issues are resolved:
-            # Java: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9478
-            # Go: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4301
-            - set(description, "") where name == "rpc.server.duration"
             # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1958
             - set(description, "") where name == "http.client.duration"
 

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -17,16 +17,25 @@ exporters:
 
 processors:
   batch:
-  transform:
-    metric_statements:
-      - context: metric
-        statements:
-          # FIXME: remove this when this is issue is resolved: https://github.com/open-telemetry/opentelemetry-java/issues/4834
-          - set(description, "") where name == "queueSize"
-          # FIXME: remove this when the following 2 issues are resolved
-          # Java: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9478
-          # Go: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4301
-          - set(description, "") where name == "rpc.server.duration"
+    filter/ottl:
+      error_mode: ignore
+      metrics:
+        metric:
+          # FIXME: remove when a Metrics View is implemented in the checkout and productcatalog components
+          # or when this issue is resolved: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3071
+          - 'name == "rpc.server.duration"'
+    transform:
+      metric_statements:
+        - context: metric
+          statements:
+            # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-java/issues/4834
+            - set(description, "") where name == "queueSize"
+            # FIXME: remove when these 2 issues are resolved:
+            # Java: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9478
+            # Go: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4301
+            - set(description, "") where name == "rpc.server.duration"
+            # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1958
+            - set(description, "") where name == "http.client.duration"
 
 connectors:
   spanmetrics:
@@ -39,7 +48,7 @@ service:
       exporters: [logging, spanmetrics]
     metrics:
       receivers: [otlp, spanmetrics]
-      processors: [transform, batch]
+      processors: [filter/ottl, transform, batch]
       exporters: [logging]
     logs:
       receivers: [otlp]


### PR DESCRIPTION
# Changes

Adds a filter to drop the `rpc.server.duration` metric due to high cardinality on this metric in the Go SDK, which causes downstream memory problems in the collector and Prometheus. We should remove this filter definition after implementing a Metrics View for the checkout and productcatalog services, or this [PR](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/3730) on the Go SDK is merged, released, and incorporated into the demo.

Adds a transform to clear the description for the `http.client.duration` metric. This is required to eliminate errors with the Prometheus exporter in the collector. There is a [PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1959) at the Python SDK level to fix this, but that fix will take some time before it's released and incorporated into the demo.