### PR TITLE
Remove container name to enable scaling in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -362,7 +362,6 @@ services:
   # Load Generator
   loadgenerator:
     image: ${IMAGE_NAME}:${IMAGE_VERSION}-loadgenerator
-    container_name: load-generator
     build:
       context: ./
       dockerfile: ./src/loadgenerator/Dockerfile


### PR DESCRIPTION
# Changes

Services with fixed container names can not be scaled in docker compose.

This change removes the container name so the container can be scaled like this:

```sh
docker-compose up -d --scale loadgenerator=3
```


Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
