### PR TITLE
Fix kafka permission in dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ the release.
   ([#1556](https://github.com/open-telemetry/opentelemetry-demo/pull/1556))
 * [frontend] Slowloading of images based on imageSlowLoad flag
   ([#1515](https://github.com/open-telemetry/opentelemetry-demo/pull/1486))
+* [kafka] Fix permission issue with the telemetry agent when running in docker compose
+  ([#1574](https://github.com/open-telemetry/opentelemetry-demo/pull/1574))
 
 ## 1.9.0
 

--- a/src/kafka/Dockerfile
+++ b/src/kafka/Dockerfile
@@ -6,9 +6,10 @@ FROM apache/kafka:3.7.0
 
 USER root
 ARG version=2.3.0
-ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /tmp/opentelemetry-javaagent.jar
 
 USER appuser
+
+ADD --chown=appuser:appuser https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /tmp/opentelemetry-javaagent.jar
 
 ENV KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
 ENV KAFKA_CONTROLLER_QUORUM_VOTERS='1@0.0.0.0:9093'


### PR DESCRIPTION
# Changes

Before the fix, kafka will crash immediate when running in docker compose on m1 mac, unsure if this also happens in other environments or platform.

How to reproduce the issue
```
docker compose up --no-deps --build kafka
```

logs
```
kafka  | Error opening zip file or JAR manifest missing : /tmp/opentelemetry-javaagent.jar Error occurred during initialization of VM agent library failed Agent_OnLoad: instrument
kafka exited with code 1
```

inspecting the jar showing incorrect permission
```
/ $ ls -al /tmp/opentelemetry-javaagent.jar 
-rw-------    1 root     root      21007939 Apr 12 00:45 /tmp/opentelemetry-javaagent.jar
```

after the fix
```
/ $ ls -al /tmp/opentelemetry-javaagent.jar 
-rw-------    1 appuser  appuser   21007939 Apr 12 00:45 /tmp/opentelemetry-javaagent.jar
```

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
