### PR TITLE
add httpcheck receiver example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -667,6 +667,8 @@ services:
     depends_on:
       - jaeger
     logging: *logging
+    environment:
+      - ENVOY_PORT
 
   # Prometheus
   prometheus:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -11,6 +11,9 @@ receivers:
           allowed_origins:
             - "http://*"
             - "https://*"
+  httpcheck/frontendproxy:
+    targets:
+      - endpoint: http://frontendproxy:${env:ENVOY_PORT}
 
 exporters:
   logging:
@@ -43,7 +46,7 @@ service:
       processors: [batch]
       exporters: [logging, spanmetrics]
     metrics:
-      receivers: [otlp, spanmetrics]
+      receivers: [httpcheck/frontendproxy, otlp, spanmetrics]
       processors: [filter/ottl, transform, batch]
       exporters: [logging]
     logs:


### PR DESCRIPTION
# Changes

This PR adds the httpcheck receiver to the demo to produce a synthetic check against the frontendproxy endpoint.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
