### PR TITLE
[cartservice] Update to .NET8

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -38,18 +38,23 @@ jobs:
           - file: ./src/adservice/Dockerfile
             tag_suffix: adservice
             context: ./
+            setup-qemu: true
           - file: ./src/cartservice/src/Dockerfile
             tag_suffix: cartservice
             context: ./
+            setup-qemu: false
           - file: ./src/checkoutservice/Dockerfile
             tag_suffix: checkoutservice
             context: ./
+            setup-qemu: true
           - file: ./src/currencyservice/Dockerfile
             tag_suffix: currencyservice
             context: ./src/currencyservice
+            setup-qemu: true
           - file: ./src/emailservice/Dockerfile
             tag_suffix: emailservice
             context: ./src/emailservice
+            setup-qemu: true
           # NOTE:
           # https://github.com/open-telemetry/opentelemetry-demo/issues/956
           # Until dedicated ARM runners are available for GHA we cannot upgrade
@@ -57,45 +62,59 @@ jobs:
           - file: ./src/featureflagservice/Dockerfile
             tag_suffix: featureflagservice
             context: ./
+            setup-qemu: true
           - file: ./src/frontend/Dockerfile
             tag_suffix: frontend
             context: ./
+            setup-qemu: true
           - file: ./src/frontendproxy/Dockerfile
             tag_suffix: frontendproxy
             context: ./
+            setup-qemu: true
           - file: ./src/loadgenerator/Dockerfile
             tag_suffix: loadgenerator
             context: ./
+            setup-qemu: true
           - file: ./src/paymentservice/Dockerfile
             tag_suffix: paymentservice
             context: ./
+            setup-qemu: true
           - file: ./src/productcatalogservice/Dockerfile
             tag_suffix: productcatalogservice
             context: ./
+            setup-qemu: true
           - file: ./src/quoteservice/Dockerfile
             tag_suffix: quoteservice
             context: ./
+            setup-qemu: true
           - file: ./src/shippingservice/Dockerfile
             tag_suffix: shippingservice
             context: ./
+            setup-qemu: true
           - file: ./src/recommendationservice/Dockerfile
             tag_suffix: recommendationservice
             context: ./
+            setup-qemu: true
           - file: ./src/kafka/Dockerfile
             tag_suffix: kafka
             context: ./
+            setup-qemu: true
           - file: ./src/accountingservice/Dockerfile
             tag_suffix: accountingservice
             context: ./
+            setup-qemu: true
           - file: ./src/frauddetectionservice/Dockerfile
             tag_suffix: frauddetectionservice
             context: ./
+            setup-qemu: true
           - file: ./src/frontend/Dockerfile.cypress
             tag_suffix: frontend-tests
             context: ./
+            setup-qemu: true
           - file: ./test/Dockerfile
             tag_suffix: integrationTests
             context: ./
+            setup-qemu: true
 
     steps:
       - uses: actions/checkout@v4
@@ -131,6 +150,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ inputs.push }}
       - name: Set up QEMU
+        if: ${{ matrix.file_tag.setup-qemu }}
         uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ release.
   ([#1239](https://github.com/open-telemetry/opentelemetry-demo/pull/1239))
 * [cartservice] Add .NET memory, CPU, and thread metrics
   ([#1265](https://github.com/open-telemetry/opentelemetry-demo/pull/1265))
+* [cartservice] update .NET to .NET 8.0
+  ([#1272](https://github.com/open-telemetry/opentelemetry-demo/pull/1272))
 * enable browser traffic in loadgenerator using playwright
   ([#1266](https://github.com/open-telemetry/opentelemetry-demo/pull/1266))
 * update loadgenerator dependencies and the base image

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:7.0.403 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-1 AS builder
 
 WORKDIR /usr/src/app/
 
@@ -35,7 +35,7 @@ RUN \
 # -----------------------------------------------------------------------------
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0.4-alpine3.16
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.0-alpine3.18
 
 WORKDIR /usr/src/app/
 COPY --from=builder /cartservice/ ./

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:8.0.100-1 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.100-1 AS builder
+ARG TARGETARCH
 
 WORKDIR /usr/src/app/
 
@@ -24,12 +25,12 @@ COPY ./pb/ ./src/protos/
 
 RUN \
   RUNTIME_IDENTIIFER=linux-musl-x64; \
-  if [ "$(uname -m)" = "aarch64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
+  if [ "${TARGETARCH}" = "arm64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
   dotnet restore ./src/cartservice.csproj -v d -r $RUNTIME_IDENTIIFER
 
 RUN \
   RUNTIME_IDENTIIFER=linux-musl-x64; \
-  if [ "$(uname -m)" = "aarch64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
+  if [ "${TARGETARCH}" = "arm64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
   dotnet publish ./src/cartservice.csproj -v d -p:PublishSingleFile=true -r $RUNTIME_IDENTIIFER --self-contained true -p:PublishTrimmed=False -p:TrimMode=Link -c Release -o /cartservice --no-restore
 
 # -----------------------------------------------------------------------------

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
@@ -11,9 +11,9 @@
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.59.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
# Changes

Update cartservice to .NET8 which is new LTS release.

Replaces #1269
Fixes #1262

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* ~~[ ] Appropriate documentation updates in the [docs][]~~ N/A
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~ N/A

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
