### PR TITLE
(prometheus) Add OTLP write support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
   ([#1132](https://github.com/open-telemetry/opentelemetry-demo/pull/1132))
 * update dependent components to latest versions
   ([#1146](https://github.com/open-telemetry/opentelemetry-demo/pull/1146))
+* [prometheus] Enabled support for the OTLP write receiver
+  ([#1149](https://github.com/open-telemetry/opentelemetry-demo/pull/1149))
 
 ## 1.5.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -616,6 +616,7 @@ services:
       - "/jaeger/ui"
       - "--prometheus.server-url"
       - "http://${PROMETHEUS_ADDR}"
+      - "--prometheus.query.support-spanmetrics-connector=true"
     deploy:
       resources:
         limits:
@@ -680,6 +681,7 @@ services:
       - --web.enable-lifecycle
       - --web.route-prefix=/
       - --enable-feature=exemplar-storage
+      - --enable-feature=otlp-write-receiver
     volumes:
       - ./src/prometheus/prometheus-config.yaml:/etc/prometheus/prometheus-config.yaml
     deploy:

--- a/src/otelcollector/otelcol-observability.yml
+++ b/src/otelcollector/otelcol-observability.yml
@@ -7,15 +7,14 @@ exporters:
     endpoint: "jaeger:4317"
     tls:
       insecure: true
-  prometheus:
-    endpoint: "otelcol:9464"
-    resource_to_telemetry_conversion:
-      enabled: true
-    enable_open_metrics: true
+  otlphttp/prometheus:
+    endpoint: "http://prometheus:9090/api/v1/otlp"
+    tls:
+      insecure: true
 
 service:
   pipelines:
     traces:
       exporters: [otlp, logging, spanmetrics]
     metrics:
-      exporters: [prometheus, logging]
+      exporters: [otlphttp/prometheus, logging]


### PR DESCRIPTION
# Changes

Fixes #1143 

Prometheus now supports push with the OpenTelemetry Protocol OTLP. This PR enables that supports and moves away from the `prometheus` exporter in favor of the `otlphttp` for metrics export to Prometheus.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]
