### PR TITLE
Fix crashlooping for two services with insufficient privileges on opentelemetry-javaagent.jar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ content of "Unreleased" section content will generate release notes for the
 release.
 
 ## Unreleased
-* [adservice] added group and anonymous read permission to opentelemetry-javaagent.jar
-  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
-* [frauddetectionservice] added group and anonymous read permission to opentelemetry-javaagent.jar
-  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
+
 * [grafana] update grafana to 10.2.3
   ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
 * [frontendproxy] Enable envoy environment resource detector
@@ -26,6 +23,10 @@ release.
   ([#1346](https://github.com/open-telemetry/opentelemetry-demo/pull/1346))
 * [productcatalogservice] update wiki link
   ([#1346](https://github.com/open-telemetry/opentelemetry-demo/pull/1346))
+* [adservice] added group and anonymous read permission to opentelemetry-javaagent.jar
+  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
+* [frauddetectionservice] added group and anonymous read permission to opentelemetry-javaagent.jar
+  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
 
 ## 1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ content of "Unreleased" section content will generate release notes for the
 release.
 
 ## Unreleased
-
+* [adservice] added group and anonymous read permission to opentelemetry-javaagent.jar
+  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
+* [frauddetectionservice] added group and anonymous read permission to opentelemetry-javaagent.jar
+  ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
 * [grafana] update grafana to 10.2.3
   ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
 * [frontendproxy] Enable envoy environment resource detector

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -24,7 +24,7 @@ ARG version=1.31.0
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/ ./
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /usr/src/app/opentelemetry-javaagent.jar
+ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /usr/src/app/opentelemetry-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
 
 EXPOSE ${AD_SERVICE_PORT}

--- a/src/frauddetectionservice/Dockerfile
+++ b/src/frauddetectionservice/Dockerfile
@@ -18,7 +18,7 @@ ARG version=1.31.0
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/build/libs/frauddetectionservice-1.0-all.jar ./
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
+ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
 
 ENTRYPOINT [ "java", "-jar", "frauddetectionservice-1.0-all.jar" ]


### PR DESCRIPTION
# Changes

Changed file access permission (chmod 644 instead of the default 600) for opentelemetry-javaagent.jar as it gets copied into the docker image for services adservice and frauddetectionservice.

This is done for the case where the containers are executed in a secure environment that has `runAsRoot: false` enforced.  In such cases, the user `nobody` didn't even have read access to the mentioned jar, causing crashlooping for the two mentioned services.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* ~Appropriate documentation updates in the [docs][]~
* ~Appropriate Helm chart updates in the [helm-charts][]~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
