### PR TITLE
Shippingservice: update release image to match builder

### DIFF
--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -44,7 +44,7 @@ ENV GRPC_HEALTH_PROBE_VERSION=v0.4.18
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
     chmod +x /bin/grpc_health_probe
 
-FROM debian:bullseye-slim as release
+FROM debian:bookworm-slim as release
 
 WORKDIR /app
 COPY --from=builder /app/target/release/shippingservice /app/shippingservice


### PR DESCRIPTION
fixes #1240

Updated builder image `rust:1.73` is now based on debian bookworm ([dockerhub link](https://hub.docker.com/layers/library/rust/1.73/images/sha256-e5a28b9e772535dc50205b4684b4e1cd113bb52e02e54ff387015c55c561e477?context=explore)). The fix matches the release image accordingly.