### PR TITLE
ci: migrate Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,114 +1,98 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+
   "schedule": "every weekend",
+
+  // double PR and branch limits
+  prConcurrentLimit: 20,
+  branchConcurrentLimit: 20,
+  labels: ['dependencies'],
+
+  // put by default dependency update all in one group
+  groupName: "config-no-service",
+
+  "assigneesFromCodeOwners": true,
+
   "packageRules": [
     {
-      "matchPaths": ["*"],
-      "ignorePaths": ["src/"],
-      "groupName": "config-no-service"
-    },
-    { 
-      "matchPaths": ["src/accountingservice"],
+      "matchFileNames": ["src/accountingservice/**"],
       "groupName": "accountingservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/adservice"],
+    {
+      "matchFileNames": ["src/adservice/**"],
       "groupName": "adservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/cartservice"],
+    {
+      "matchFileNames": ["src/cartservice/**"],
       "groupName": "cartservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/checkoutservice"],
+    {
+      "matchFileNames": ["src/checkoutservice/**"],
       "groupName": "checkoutservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/currencyservice"],
+    {
+      "matchFileNames": ["src/currencyservice/**"],
       "groupName": "currencyservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/emailservice"],
+    {
+      "matchFileNames": ["src/emailservice/**"],
       "groupName": "emailservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/featureflagservice"],
+    {
+      "matchFileNames": ["src/featureflagservice/**"],
       "groupName": "featureflagservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/frauddetectionservice"],
+    {
+      "matchFileNames": ["src/frauddetectionservice/**"],
       "groupName": "frauddetectionservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/frontend"],
+    {
+      "matchFileNames": ["src/frontend/**"],
       "groupName": "frontend",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/frontendproxy"],
+    {
+      "matchFileNames": ["src/frontendproxy/**"],
       "groupName": "frontendproxy",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/grafana"],
+    {
+      "matchFileNames": ["src/grafana/**"],
       "groupName": "grafana",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/kakfa"],
-      "groupName": "kakfa",
-      "assigneesFromCodeOwners": true
+    {
+      "matchFileNames": ["src/kafka/**"],
+      "groupName": "kafka",
     },
-    { 
-      "matchPaths": ["src/loadgenerator"],
+    {
+      "matchFileNames": ["src/loadgenerator/**"],
       "groupName": "loadgenerator",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/otelcollector"],
+    {
+      "matchFileNames": ["src/otelcollector/**"],
       "groupName": "otelcollector",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/paymentservice"],
+    {
+      "matchFileNames": ["src/paymentservice/**"],
       "groupName": "paymentservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/productcatalogservice"],
+    {
+      "matchFileNames": ["src/productcatalogservice/**"],
       "groupName": "productcatalogservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/prometheus"],
+    {
+      "matchFileNames": ["src/prometheus/**"],
       "groupName": "prometheus",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/quoteservice"],
+    {
+      "matchFileNames": ["src/quoteservice/**"],
       "groupName": "quoteservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/recommendationservice"],
+    {
+      "matchFileNames": ["src/recommendationservice/**"],
       "groupName": "recommendationservice",
-      "assigneesFromCodeOwners": true
     },
-    { 
-      "matchPaths": ["src/shippingservice"],
+    {
+      "matchFileNames": ["src/shippingservice/**"],
       "groupName": "shippingservice",
-      "assigneesFromCodeOwners": true
     },
     {
       // intentionally using Java 11 in some examples


### PR DESCRIPTION
# Changes
Made some adaptions to the Renovate config:

- migrate packageRules away from removed options, to allow again grouping of services
- increase PR limit from 10 (default) to 20
- add PR label ( `dependencies` )
- do not extend base to prevent grouping by monorepos 

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
