### PR TITLE
Update wiki url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ release.
   ([#1335](https://github.com/open-telemetry/opentelemetry-demo/pull/1335))
 * [ffspostgres] define and use demo specific postgres image
   ([#1338](https://github.com/open-telemetry/opentelemetry-demo/pull/1338))
+* [accountingservice] update wiki link
+  ([#1346](https://github.com/open-telemetry/opentelemetry-demo/pull/1346))
+* [checkoutservice] update wiki link
+  ([#1346](https://github.com/open-telemetry/opentelemetry-demo/pull/1346))
+* [productcatalogservice] update wiki link
+  ([#1346](https://github.com/open-telemetry/opentelemetry-demo/pull/1346))
 
 ## 1.7.2
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,7 +6,7 @@
 package tools
 
 // This file follows the recommendation at
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // on how to pin tooling dependencies to a go.mod file.
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 

--- a/src/accountingservice/tools.go
+++ b/src/accountingservice/tools.go
@@ -7,7 +7,7 @@
 package tools
 
 // This file follows the recommendation at
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // on how to pin tooling dependencies to a go.mod file.
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 

--- a/src/checkoutservice/tools.go
+++ b/src/checkoutservice/tools.go
@@ -7,7 +7,7 @@
 package tools
 
 // This file follows the recommendation at
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // on how to pin tooling dependencies to a go.mod file.
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 

--- a/src/productcatalogservice/tools.go
+++ b/src/productcatalogservice/tools.go
@@ -7,7 +7,7 @@
 package tools
 
 // This file follows the recommendation at
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // on how to pin tooling dependencies to a go.mod file.
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 


### PR DESCRIPTION
# Changes

This pull request updates the URLs for the Go wiki, which has been moved from GitHub Wiki to go.dev. The previous URLs were broken due to this relocation.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] ~Appropriate documentation updates in the [docs][]~ (no changes?)
* [ ] ~Appropriate Helm chart updates in the [helm-charts][]~ (no changes?)

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
