### PR TITLE
Cache playwright browsers outside root home

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -18,5 +18,6 @@ COPY --from=builder /reqs /usr/local
 COPY ./src/loadgenerator/locustfile.py .
 COPY ./src/loadgenerator/people.json .
 ENV LOCUST_PLAYWRIGHT=1
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install --with-deps chromium
 ENTRYPOINT locust


### PR DESCRIPTION
This allows the loadgenerator to run as non-root user

# Changes

The playwright browsers are now cached in /opt, instead of under /root
