### PR TITLE
(chore) update dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   ([#1121](https://github.com/open-telemetry/opentelemetry-demo/pull/1121))
 * [kafka frauddetection adservice] update java agent versions
   ([#1132](https://github.com/open-telemetry/opentelemetry-demo/pull/1132))
+* update dependent components to latest versions
+  ([#1146](https://github.com/open-telemetry/opentelemetry-demo/pull/1146))
 
 ## 1.5.0
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ install-tools: $(MISSPELL)
 	npm install
 	@echo "All tools installed"
 
+.PHONY: build
+build:
+	docker compose build
+
 .PHONY: build-and-push-dockerhub
 build-and-push-dockerhub:
 	docker compose --env-file .dockerhub.env -f docker-compose.yml build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -611,7 +611,7 @@ services:
     container_name: jaeger
     command:
       - "--memory.max-traces"
-      - "10000"
+      - "8000"
       - "--query.base-path"
       - "/jaeger/ui"
       - "--prometheus.server-url"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -539,7 +539,7 @@ services:
   # ******************
   # Postgres used by Feature Flag service
   ffs_postgres:
-    image: postgres:14
+    image: postgres:16.0
     container_name: postgres
     user: postgres
     deploy:
@@ -589,7 +589,7 @@ services:
 
   # Redis used by Cart service
   redis-cart:
-    image: redis:alpine
+    image: redis:7.2-alpine
     container_name: redis-cart
     user: redis
     deploy:
@@ -607,7 +607,7 @@ services:
   # ********************
   # Jaeger
   jaeger:
-    image: jaegertracing/all-in-one:1.48.0
+    image: jaegertracing/all-in-one:1.49
     container_name: jaeger
     command:
       - "--memory.max-traces"
@@ -631,7 +631,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:10.1.0
+    image: grafana/grafana:10.1.2
     container_name: grafana
     deploy:
       resources:
@@ -646,7 +646,7 @@ services:
 
   # OpenTelemetry Collector
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.84.0
+    image: otel/opentelemetry-collector-contrib:0.86.0
     container_name: otel-col
     deploy:
       resources:
@@ -669,7 +669,7 @@ services:
 
   # Prometheus
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.46.0
+    image: quay.io/prometheus/prometheus:v2.47.0
     container_name: prometheus
     command:
       - --web.console.templates=/etc/prometheus/consoles
@@ -798,7 +798,7 @@ services:
         condition: service_started
 
   tracetest-server:
-    image: kubeshop/tracetest:latest
+    image: kubeshop/tracetest:v0.13.10
     platform: linux/amd64
     container_name: tracetest-server
     profiles:
@@ -827,7 +827,7 @@ services:
       retries: 60
 
   tracetest-postgres:
-    image: postgres:14
+    image: postgres:16.0
     container_name: tracetest-postgres
     profiles:
       - tests

--- a/src/frontendproxy/Dockerfile
+++ b/src/frontendproxy/Dockerfile
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM envoyproxy/envoy-dev:8c202194ac6a2cb781eb6ce27d924b379b1e787f
-RUN apt-get update && apt-get install -y gettext-base && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM envoyproxy/envoy:v1.27-latest
 
 USER envoy
 WORKDIR /home/envoy

--- a/src/frontendproxy/Dockerfile
+++ b/src/frontendproxy/Dockerfile
@@ -3,6 +3,7 @@
 
 
 FROM envoyproxy/envoy:v1.27-latest
+RUN apt-get update && apt-get install -y gettext-base && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER envoy
 WORKDIR /home/envoy

--- a/src/kafka/Dockerfile
+++ b/src/kafka/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM confluentinc/cp-kafka:latest-ubi8
+FROM confluentinc/cp-kafka:7.5.0
 
 USER root
 ARG version=1.30.0


### PR DESCRIPTION
# Changes

Updates version for all dependent components:

- postgres
- kafka
- redis
- grafana
- jaeger
- prometheus
- opentelemetry-collector
- envoy

Where possible, I locked to minor versions instead of patch versions. The alpine variant is used for redis because it significantly reduces container size, but not for other components.

While doing all this, I found myself wanting a `make build` target, which is also included in this PR.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
