### PR TITLE
chore: add env var for pinning trace-based test tool version

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@
 # Images
 IMAGE_VERSION=1.6.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
+TRACETEST_IMAGE_VERSION=v0.14.5
 
 # Demo Platform
 ENV_PLATFORM=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release.
 
 ## Unreleased
 
+* add env var for pinning trace-based test tool version
+  ([#1239](https://github.com/open-telemetry/opentelemetry-demo/pull/1239))
 * update PHP quoteservice to use 1.0.0
   ([#1236](https://github.com/open-telemetry/opentelemetry-demo/pull/1236))
 

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,18 @@ start-minimal:
 	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
 	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
 
+.PHONY: start-odd
+start-odd: # Observabilty-Driven Development (ODD)
+	docker compose --profile odd up --force-recreate --remove-orphans --detach
+	@echo ""
+	@echo "OpenTelemetry Demo is running."
+	@echo "Go to http://localhost:8080 for the demo UI."
+	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
+	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
+	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
+	@echo "Go to http://localhost:8080/feature/ for the Feature Flag UI."
+	@echo "Go to http://localhost:11633/ for the Tracetest Web UI."
+
 .PHONY: stop
 stop:
 	docker compose down --remove-orphans --volumes

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,9 @@ start-minimal:
 	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
 	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
 
+# Observabilty-Driven Development (ODD)
 .PHONY: start-odd
-start-odd: # Observabilty-Driven Development (ODD)
+start-odd:
 	docker compose --profile odd up --force-recreate --remove-orphans --detach
 	@echo ""
 	@echo "OpenTelemetry Demo is running."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -837,6 +837,7 @@ services:
     container_name: tracetest-server
     profiles:
       - tests
+      - odd # Observabilty-Driven Development (ODD)
     volumes:
       - type: bind
         source: ./test/tracetesting/tracetest-config.yaml
@@ -865,6 +866,7 @@ services:
     container_name: tracetest-postgres
     profiles:
       - tests
+      - odd # Observabilty-Driven Development (ODD)
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -832,7 +832,7 @@ services:
         condition: service_started
 
   tracetest-server:
-    image: kubeshop/tracetest:v0.14.5
+    image: kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
     platform: linux/amd64
     container_name: tracetest-server
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -837,7 +837,7 @@ services:
     container_name: tracetest-server
     profiles:
       - tests
-      - odd # Observabilty-Driven Development (ODD)
+      - odd          # Observabilty-Driven Development (ODD)
     volumes:
       - type: bind
         source: ./test/tracetesting/tracetest-config.yaml
@@ -866,7 +866,7 @@ services:
     container_name: tracetest-postgres
     profiles:
       - tests
-      - odd # Observabilty-Driven Development (ODD)
+      - odd          # Observabilty-Driven Development (ODD)
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/test/tracetesting/Dockerfile
+++ b/test/tracetesting/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine
 WORKDIR /app
 
 RUN apk --update add bash jq curl
-RUN curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- v0.13.10
+RUN curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- ${TRACETEST_IMAGE_VERSION}
 
 WORKDIR /app/test/tracetesting
 


### PR DESCRIPTION
# Changes

Added an env var to make sure the same image version is used for the trace-based test tool. Currently the image version pin in the `tracetesting/Dockerfile` differs from the image version pin in the `docker-compose.yaml`.

Updated docs in this PR: https://github.com/open-telemetry/opentelemetry.io/pull/3526

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
