### PR TITLE
Update dependent services - Collector, Grafana, Jaeger, Prometheus, etc.

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,20 @@
 
 
-# Images
+# Demo App version
 IMAGE_VERSION=1.7.2
 IMAGE_NAME=ghcr.io/open-telemetry/demo
+
+# Dependent images
+COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.93.0
+DATAPREPPER_IMAGE=opensearchproject/data-prepper:latest
+GRAFANA_IMAGE=grafana/grafana:10.3.1
+JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.53
+OPENSEARCH_IMAGE=opensearchproject/opensearch:latest
+POSTGRES_IMAGE=postgres:16.1
+PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v2.49.1
+REDIS_IMAGE=redis:7.2-alpine
 TRACETEST_IMAGE_VERSION=v0.14.5
+TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
 
 # Demo Platform
 ENV_PLATFORM=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ release.
   ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
 * [frauddetectionservice] added group and anonymous read permission to opentelemetry-javaagent.jar
   ([#1348](https://github.com/open-telemetry/opentelemetry-demo/pull/1348))
+* Update dependent services - Collector, Grafana, Jaeger, Prometheus, etc.
+  ([#1354](https://github.com/open-telemetry/opentelemetry-demo/pull/1354))
 
 ## 1.7.2
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -446,7 +446,7 @@ services:
   # ******************
   # Redis used by Cart service
   redis-cart:
-    image: redis:7.2-alpine
+    image: ${REDIS_IMAGE}
     container_name: redis-cart
     user: redis
     deploy:
@@ -464,7 +464,7 @@ services:
   # ********************
   # Jaeger
   jaeger:
-    image: jaegertracing/all-in-one:1.52
+    image: ${JAEGERTRACING_IMAGE}
     container_name: jaeger
     command:
       - "--memory.max-traces=8000"
@@ -486,7 +486,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:10.2.0
+    image: ${GRAFANA_IMAGE}
     container_name: grafana
     deploy:
       resources:
@@ -503,7 +503,7 @@ services:
 
   # OpenTelemetry Collector
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.91.0
+    image: ${COLLECTOR_CONTRIB_IMAGE}
     container_name: otel-col
     deploy:
       resources:
@@ -525,7 +525,7 @@ services:
 
   # Prometheus
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.48.1
+    image: ${PROMETHEUS_IMAGE}
     container_name: prometheus
     command:
       - --web.console.templates=/etc/prometheus/consoles
@@ -548,7 +548,7 @@ services:
     logging: *logging
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: ${OPENSEARCH_IMAGE}
     container_name: opensearch
     environment:
       - cluster.name=demo-cluster
@@ -570,7 +570,7 @@ services:
     logging: *logging
 
   dataprepper:
-    image: opensearchproject/data-prepper:latest
+    image: ${DATAPREPPER_IMAGE}
     volumes:
       - ./src/opensearch/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
       - ./src/opensearch/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -599,7 +599,7 @@ services:
 
   # Redis used by Cart service
   redis-cart:
-    image: redis:7.2-alpine
+    image: ${REDIS_IMAGE}
     container_name: redis-cart
     user: redis
     deploy:
@@ -617,7 +617,7 @@ services:
   # ********************
   # Jaeger
   jaeger:
-    image: jaegertracing/all-in-one:1.52
+    image: ${JAEGERTRACING_IMAGE}
     container_name: jaeger
     command:
       - "--memory.max-traces=8000"
@@ -639,7 +639,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:10.2.3
+    image: ${GRAFANA_IMAGE}
     container_name: grafana
     deploy:
       resources:
@@ -656,7 +656,7 @@ services:
 
   # OpenTelemetry Collector
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.91.0
+    image: ${COLLECTOR_CONTRIB_IMAGE}
     container_name: otel-col
     deploy:
       resources:
@@ -678,7 +678,7 @@ services:
 
   # Prometheus
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.48.1
+    image: ${PROMETHEUS_IMAGE}
     container_name: prometheus
     command:
       - --web.console.templates=/etc/prometheus/consoles
@@ -701,7 +701,7 @@ services:
     logging: *logging
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: ${OPENSEARCH_IMAGE}
     container_name: opensearch
     environment:
       - cluster.name=demo-cluster
@@ -723,7 +723,7 @@ services:
     logging: *logging
 
   dataprepper:
-    image: opensearchproject/data-prepper:latest
+    image: ${DATAPREPPER_IMAGE}
     volumes:
       - ./src/opensearch/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
       - ./src/opensearch/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
@@ -844,7 +844,7 @@ services:
         condition: service_started
 
   tracetest-server:
-    image: kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
+    image: ${TRACETEST_IMAGE}
     platform: linux/amd64
     container_name: tracetest-server
     profiles:
@@ -874,7 +874,7 @@ services:
       retries: 60
 
   tracetest-postgres:
-    image: postgres:16.0
+    image: ${POSTGRES_IMAGE}
     container_name: tracetest-postgres
     profiles:
       - tests


### PR DESCRIPTION
# Changes

Update dependent services - Collector, Grafana, Jaeger, Prometheus, etc.

Move those external service image paths and versions to `.env` file to make it easier to update them for multiple docker compose files.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
