### PR TITLE
update cpp and pin to 3.18

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine as builder
+FROM alpine:3.18 as builder
 
-RUN apk update && apk add git cmake make g++ grpc-dev protobuf-dev
+RUN apk update && apk add git cmake make g++ grpc-dev protobuf-dev linux-headers
 
-ARG OPENTELEMETRY_CPP_VERSION=1.12.0
+ARG OPENTELEMETRY_CPP_VERSION=1.13.0
 
 RUN git clone https://github.com/open-telemetry/opentelemetry-cpp \
 	  && cd opentelemetry-cpp/ \
@@ -27,7 +27,7 @@ RUN git clone https://github.com/open-telemetry/opentelemetry-cpp \
     && cd build \
     && cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
-          -DWITH_EXAMPLES=OFF -DWITH_OTLP_GRPC=ON \
+          -DWITH_EXAMPLES=OFF -DWITH_OTLP_GRPC=ON -DWITH_ABSEIL=ON \
     && make -j$(nproc || sysctl -n hw.ncpu || echo 1) install && cd ../..
 
 COPY . /currencyservice
@@ -38,7 +38,7 @@ RUN cd /currencyservice \
     && make -j$(nproc || sysctl -n hw.ncpu || echo 1) install
 
 
-FROM alpine as release
+FROM alpine:3.18 as release
 
 RUN apk update && apk add grpc-dev protobuf-dev
 COPY --from=builder /usr/local /usr/local


### PR DESCRIPTION
This PR fixes the currencyservice build failure; We also need to update some flags to handle the updated protobuf libraries.