### PR TITLE
[otelcol] Prevent overwriting of pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   ([#1121](https://github.com/open-telemetry/opentelemetry-demo/pull/1121))
 * [kafka frauddetection adservice] update java agent versions
   ([#1132](https://github.com/open-telemetry/opentelemetry-demo/pull/1132))
+* [otelcol] use forward connector to decouple pipelines
+  ([#1142](https://github.com/open-telemetry/opentelemetry-demo/pull/1142))
 
 ## 1.5.0
 

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -29,6 +29,7 @@ processors:
           - set(description, "") where name == "rpc.server.duration"
 
 connectors:
+  forward:
   spanmetrics:
 
 service:
@@ -36,12 +37,23 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, spanmetrics]
+      exporters: [spanmetrics, forward]
+    traces/logging:
+      receivers: [forward]
+      exporters: [logging]
+
     metrics:
       receivers: [otlp, spanmetrics]
       processors: [transform, batch]
+      exporters: [forward]
+    metrics/logging:
+      receivers: [forward]
       exporters: [logging]
+
     logs:
       receivers: [otlp]
       processors: [batch]
+      exporters: [forward]
+    logs/logging:
+      receivers: [forward]
       exporters: [logging]

--- a/src/otelcollector/otelcol-observability.yml
+++ b/src/otelcollector/otelcol-observability.yml
@@ -15,7 +15,9 @@ exporters:
 
 service:
   pipelines:
-    traces:
-      exporters: [otlp, logging, spanmetrics]
-    metrics:
-      exporters: [prometheus, logging]
+    traces/observability:
+      receivers: [forward]
+      exporters: [otlp]
+    metrics/observability:
+      receivers: [forward]
+      exporters: [prometheus]


### PR DESCRIPTION
# Changes

Currently, some elements of the pipelines defined in `otelcol-config.yml` are clobbered by conflicting definitions in `otelcol-observability.yml`. Specifically, the exporters list in the `traces` and `metrics` pipelines. 
```yaml
# in otelcol-config.yml
pipelines:
  traces:
    ...
    exporters: [logging, spanmetrics] # blown away by list in otelcol-observability.yml
  metrics: 
    ...
    exporters: [logging]              # blown away by list in otelcol-observability.yml
```

```yaml
# in otelcol-observability.yml
pipelines:
  traces:
    exporters: [otlp, logging, spanmetrics] # blows away list in otelcol-config.yml
  metrics:
    exporters: [prometheus, logging]        # blows away list in otelcol-config.yml
```

Since we expect users to customize the configuration in many cases, I see the following issues:

1. If a user adds an exporter directly to one of the lists in `otelcol-config.yml`, it has no effect. There's no error or obvious way to detect this - it's just silently ignored.
2. The two exporter lists in `otelcol-config.yml` are effectively ignored so they _could_ be deleted. However, this would mean that it is not a valid config file on its own. i.e. A user who excludes `otelcol-observability.yml` may be surprised to find that this breaks the service.

The solution I'm proposing uses the `forward` connector to _mostly_ decouple the two files.
- Each pipeline in `otelcol-config.yml` is split into two, connected by the `forward` connector. One pipeline receives and processes data. The other exports. The functionality is the same, but the pipelines are no long clobbered _and_ its possible to exclude `otelcol-observability.yml`.
- The pipelines in `otelcol-observability.yml` are separated from those in `otelcol-config.yml`. Instead, they receive data from `forward` connector. This allows any additional components to be added to pipelines in either file without conflicts.

The downside of this approach is that it increases the apparent complexity of the configuration. This may be a barrier to entry for some users, even if it is less error prone.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
