### PR TITLE
[chore] update buildx config

### DIFF
--- a/.github/workflows/component_build-images.yml
+++ b/.github/workflows/component_build-images.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          config-inline: |
+          buildkitd-config-inline: |
             [worker.oci]
             max-parallelism = 2
       - name: Matrix Build and push demo images


### PR DESCRIPTION
# Changes

The `config-inline` parameter is deprecated, and we should use `buildkitd-config-inline` instead. See this [PR](https://github.com/docker/setup-buildx-action/pull/303) for more details.

This is the warning message in our GHA for build and publish.
![Screenshot 2024-06-07 at 12 18 07 AM](https://github.com/open-telemetry/opentelemetry-demo/assets/1296118/18828dba-3db4-47a8-a3c2-68b4d1c8b161)
