### PR TITLE
[frontendproxy] enable envoy environment resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 * [grafana] update grafana to 10.2.3
   ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
+* [frontendproxy] Enable envoy environment resource detector
+  ([#1291](https://github.com/open-telemetry/opentelemetry-demo/pull/1291))
 
 ## 1.7.2
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -256,6 +256,7 @@ services:
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP
+      - OTEL_RESOURCE_ATTRIBUTES
       - ENVOY_PORT
     depends_on:
       frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -345,6 +345,7 @@ services:
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP
+      - OTEL_RESOURCE_ATTRIBUTES
       - ENVOY_PORT
     depends_on:
       frontend:

--- a/src/frontendproxy/Dockerfile
+++ b/src/frontendproxy/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM envoyproxy/envoy:dev-698abe98131fa5c64904082407878d1fcc62cb88
+FROM envoyproxy/envoy:v1.29.0
 RUN apt-get update && apt-get install -y gettext-base && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER envoy

--- a/src/frontendproxy/Dockerfile
+++ b/src/frontendproxy/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM envoyproxy/envoy:v1.29.0
+FROM envoyproxy/envoy:v1.29-latest
 RUN apt-get update && apt-get install -y gettext-base && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER envoy

--- a/src/frontendproxy/Dockerfile
+++ b/src/frontendproxy/Dockerfile
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-
-FROM envoyproxy/envoy:v1.28-latest
+FROM envoyproxy/envoy:dev-698abe98131fa5c64904082407878d1fcc62cb88
 RUN apt-get update && apt-get install -y gettext-base && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER envoy

--- a/src/frontendproxy/envoy.tmpl.yaml
+++ b/src/frontendproxy/envoy.tmpl.yaml
@@ -26,6 +26,10 @@ static_resources:
                           cluster_name: opentelemetry_collector_grpc
                         timeout: 0.250s
                       service_name: frontend-proxy
+                      resource_detectors:
+                        - name: envoy.tracers.opentelemetry.resource_detectors.environment
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.resource_detectors.v3.EnvironmentResourceDetectorConfig
                 route_config:
                   name: local_route
                   virtual_hosts:


### PR DESCRIPTION
# Changes

This enables the environment resource detector for the envoy opentelemetry tracer. See https://github.com/envoyproxy/envoy/pull/29547

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
