### PR TITLE
use Phoenix 1.6 style

### DIFF
--- a/src/featureflagservice/lib/featureflagservice_web.ex
+++ b/src/featureflagservice/lib/featureflagservice_web.ex
@@ -37,6 +37,8 @@ defmodule FeatureflagserviceWeb do
         root: "lib/featureflagservice_web/templates",
         namespace: FeatureflagserviceWeb
 
+      # Import moved helpers
+      use Phoenix.Component
       # Import convenience functions from controllers
       import Phoenix.Controller,
         only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]

--- a/src/featureflagservice/lib/featureflagservice_web/templates/feature_flag/form.html.heex
+++ b/src/featureflagservice/lib/featureflagservice_web/templates/feature_flag/form.html.heex
@@ -14,7 +14,7 @@
   limitations under the License.
 --%>
 
-<.form let={f} for={@changeset} action={@action}>
+<.form :let={f} for={@changeset} action={@action}>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>

--- a/src/featureflagservice/lib/featureflagservice_web/templates/layout/app.html.heex
+++ b/src/featureflagservice/lib/featureflagservice_web/templates/layout/app.html.heex
@@ -15,7 +15,7 @@
 --%>
 
 <main class="container">
-  <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+  <p class="alert alert-info" role="alert"><%= Phoenix.Flash.get(@flash, :info) %></p>
+  <p class="alert alert-danger" role="alert"><%= Phoenix.Flash.get(@flash, :error) %></p>
   <%= @inner_content %>
 </main>

--- a/src/featureflagservice/lib/featureflagservice_web/templates/layout/root.html.heex
+++ b/src/featureflagservice/lib/featureflagservice_web/templates/layout/root.html.heex
@@ -21,7 +21,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="csrf-token" content={csrf_token_value()}>
-    <%= live_title_tag assigns[:page_title] || "Feature flag service" %>
+    <.live_title>
+      <%= assigns[:page_title] || "Feature flag service" %>
+    </.live_title>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>

--- a/src/featureflagservice/mix.exs
+++ b/src/featureflagservice/mix.exs
@@ -49,6 +49,7 @@ defmodule Featureflagservice.MixProject do
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:phoenix_live_view, "~> 0.20.0"},
+      {:phoenix_view, "~> 2.0"},
       {:floki, "~> 0.35.0", only: :test},
       {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
       {:telemetry_metrics, "~> 0.6"},


### PR DESCRIPTION
Phoenix 1.7 has deprecated Phoenix.View in favor
of Phoenix.Component and moved the get_flash
function out of controllers, making us call it
directly

This is an addendum to #1224 
