### PR TITLE
fix: pass proper env var to tracetesting Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ release.
 
 ## Unreleased
 
-* fix env var for pinning trace-based test tool version
-  ([#1283](https://github.com/open-telemetry/opentelemetry-demo/pull/1283))
 * [currencyservice] bring back multistage build
   ([#1276](https://github.com/open-telemetry/opentelemetry-demo/pull/1276))
 * [currencyservice]: update opentelemetry-cpp to 1.12.0
@@ -25,6 +23,8 @@ release.
   ([#1266](https://github.com/open-telemetry/opentelemetry-demo/pull/1266))
 * [accountingservice] Add additional attributes to Kafka spans
   ([#1286](https://github.com/open-telemetry/opentelemetry-demo/pull/1286))
+* fix env var for pinning trace-based test tool version
+  ([#1283](https://github.com/open-telemetry/opentelemetry-demo/pull/1283))
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release.
 
 ## Unreleased
 
+* fix env var for pinning trace-based test tool version
+  ([#1283](https://github.com/open-telemetry/opentelemetry-demo/pull/1283))
 * [currencyservice] bring back multistage build
   ([#1276](https://github.com/open-telemetry/opentelemetry-demo/pull/1276))
 * [currencyservice]: update opentelemetry-cpp to 1.12.0

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -639,6 +639,8 @@ services:
     build:
       context: ./
       dockerfile: ./test/tracetesting/Dockerfile
+      args:
+        - TRACETEST_IMAGE_VERSION
     environment:
       - AD_SERVICE_ADDR
       - CART_SERVICE_ADDR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -784,6 +784,8 @@ services:
     build:
       context: ./
       dockerfile: ./test/tracetesting/Dockerfile
+      args:
+        - TRACETEST_IMAGE_VERSION
     environment:
       - AD_SERVICE_ADDR
       - CART_SERVICE_ADDR

--- a/test/tracetesting/Dockerfile
+++ b/test/tracetesting/Dockerfile
@@ -6,6 +6,8 @@ FROM alpine
 
 WORKDIR /app
 
+ARG TRACETEST_IMAGE_VERSION
+
 RUN apk --update add bash jq curl
 RUN curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- ${TRACETEST_IMAGE_VERSION}
 


### PR DESCRIPTION
# Changes

This PR fixes the CLI version in `test/tracetesting/Dockerfile` to use the env variable that was added as part of https://github.com/open-telemetry/opentelemetry-demo/pull/1239. This guarantees the use of the same image version for the tracetest server and CLI in the trace-based process. 

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
