### PR TITLE
[chore] remove link failing CI (Coralogix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ keeping it up to date for you.
 | [Axiom][Axiom]                          | [Guance][Guance]            | [ServiceNow Cloud Observability][ServiceNowCloudObservability] |
 | [Axoflow][Axoflow]                      | [Helios][Helios]            | [Splunk][Splunk]                                               |
 | [Azure Data Explorer][Azure]            | [Honeycomb.io][Honeycombio] | [Sumo Logic][SumoLogic]                                        |
-| [Coralogix][Coralogix]                  | [Instana][Instana]          | [TelemetryHub][TelemetryHub]                                   |
+| Coralogix                               | [Instana][Instana]          | [TelemetryHub][TelemetryHub]                                   |
 | [Dash0][Dash0]                          | [Kloudfuse][Kloudfuse]      | [Teletrace][Teletrace]                                         |
 | [Datadog][Datadog]                      | [Liatrio][Liatrio]          | [Tracetest][Tracetest]                                         |
 | [Dynatrace][Dynatrace]                  | [Logz.io][Logzio]           | [Uptrace][Uptrace]                                             |
@@ -111,7 +111,6 @@ Emeritus:
 [Axiom]: https://play.axiom.co/axiom-play-qf1k/dashboards/otel.traces.otel-demo-traces
 [Axoflow]: https://axoflow.com/opentelemetry-support-in-more-detail-in-axosyslog-and-syslog-ng/
 [Azure]: https://github.com/Azure/Azure-kusto-opentelemetry-demo
-[Coralogix]: https://coralogix.com/blog/configure-otel-demo-send-telemetry-data-coralogix
 [Dash0]: https://github.com/dash0hq/opentelemetry-demo
 [Datadog]: https://docs.datadoghq.com/opentelemetry/guide/otel_demo_to_datadog
 [Dynatrace]: https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/


### PR DESCRIPTION
# Changes

This removes the link for Coralogix but keeps the text as a vendor supporting the demo. This is to resolve the CI error where the markdown-link-checker running in our GitHub Actions CI fails when checking that link. This is a temporary solution so Coralogix can update the link or fix their web hosting configuration to ensure the CI failure no longer happens.

/cc @oded-dd who did the original PR to add Coralogix
