### PR TITLE
remove deprecated start_child_span option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ the release.
   ([#1448](https://github.com/open-telemetry/opentelemetry-demo/pull/1448))
 * [cartservice] update .NET to .NET 8.0.3
   ([#1460](https://github.com/open-telemetry/opentelemetry-demo/pull/1460))
+* [frontendproxy] remove deprecated start_child_span option
+  ([#1469](https://github.com/open-telemetry/opentelemetry-demo/pull/1469))
 
 ## 1.8.0
 

--- a/src/frontendproxy/envoy.tmpl.yaml
+++ b/src/frontendproxy/envoy.tmpl.yaml
@@ -51,7 +51,6 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                      start_child_span: true
 
   clusters:
     - name: opentelemetry_collector_grpc


### PR DESCRIPTION
# Changes

Removes a deprecated option from the Envoy config. This removes the following warning from the frontend-proxy logs on startup. 
```
frontend-proxy  | [2024-03-19 18:00:53.063][8][info][tracing] [source/common/tracing/tracer_manager_impl.cc:42] instantiating a new tracer: envoy.tracers.opentelemetry
frontend-proxy  | [2024-03-19 18:00:53.063][8][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.extensions.filters.http.router.v3.Router Using deprecated option 'envoy.extensions.filters.http.router.v3.Router.start_child_span' from file router.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
frontend-proxy  | [2024-03-19 18:00:53.063][8][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.extensions.filters.http.router.v3.Router Using deprecated option 'envoy.extensions.filters.http.router.v3.Router.start_child_span' from file router.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
```
We already use the `spawn_upstream_span` option configured within the tracing portion of the envoy filter, as recommended by Envoy [docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#extensions-filters-http-router-v3-router), so tracing still works as expected.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
