### PR TITLE
[chore] - update changelog to 1.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+## 1.10.0
+
 * [frauddetectionservice] use span links when consuming from Kafka
   ([#1501](https://github.com/open-telemetry/opentelemetry-demo/pull/1501))
 * [frontend] reunite trace from loadgenerator


### PR DESCRIPTION
# Changes

We did not update the changelog heading accordingly when releasing 1.10.0. This fixes that.
