### PR TITLE
remove reference of featureflag endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,6 @@ start:
 	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
 	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
 	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
-	@echo "Go to http://localhost:8080/feature/ for the Feature Flag UI."
 
 .PHONY: start-minimal
 start-minimal:
@@ -153,7 +152,6 @@ start-odd:
 	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
 	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
 	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
-	@echo "Go to http://localhost:8080/feature/ for the Feature Flag UI."
 	@echo "Go to http://localhost:11633/ for the Tracetest Web UI."
 
 .PHONY: stop


### PR DESCRIPTION
# Changes

Fix #1459

`/feature` was removed with the FeatureFlag custom service we had.
We are now using `flagd` which doesn't have an endpoint.