### PR TITLE
[currency] - fix metricreader export and temporality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 * [grafana] update grafana to 10.2.3
   ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
+* [currency] fix metric exporter options
+  ([#1335](https://github.com/open-telemetry/opentelemetry-demo/pull/1335))
 
 ## 1.7.2
 

--- a/src/currencyservice/src/meter_common.h
+++ b/src/currencyservice/src/meter_common.h
@@ -24,15 +24,14 @@ namespace
   {
     // Build MetricExporter
     otlp_exporter::OtlpGrpcMetricExporterOptions otlpOptions;
-
     // Configuration via environment variable not supported yet
-    otlpOptions.aggregation_temporality = otlp_exporter::PreferredAggregationTemporality::kDelta;
+    //otlpOptions.aggregation_temporality = otlp_exporter::PreferredAggregationTemporality::kCumulative;
     auto exporter = otlp_exporter::OtlpGrpcMetricExporterFactory::Create(otlpOptions);
 
     // Build MeterProvider and Reader
     metric_sdk::PeriodicExportingMetricReaderOptions options;
-    options.export_interval_millis = std::chrono::milliseconds(1000);
-    options.export_timeout_millis = std::chrono::milliseconds(500);
+    //options.export_interval_millis = std::chrono::milliseconds(60000);
+    //options.export_timeout_millis = std::chrono::milliseconds(30000);
     std::unique_ptr<metric_sdk::MetricReader> reader{
         new metric_sdk::PeriodicExportingMetricReader(std::move(exporter), options) };
     auto provider = std::shared_ptr<metrics_api::MeterProvider>(new metric_sdk::MeterProvider());


### PR DESCRIPTION
# Changes

Fixes #1330

Sets the OTLP metric export temporality to be cumulative (default), similar to other services. Sets the MetricReader to export every 60 seconds (default), similar to other services. 

I left the lines of code to change the options in as comments set to their default values, so other users can see what the options objects are used for.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
