### PR TITLE
[chore] - restrict GitHub workflows to OpenTelemetry repo

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   assign-reviewers:
+    if: github.repository == 'open-telemetry/opentelemetry-demo'
     runs-on: ubuntu-latest
     steps:
       - uses: dyladan/component-owners@main

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   build_and_push_images:
+    if: github.repository == 'open-telemetry/opentelemetry-demo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build_and_push_images:
     uses: ./.github/workflows/build-images.yml
+    if: github.repository == 'open-telemetry/opentelemetry-demo'
     with:
       push: true
       version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
# Changes

Restricts several workflows to only run on the primary OpenTelemetry repo and not other forks. This is to prevent errors from showing up on forks due to failed workflows.

related to #1405 
