### PR TITLE
[frontend] - disable fs instrumentation library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ the release.
   ([#1448](https://github.com/open-telemetry/opentelemetry-demo/pull/1448))
 * [cartservice] update .NET to .NET 8.0.3
   ([#1460](https://github.com/open-telemetry/opentelemetry-demo/pull/1460))
+* [frontend] disable instrumentation-fs library
+  ([#1473](https://github.com/open-telemetry/opentelemetry-demo/pull/1473))
 
 ## 1.8.0
 

--- a/src/frontend/utils/telemetry/Instrumentation.js
+++ b/src/frontend/utils/telemetry/Instrumentation.js
@@ -16,9 +16,9 @@ const sdk = new opentelemetry.NodeSDK({
   traceExporter: new OTLPTraceExporter(),
   instrumentations: [
     getNodeAutoInstrumentations({
-      // only instrument fs if it is part of another trace
+      // disable fs instrumentation to reduce noise
       '@opentelemetry/instrumentation-fs': {
-        requireParentSpan: true,
+        enabled: false,
       },
     })
   ],


### PR DESCRIPTION
# Changes

Fixes #1468 

The `instrumentaion-fs` library was generating 2 spans for nearly every GET request into the frontend. Since we now use a playwright enabled loadgenerator, this was happening for every resource being loaded, leading to a much larger load and additional noise being generated. Disabling the library removes that noise.

This chart is a count of spans for the frontend service by name before and after the change in this PR was deployed.
![Screenshot 2024-03-20 at 4 58 32 PM](https://github.com/open-telemetry/opentelemetry-demo/assets/1296118/833d1239-24c1-40a6-9bf1-fec57eb36ad9)

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
