### PR TITLE
refactor(productcatalogservice): refactor productcatalogservice dockerfile

### DIFF
--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -2,22 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM golang:1.22.0-alpine AS builder
-RUN apk update && apk add --no-cache make protobuf-dev
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /usr/src/app/
 
-RUN apk add build-base protobuf-dev protoc
-COPY ./pb/ ./pb
+RUN apk update \
+    && apk add --no-cache make protobuf-dev
 
-RUN protoc -I ./pb ./pb/demo.proto --go_out=./ --go-grpc_out=./
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=./src/productcatalogservice/go.sum,target=go.sum \
+    --mount=type=bind,source=./src/productcatalogservice/go.mod,target=go.mod \
+    --mount=type=bind,source=./src/productcatalogservice/tools.go,target=tools.go \
+    go mod download \
+    && go list -e -f '{{range .Imports}}{{.}} {{end}}' tools.go | CGO_ENABLED=0 xargs go install -mod=readonly
 
-COPY ./src/productcatalogservice/ ./
-RUN go build -o /go/bin/productcatalogservice/
-
-# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=bind,rw,source=./src/productcatalogservice,target=. \
+    --mount=type=bind,rw,source=./pb,target=./pb \
+    protoc -I ./pb ./pb/demo.proto --go_out=./ --go-grpc_out=./ \
+    && go build -ldflags "-s -w" -o /go/bin/productcatalogservice/ ./
 
 FROM alpine AS release
 


### PR DESCRIPTION
# Changes

- Use `golang:1.22-alpine` instead of `golang:1.22.x-alpine` to always get the latest patch version. (i.e: currently golang:1.22-alpine will resolve the go version: 1.22.1 (latest))
- Use mount type=cache and type=bind from buildkit spec (this is also suggested by command `docker init`) for better performance when running `docker build`.
- Use `go list` command to install go tools in tools.go with versions locked in go.mod

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
