### PR TITLE
chore(kafka): use apache/kafka official image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -590,7 +590,7 @@ services:
       - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
       - OTEL_RESOURCE_ATTRIBUTES
       - OTEL_SERVICE_NAME=kafka
-      - KAFKA_HEAP_OPTS=-Xmx200m -Xms200m
+      - KAFKA_HEAP_OPTS=-Xmx250m -Xms250m
     healthcheck:
       test: nc -z kafka 9092
       start_period: 10s

--- a/src/kafka/Dockerfile
+++ b/src/kafka/Dockerfile
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM confluentinc/cp-kafka:7.5.2
+FROM apache/kafka:3.7.0
 
 USER root
-ARG version=2.0.0
+ARG version=2.2.0
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /tmp/opentelemetry-javaagent.jar
 RUN chmod go+r /tmp/opentelemetry-javaagent.jar
 


### PR DESCRIPTION
# Changes

- Use official image `apache/kafka` (ref: https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka)
- Upgrade otel java instrumentation.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
