### PR TITLE
[chore] specify default value for tracetest image version

### DIFF
--- a/.env
+++ b/.env
@@ -14,8 +14,7 @@ OPENSEARCH_IMAGE=opensearchproject/opensearch:2.12.0
 POSTGRES_IMAGE=postgres:16.2
 PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v2.51.1
 REDIS_IMAGE=redis:7.2-alpine
-TRACETEST_IMAGE_VERSION=v0.16.0
-TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
+TRACETEST_IMAGE=kubeshop/tracetest:v1.0.0
 
 # Demo Platform
 ENV_PLATFORM=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ the release.
   ([#1528](https://github.com/open-telemetry/opentelemetry-demo/pull/1528))
 * [otelcollector] Add `redisreceiver`
   ([#1537](https://github.com/open-telemetry/opentelemetry-demo/pull/1537))
+* [traceBasedTests] update to v1.0.0
+  ([#1551](https://github.com/open-telemetry/opentelemetry-demo/pull/1551))
 
 ## 1.9.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -778,8 +778,6 @@ services:
     build:
       context: ./
       dockerfile: ./test/tracetesting/Dockerfile
-      args:
-        - TRACETEST_IMAGE_VERSION
     environment:
       - AD_SERVICE_ADDR
       - CART_SERVICE_ADDR

--- a/test/tracetesting/Dockerfile
+++ b/test/tracetesting/Dockerfile
@@ -6,10 +6,11 @@ FROM alpine
 
 WORKDIR /app
 
-ARG TRACETEST_IMAGE_VERSION
+# The build-images workflow action does not set a build-arg so we need to specify a default value here
+ARG TRACETEST_IMAGE_VERSION=v1.0.0
 
 RUN apk --update add bash jq curl
-RUN curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- ${TRACETEST_IMAGE_VERSION}
+RUN curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash -s -- $TRACETEST_IMAGE_VERSION
 
 WORKDIR /app/test/tracetesting
 


### PR DESCRIPTION
Fixes #1550 

Since the tracetest server and CLI version need to match, we must ensure both images are aligned. The solution is to hardcode the tracetest version in the GitHub workflow or the Dockerfile. I opted to specify this in the Dockerfile, adding a comment on why we need to do it there.