### PR TITLE
chore(jaeger): enable service performance monitoring

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ DEMO_VERSION=latest
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.97.0
 GRAFANA_IMAGE=grafana/grafana:10.4.1
-JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.55
+JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.56
 # must also update version field in /src/grafana/provisioning/datasources/opensearch.yml
 OPENSEARCH_IMAGE=opensearchproject/opensearch:2.12.0
 POSTGRES_IMAGE=postgres:16.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -636,15 +636,19 @@ services:
     container_name: jaeger
     command:
       - "--memory.max-traces=5000"
+      - "--query.ui-config=/etc/jaeger/jaeger-ui.json"
       - "--query.base-path=/jaeger/ui"
       - "--prometheus.server-url=http://${PROMETHEUS_ADDR}"
       - "--prometheus.query.normalize-calls=true"
       - "--prometheus.query.normalize-duration=true"
+      - "--prometheus.query.support-spanmetrics-connector=true"
     deploy:
       resources:
         limits:
           memory: 400M
     restart: unless-stopped
+    volumes:
+      - ./src/jaeger/jaeger-ui.json:/etc/jaeger/jaeger-ui.json
     ports:
       - "${JAEGER_SERVICE_PORT}"         # Jaeger UI
       - "${OTEL_COLLECTOR_PORT_GRPC}"

--- a/src/jaeger/jaeger-ui.json
+++ b/src/jaeger/jaeger-ui.json
@@ -1,0 +1,8 @@
+{
+  "monitor": {
+    "menuEnabled": true
+  },
+  "dependencies": {
+    "menuEnabled": true
+  }
+}


### PR DESCRIPTION
# Changes

- Enable SPM in Jaeger, reference: https://www.jaegertracing.io/docs/1.56/spm

<img width="1728" alt="image" src="https://github.com/open-telemetry/opentelemetry-demo/assets/4991619/02a8bafc-1e78-40e6-8f9f-e100689edaef">

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
