### PR TITLE
Simplify cartservice Dockerfile

### DIFF
--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -23,15 +23,9 @@ WORKDIR /usr/src/app/
 COPY ./src/cartservice/ ./
 COPY ./pb/ ./src/protos/
 
-RUN \
-  RUNTIME_IDENTIIFER=linux-musl-x64; \
-  if [ "${TARGETARCH}" = "arm64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
-  dotnet restore ./src/cartservice.csproj -v d -r $RUNTIME_IDENTIIFER
+RUN dotnet restore ./src/cartservice.csproj -v d -r linux-musl-$TARGETARCH
 
-RUN \
-  RUNTIME_IDENTIIFER=linux-musl-x64; \
-  if [ "${TARGETARCH}" = "arm64" ]; then RUNTIME_IDENTIIFER=linux-musl-arm64; fi; \
-  dotnet publish ./src/cartservice.csproj -v d -p:PublishSingleFile=true -r $RUNTIME_IDENTIIFER --self-contained true -p:PublishTrimmed=False -p:TrimMode=Link -c Release -o /cartservice --no-restore
+RUN dotnet publish ./src/cartservice.csproj -v d -r linux-musl-$TARGETARCH --no-restore -o /cartservice
 
 # -----------------------------------------------------------------------------
 

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A number of simplifications to the cartservice Dockerfile.

1. Per https://github.com/dotnet/dotnet-docker/pull/4742, it is an anti-pattern to use msbuild properties in a Dockerfile. The properties are now set in the csproj file. 
3. Removed `-c Release` from `dotnet publish` command. As mentioned in [this blog post](https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/) it is now the default.
4. Simplified determining the runtime identifier. The `-r` switch now translates `linux-musl-amd64` to `linux-musl-x64` under the covers. See https://github.com/dotnet/sdk/issues/30369.