### PR TITLE
[chore] Update frontend test to remove fraud detection span check

### DIFF
--- a/test/tracetesting/frontend-service/06-checking-out-cart.yaml
+++ b/test/tracetesting/frontend-service/06-checking-out-cart.yaml
@@ -67,8 +67,3 @@ spec:
     selector: span[tracetest.span.type="messaging" name="orders receive" messaging.system="kafka" messaging.destination.name="orders" messaging.operation="receive"]
     assertions:
     - attr:name = "orders receive"
-  - name: The order was sent to fraud detection team
-    # captures the span emitted by Kafka instrumentation for Kotlin
-    selector: span[tracetest.span.type="messaging" name="orders process" messaging.system="kafka" messaging.operation="process"]
-    assertions:
-    - attr:name = "orders process"


### PR DESCRIPTION
# Changes

This PR updates the TraceTest, as `frauddetection` is not part of the checkout anymore.

I've reached out to the TraceTest team to see if we can validate linked traces somehow, but as of now, we can remove the test.

The trace path was changed on this PR: #1501