### PR TITLE
[quoteservice] manual metrics, logs export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ the release.
   ([#1507](https://github.com/open-telemetry/opentelemetry-demo/pull/1507))
 * [cartservice] update .NET package to 1.8.0 release
   ([#1514](https://github.com/open-telemetry/opentelemetry-demo/pull/1514))
+* [quoteservice] add manual metric, export logs periodically
+  ([#1519](https://github.com/open-telemetry/opentelemetry-demo/pull/1519))
 
 ## 1.9.0
 

--- a/src/quoteservice/app/routes.php
+++ b/src/quoteservice/app/routes.php
@@ -35,11 +35,11 @@ function calculateQuote($jsonObject): float
         $childSpan->addEvent('Quote calculated, returning its value');
 
         //manual metrics
-        static $meter;
-        $meter ??= Globals::meterProvider()
+        static $counter;
+        $counter ??= Globals::meterProvider()
             ->getMeter('quotes')
             ->createCounter('quotes', 'quotes', 'number of quotes calculated');
-        $meter->add(1, ['number_of_items' => $numberOfItems, 'total_cost' => $quote]);
+        $counter->add(1, ['number_of_items' => $numberOfItems, 'total_cost' => $quote]);
     } catch (\Exception $exception) {
         $childSpan->recordException($exception);
     } finally {

--- a/src/quoteservice/app/routes.php
+++ b/src/quoteservice/app/routes.php
@@ -26,12 +26,20 @@ function calculateQuote($jsonObject): float
             throw new \InvalidArgumentException('numberOfItems not provided');
         }
         $numberOfItems = intval($jsonObject['numberOfItems']);
-        $quote = round(8.90 * $numberOfItems, 2);
+        $costPerItem = rand(400, 1000)/10;
+        $quote = round($costPerItem * $numberOfItems, 2);
 
         $childSpan->setAttribute('app.quote.items.count', $numberOfItems);
         $childSpan->setAttribute('app.quote.cost.total', $quote);
 
         $childSpan->addEvent('Quote calculated, returning its value');
+
+        //manual metrics
+        static $meter;
+        $meter ??= Globals::meterProvider()
+            ->getMeter('quotes')
+            ->createCounter('quotes', 'quotes', 'number of quotes calculated');
+        $meter->add(1, ['number_of_items' => $numberOfItems, 'total_cost' => $quote]);
     } catch (\Exception $exception) {
         $childSpan->recordException($exception);
     } finally {
@@ -55,6 +63,7 @@ return function (App $app) {
         $span->addEvent('Quote processed, response sent back', [
             'app.quote.cost.total' => $data
         ]);
+        //exported as an opentelemetry log (see dependencies.php)
         $logger->info('Calculated quote', [
             'total' => $data,
         ]);

--- a/src/quoteservice/app/routes.php
+++ b/src/quoteservice/app/routes.php
@@ -39,7 +39,7 @@ function calculateQuote($jsonObject): float
         $counter ??= Globals::meterProvider()
             ->getMeter('quotes')
             ->createCounter('quotes', 'quotes', 'number of quotes calculated');
-        $counter->add(1, ['number_of_items' => $numberOfItems, 'total_cost' => $quote]);
+        $counter->add(1, ['number_of_items' => $numberOfItems]);
     } catch (\Exception $exception) {
         $childSpan->recordException($exception);
     } finally {

--- a/src/quoteservice/app/settings.php
+++ b/src/quoteservice/app/settings.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 use App\Application\Settings\Settings;
 use App\Application\Settings\SettingsInterface;
 use DI\ContainerBuilder;
-use Monolog\Logger;
+use Psr\Log\LogLevel;
 
 return function (ContainerBuilder $containerBuilder) {
     // Global Settings Object
@@ -22,7 +22,7 @@ return function (ContainerBuilder $containerBuilder) {
                 'logger' => [
                     'name' => 'slim-app',
                     'path' => 'php://stdout',
-                    'level' => Logger::DEBUG,
+                    'level' => LogLevel::DEBUG,
                 ],
             ]);
         }

--- a/src/quoteservice/composer.json
+++ b/src/quoteservice/composer.json
@@ -9,7 +9,7 @@
         "monolog/monolog": "3.5.0",
         "open-telemetry/api": "1.0.3",
         "open-telemetry/sdk": "1.0.8",
-        "open-telemetry/exporter-otlp": "1.0.3",
+        "open-telemetry/exporter-otlp": "1.0.4",
         "open-telemetry/opentelemetry-auto-slim": "1.0.4",
         "open-telemetry/detector-container": "1.0.0",
         "open-telemetry/opentelemetry-logger-monolog": "1.0.0",

--- a/src/quoteservice/public/index.php
+++ b/src/quoteservice/public/index.php
@@ -11,6 +11,7 @@ use DI\ContainerBuilder;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -61,7 +62,7 @@ if (($tracerProvider = Globals::tracerProvider()) instanceof TracerProviderInter
         $tracerProvider->forceFlush();
     });
 }
-if (($loggerProvider = Globals::tracerProvider()) instanceof \OpenTelemetry\SDK\Logs\LoggerProviderInterface) {
+if (($loggerProvider = Globals::loggerProvider()) instanceof LoggerProviderInterface) {
     Loop::addPeriodicTimer(Configuration::getInt(Variables::OTEL_BLRP_SCHEDULE_DELAY)/1000, function() use ($loggerProvider) {
         $loggerProvider->forceFlush();
     });

--- a/src/quoteservice/public/index.php
+++ b/src/quoteservice/public/index.php
@@ -61,6 +61,11 @@ if (($tracerProvider = Globals::tracerProvider()) instanceof TracerProviderInter
         $tracerProvider->forceFlush();
     });
 }
+if (($loggerProvider = Globals::tracerProvider()) instanceof \OpenTelemetry\SDK\Logs\LoggerProviderInterface) {
+    Loop::addPeriodicTimer(Configuration::getInt(Variables::OTEL_BLRP_SCHEDULE_DELAY)/1000, function() use ($loggerProvider) {
+        $loggerProvider->forceFlush();
+    });
+}
 if (($meterProvider = Globals::meterProvider()) instanceof MeterProviderInterface) {
     Loop::addPeriodicTimer(Configuration::getInt(Variables::OTEL_METRIC_EXPORT_INTERVAL)/1000, function() use ($meterProvider) {
         $meterProvider->forceFlush();

--- a/test/tracetesting/shipping-service/quote.yaml
+++ b/test/tracetesting/shipping-service/quote.yaml
@@ -37,5 +37,4 @@ spec:
     selector: span[tracetest.span.type="general" name="Tracetest trigger"]
     assertions:
     - attr:tracetest.response.body | json_path '$.costUsd.currencyCode' = "USD"
-    - attr:tracetest.response.body | json_path '$.costUsd.units' = 17
-    - attr:tracetest.response.body | json_path '$.costUsd.nanos' = 800000000
+    - attr:tracetest.response.body | json_path '$.costUsd.units' > 0


### PR DESCRIPTION
# Changes

- add a manual metric to the php quote service
- randomize per-item cost to add some variability to quotes
- bump dependencies to latest
- fix a monolog deprecation
- ensure logs are exported per the configured delay

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
