### PR TITLE
refactor(productcatalogservice): use `//go:embed` directive for products.json

### DIFF
--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -17,7 +17,6 @@ FROM alpine AS release
 
 WORKDIR /usr/src/app/
 
-COPY ./src/productcatalogservice/products.json ./
 COPY --from=builder /go/bin/productcatalogservice/ ./
 
 EXPOSE ${PRODUCT_SERVICE_PORT}

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -8,9 +8,9 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -49,6 +49,9 @@ var (
 	resource          *sdkresource.Resource
 	initResourcesOnce sync.Once
 )
+
+//go:embed products.json
+var products []byte
 
 func init() {
 	log = logrus.New()
@@ -157,13 +160,8 @@ type productCatalog struct {
 }
 
 func readCatalogFile() []*pb.Product {
-	catalogJSON, err := ioutil.ReadFile("products.json")
-	if err != nil {
-		log.Fatalf("Reading Catalog File: %v", err)
-	}
-
 	var res pb.ListProductsResponse
-	if err := protojson.Unmarshal(catalogJSON, &res); err != nil {
+	if err := protojson.Unmarshal(products, &res); err != nil {
 		log.Fatalf("Parsing Catalog JSON: %v", err)
 	}
 


### PR DESCRIPTION
# Changes

- Apply `//go:embed` directive to store the products.json data, by doing this we don't need to COPY the json file into container image.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
