### PR TITLE
[currency] - fix metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ the release.
   ([#1448](https://github.com/open-telemetry/opentelemetry-demo/pull/1448))
 * [cartservice] update .NET to .NET 8.0.3
   ([#1460](https://github.com/open-telemetry/opentelemetry-demo/pull/1460))
+* [currency] fix metric name
+  ([#1470](https://github.com/open-telemetry/opentelemetry-demo/pull/1470))
 
 ## 1.8.0
 

--- a/src/currencyservice/src/server.cpp
+++ b/src/currencyservice/src/server.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
   initTracer();
   initMeter();
   initLogger();
-  currency_counter = initIntCounter(name, version);
+  currency_counter = initIntCounter("app.currency", version);
   logger = getLogger(name);
   RunServer(port);
 


### PR DESCRIPTION
# Changes

We broke the metric name in #1378. This fixes that name and sets it to `app.currency.counter.total` as it was before.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
