### PR TITLE
[frontend] reunite trace from loadgenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the release.
 
 ## Unreleased
 
-* [frontend] reunite trace and add session id to baggage
+* [frontend] reunite trace from loadgenerator
   ([#1506](https://github.com/open-telemetry/opentelemetry-demo/pull/1506))
 * [frauddetectionservice] use span links when consuming from Kafka
   ([#1501](https://github.com/open-telemetry/opentelemetry-demo/pull/1501))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [frontend] reunite trace and add session id to baggage
+  ([#1506](https://github.com/open-telemetry/opentelemetry-demo/pull/1506))
 * [frauddetectionservice] use span links when consuming from Kafka
   ([#1501](https://github.com/open-telemetry/opentelemetry-demo/pull/1501))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ the release.
 
 ## Unreleased
 
-* [frontend] reunite trace from loadgenerator
-  ([#1506](https://github.com/open-telemetry/opentelemetry-demo/pull/1506))
 * [frauddetectionservice] use span links when consuming from Kafka
   ([#1501](https://github.com/open-telemetry/opentelemetry-demo/pull/1501))
+* [frontend] reunite trace from loadgenerator
+  ([#1506](https://github.com/open-telemetry/opentelemetry-demo/pull/1506))
 
 ## 1.9.0
 

--- a/src/frontend/utils/enums/AttributeNames.ts
+++ b/src/frontend/utils/enums/AttributeNames.ts
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export enum AttributeNames {
-    SESSION_ID = 'app.session.id'
+    SESSION_ID = 'session.id'
 }

--- a/src/frontend/utils/enums/AttributeNames.ts
+++ b/src/frontend/utils/enums/AttributeNames.ts
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export enum AttributeNames {
-    SESSION_ID = 'session.id'
+    SESSION_ID = 'app.session.id'
 }

--- a/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
+++ b/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NextApiHandler } from 'next';
-import { context, Exception, propagation, Span, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import { context, Exception, Span, SpanStatusCode, trace } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { metrics } from '@opentelemetry/api';
 import { AttributeNames } from '../enums/AttributeNames';
@@ -12,33 +12,10 @@ const requestCounter = meter.createCounter('app.frontend.requests');
 
 const InstrumentationMiddleware = (handler: NextApiHandler): NextApiHandler => {
   return async (request, response) => {
-    const { headers, method, url = '', httpVersion } = request;
+    const {method, url = ''} = request;
     const [target] = url.split('?');
 
-    let span;
-    const baggage = propagation.getBaggage(context.active());
-    if (baggage?.getEntry('synthetic_request')?.value == 'true') {
-      // if synthetic_request baggage is set, create a new trace linked to the span in context
-      // this span will look similar to the auto-instrumented HTTP span
-      const syntheticSpan = trace.getSpan(context.active()) as Span;
-      const tracer = trace.getTracer(process.env.OTEL_SERVICE_NAME as string);
-      span = tracer.startSpan(`HTTP ${method}`, {
-        root: true,
-        kind: SpanKind.SERVER,
-        links: [{ context: syntheticSpan.spanContext() }],
-        attributes: {
-          'app.synthetic_request': true,
-          [SemanticAttributes.HTTP_TARGET]: target,
-          [SemanticAttributes.HTTP_METHOD]: method,
-          [SemanticAttributes.HTTP_USER_AGENT]: headers['user-agent'] || '',
-          [SemanticAttributes.HTTP_URL]: `${headers.host}${url}`,
-          [SemanticAttributes.HTTP_FLAVOR]: httpVersion,
-        },
-      });
-    } else {
-      // continue current trace/span
-      span = trace.getSpan(context.active()) as Span;
-    }
+    const span = trace.getSpan(context.active()) as Span;
 
     if (request.query['sessionId'] != null) {
       span.setAttribute(AttributeNames.SESSION_ID, request.query['sessionId']);
@@ -56,9 +33,6 @@ const InstrumentationMiddleware = (handler: NextApiHandler): NextApiHandler => {
     } finally {
       requestCounter.add(1, { method, target, status: httpStatus });
       span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpStatus);
-      if (baggage?.getEntry('synthetic_request')?.value == 'true') {
-        span.end();
-      }
     }
   };
 };

--- a/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
+++ b/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NextApiHandler } from 'next';
-import { context, Exception, Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import {BaggageEntry, context, Exception, propagation, Span, SpanStatusCode, trace} from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { metrics } from '@opentelemetry/api';
 import { AttributeNames } from '../enums/AttributeNames';
@@ -19,6 +19,8 @@ const InstrumentationMiddleware = (handler: NextApiHandler): NextApiHandler => {
 
     if (request.query['sessionId'] != null) {
       span.setAttribute(AttributeNames.SESSION_ID, request.query['sessionId']);
+      const baggage = propagation.getBaggage(context.active());
+      baggage?.setEntry(AttributeNames.SESSION_ID, { value: request.query['sessionId'] } as BaggageEntry);
     }
 
     let httpStatus = 200;

--- a/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
+++ b/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NextApiHandler } from 'next';
-import {BaggageEntry, context, Exception, propagation, Span, SpanStatusCode, trace} from '@opentelemetry/api';
+import {context, Exception, Span, SpanStatusCode, trace} from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { metrics } from '@opentelemetry/api';
-import { AttributeNames } from '../enums/AttributeNames';
 
 const meter = metrics.getMeter('frontend');
 const requestCounter = meter.createCounter('app.frontend.requests');
@@ -16,12 +15,6 @@ const InstrumentationMiddleware = (handler: NextApiHandler): NextApiHandler => {
     const [target] = url.split('?');
 
     const span = trace.getSpan(context.active()) as Span;
-
-    if (request.query['sessionId'] != null) {
-      span.setAttribute(AttributeNames.SESSION_ID, request.query['sessionId']);
-      const baggage = propagation.getBaggage(context.active());
-      baggage?.setEntry(AttributeNames.SESSION_ID, { value: request.query['sessionId'] } as BaggageEntry);
-    }
 
     let httpStatus = 200;
     try {


### PR DESCRIPTION
# Changes

This reunites the trace when initiated from the load generator. Now that #1501 is merged, we have span links done from a Kafka consumer service. Making this 1 trace will remove confusion from people looking to see the load from the load generator, only to see it broken up into multiple traces.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
