### PR TITLE
[chore] - use GitHub markdown syntax in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ GitHub pull requests (PRs).
 
 To create a new PR, fork the project in GitHub and clone the upstream repo:
 
-> **Note**
+> [!NOTE]
 > Please fork to a personal GitHub account rather than a corporate/enterprise
 > one so maintainers can push commits to your branch.
 > **Pull requests from protected forks will not be accepted.**

--- a/src/accountingservice/README.md
+++ b/src/accountingservice/README.md
@@ -20,7 +20,7 @@ docker compose build accountingservice
 
 ## Regenerate protos
 
-> **Note**
+> [!NOTE]
 > [`protoc`](https://grpc.io/docs/protoc-installation/) is required.
 
 To regenerate gRPC code run:

--- a/src/checkoutservice/README.md
+++ b/src/checkoutservice/README.md
@@ -20,7 +20,7 @@ docker compose build checkoutservice
 
 ## Regenerate protos
 
-> **Note**
+> [!NOTE]
 > [`protoc`](https://grpc.io/docs/protoc-installation/) is required.
 
 To regenerate gRPC code run:

--- a/src/productcatalogservice/README.md
+++ b/src/productcatalogservice/README.md
@@ -25,7 +25,7 @@ docker compose build productcatalogservice
 
 ## Regenerate protos
 
-> **Note**
+> [!NOTE]
 > [`protoc`](https://grpc.io/docs/protoc-installation/) is required.
 
 To regenerate gRPC code run:


### PR DESCRIPTION
# Changes

Uses the proper GitHub Markdown syntax to indicate notes, warnings, etc.

```
> [!NOTE]
> my note
```

This is the before and after for the change.

before:
![Screenshot 2024-01-18 at 11 39 21 PM](https://github.com/open-telemetry/opentelemetry-demo/assets/1296118/1b7ec2c0-c73e-4409-9a24-16d29d71d4f1)

after:
![Screenshot 2024-01-18 at 11 40 24 PM](https://github.com/open-telemetry/opentelemetry-demo/assets/1296118/fc33c8d5-3165-4735-9964-c33ea9c6e4a0)



