### PR TITLE
[chore] - revert grafana to 10.2.0

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -485,7 +485,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:10.2.2
+    image: grafana/grafana:10.2.0
     container_name: grafana
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -629,7 +629,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:10.2.2
+    image: grafana/grafana:10.2.0
     container_name: grafana
     deploy:
       resources:


### PR DESCRIPTION
Fixed #1309 

Reverts the version of Grafana back to 10.2.0. Seems like the latest version has an issue starting up with our config.