### PR TITLE
Re-add prometheus collector metric scrape

### DIFF
--- a/src/grafana/provisioning/dashboards/demo/opentelemetry-collector-data-flow.json
+++ b/src/grafana/provisioning/dashboards/demo/opentelemetry-collector-data-flow.json
@@ -1813,7 +1813,7 @@
         "type": "prometheus",
         "uid": "webstore-metrics"
       },
-      "description": "otelcol prometheus exporter 9464 export rate versus prometheus scrape metrics",
+      "description": "otelcol prometheus exporter 8888 export rate versus prometheus scrape metrics",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1882,7 +1882,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/ count_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/(5*30)) ",
+          "expr": "(sum_over_time(scrape_samples_scraped{job=\"otel-collector\"}[$__range])/ count_over_time(scrape_samples_scraped{job=\"otel-collector\"}[$__range])/(5*30)) ",
           "format": "time_series",
           "instant": false,
           "legendFormat": "__auto",
@@ -1910,7 +1910,7 @@
           "options": {
             "alias": "percent",
             "binary": {
-              "left": "{instance=\"otelcol:9464\", job=\"otel\"}",
+              "left": "{instance=\"otelcol:9464\", job=\"otel-collector\"}",
               "operator": "/",
               "reducer": "sum",
               "right": "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )"
@@ -2080,7 +2080,6 @@
             "mode": "reduceRow",
             "reduce": {
               "include": [
-                "{instance=\"otelcol:9464\", job=\"otel\"}",
                 "{instance=\"otelcol:8888\", job=\"otel-collector\"}"
               ],
               "reducer": "sum"

--- a/src/prometheus/prometheus-config.yaml
+++ b/src/prometheus/prometheus-config.yaml
@@ -1,4 +1,11 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# do not delete this file
+global:
+  evaluation_interval: 30s
+  scrape_interval: 5s
+scrape_configs:
+- job_name: otel-collector
+  static_configs:
+  - targets:
+    - 'otelcol:8888'


### PR DESCRIPTION
This fixes #1292 which was introduced by #1174 

The original PR removed the `otel-collector` scrape job from Prometheus, shutting off Collector meta-metrics. This re-introduces it and updates the collector monitoring dashboard to reference the new job.