### PR TITLE
Adservice returns error status code when feature flag is enabled

### DIFF
--- a/src/adservice/src/main/java/oteldemo/AdService.java
+++ b/src/adservice/src/main/java/oteldemo/AdService.java
@@ -182,7 +182,7 @@ public final class AdService {
                 adRequestTypeKey, adRequestType.name(), adResponseTypeKey, adResponseType.name()));
 
         if (getFeatureFlagEnabled(ADSERVICE_FAILURE)) {
-          throw new StatusRuntimeException(Status.RESOURCE_EXHAUSTED);
+          throw new StatusRuntimeException(Status.UNAVAILABLE);
         }
 
         if (getFeatureFlagEnabled(ADSERVICE_MANUAL_GC_FEATURE_FLAG)) {


### PR DESCRIPTION
When the [adServiceFailture](https://opentelemetry.io/docs/demo/feature-flags/) feature flag is enabled, AdService returns a `RESOURCE_EXHAUSTED = 8` grpc status code. This does not result in the span status being set to error according to the grpc semantic conventions: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/grpc.md

Updating to return `UNAVAILABLE = 14` so that span status is reflected as error as the feature flag implies.

Side note: The docs site says that when this feature flag is enabled, an error is generated 1/10th of the time. I don't see any code that would limit this to only 10% of the time. Maybe I'm missing something. 