### PR TITLE
chore: configure renovate to bump image deps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -100,5 +100,18 @@
       "matchPackageNames": ["eclipse-temurin"],
       "enabled": false
     }
+  ],
+
+  "regexManagers": [
+    {
+      // Parse image version from .env file.
+      "fileMatch": [
+        ".env$"
+      ],
+      "datasourceTemplate": "docker",
+      "matchStrings": [
+        "IMAGE=(?<depName>.+):(?<currentValue>.+)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
# Changes

Configures renovate to bump image version defined in the `.env` file. Although it seems that Renovate is not doing any PR due the PR limit, I reckon we can manually trigger them from its dashboard: https://github.com/open-telemetry/opentelemetry-demo/issues/953

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

~~* [ ] `CHANGELOG.md` updated to document new feature additions~~
~~* [ ] Appropriate documentation updates in the [docs][]~~
~~* [ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
