### PR TITLE
[Valkey] Replace Redis with Valkey

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.57
 OPENSEARCH_IMAGE=opensearchproject/opensearch:2.14.0
 POSTGRES_IMAGE=postgres:16.3
 PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v2.52.0
-REDIS_IMAGE=redis:7.2-alpine
+VALKEY_IMAGE=valkey/valkey:7.2-alpine
 # must also update the version arg in ./test/tracetesting/Dockerfile
 TRACETEST_IMAGE=kubeshop/tracetest:v1.3.0
 
@@ -129,9 +129,9 @@ FLAGD_PORT=8013
 KAFKA_SERVICE_PORT=9092
 KAFKA_SERVICE_ADDR=kafka:${KAFKA_SERVICE_PORT}
 
-# Redis
-REDIS_PORT=6379
-REDIS_ADDR=redis-cart:${REDIS_PORT}
+# Valkey
+VALKEY_PORT=6379
+VALKEY_ADDR=valkey-cart:${VALKEY_PORT}
 
 # ********************
 # Telemetry Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ the release.
 
 * [cartservice] bump .NET package to 1.9.0 release
   ([#1610](https://github.com/open-telemetry/opentelemetry-demo/pull/1610))
+* [Valkey] Replace Redis with Valkey
+  ([#1619](https://github.com/open-telemetry/opentelemetry-demo/pull/1619))
 
 ## 1.10.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -66,13 +66,13 @@ services:
     environment:
       - CART_SERVICE_PORT
       - FLAGD_HOST
-      - REDIS_ADDR
+      - VALKEY_ADDR
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_RESOURCE_ATTRIBUTES
       - OTEL_SERVICE_NAME=cartservice
       - ASPNETCORE_URLS=http://*:${CART_SERVICE_PORT}
     depends_on:
-      redis-cart:
+      valkey-cart:
         condition: service_started
       otelcol:
         condition: service_started
@@ -515,18 +515,18 @@ services:
     logging:
       *logging
 
-  # Redis used by Cart service
-  redis-cart:
-    image: ${REDIS_IMAGE}
-    container_name: redis-cart
-    user: redis
+  # Valkey used by Cart service
+  valkey-cart:
+    image: ${VALKEY_IMAGE}
+    container_name: valkey-cart
+    user: valkey
     deploy:
       resources:
         limits:
           memory: 20M
     restart: unless-stopped
     ports:
-      - "${REDIS_PORT}"
+      - "${VALKEY_PORT}"
     logging: *logging
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,13 +96,13 @@ services:
       - CART_SERVICE_PORT
       - FLAGD_HOST
       - FLAGD_PORT
-      - REDIS_ADDR
+      - VALKEY_ADDR
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_RESOURCE_ATTRIBUTES
       - OTEL_SERVICE_NAME=cartservice
       - ASPNETCORE_URLS=http://*:${CART_SERVICE_PORT}
     depends_on:
-      redis-cart:
+      valkey-cart:
         condition: service_started
       otelcol:
         condition: service_started
@@ -625,18 +625,18 @@ services:
       retries: 10
     logging: *logging
 
-  # Redis used by Cart service
-  redis-cart:
-    image: ${REDIS_IMAGE}
-    container_name: redis-cart
-    user: redis
+  # Valkey used by Cart service
+  valkey-cart:
+    image: ${VALKEY_IMAGE}
+    container_name: valkey-cart
+    user: valkey
     deploy:
       resources:
         limits:
           memory: 20M
     restart: unless-stopped
     ports:
-      - "${REDIS_PORT}"
+      - "${VALKEY_PORT}"
     logging: *logging
 
 

--- a/src/cartservice/README.md
+++ b/src/cartservice/README.md
@@ -1,6 +1,6 @@
 # Cart Service
 
-This service stores user shopping carts in Redis.
+This service stores user shopping carts in Valkey.
 
 ## Local Build
 

--- a/src/cartservice/src/Program.cs
+++ b/src/cartservice/src/Program.cs
@@ -20,10 +20,10 @@ using OpenFeature.Contrib.Providers.Flagd;
 using OpenFeature.Contrib.Hooks.Otel;
 
 var builder = WebApplication.CreateBuilder(args);
-string redisAddress = builder.Configuration["REDIS_ADDR"];
-if (string.IsNullOrEmpty(redisAddress))
+string valkeyAddress = builder.Configuration["VALKEY_ADDR"];
+if (string.IsNullOrEmpty(valkeyAddress))
 {
-    Console.WriteLine("REDIS_ADDR environment variable is required.");
+    Console.WriteLine("VALKEY_ADDR environment variable is required.");
     Environment.Exit(1);
 }
 
@@ -33,7 +33,7 @@ builder.Logging
 
 builder.Services.AddSingleton<ICartStore>(x=>
 {
-    var store = new RedisCartStore(x.GetRequiredService<ILogger<RedisCartStore>>(), redisAddress);
+    var store = new ValkeyCartStore(x.GetRequiredService<ILogger<ValkeyCartStore>>(), valkeyAddress);
     store.Initialize();
     return store;
 });
@@ -48,7 +48,7 @@ builder.Services.AddSingleton<IFeatureClient>(x => {
 builder.Services.AddSingleton(x =>
     new CartService(
         x.GetRequiredService<ICartStore>(),
-        new RedisCartStore(x.GetRequiredService<ILogger<RedisCartStore>>(), "badhost:1234"),
+        new ValkeyCartStore(x.GetRequiredService<ILogger<ValkeyCartStore>>(), "badhost:1234"),
         x.GetRequiredService<IFeatureClient>()
 ));
 
@@ -79,8 +79,8 @@ builder.Services.AddGrpcHealthChecks()
 
 var app = builder.Build();
 
-var redisCartStore = (RedisCartStore) app.Services.GetRequiredService<ICartStore>();
-app.Services.GetRequiredService<StackExchangeRedisInstrumentation>().AddConnection(redisCartStore.GetConnection());
+var ValkeyCartStore = (ValkeyCartStore) app.Services.GetRequiredService<ICartStore>();
+app.Services.GetRequiredService<StackExchangeRedisInstrumentation>().AddConnection(ValkeyCartStore.GetConnection());
 
 app.MapGrpcService<CartService>();
 app.MapGrpcHealthChecksService();

--- a/src/cartservice/src/cartstore/ValkeyCartStore.cs
+++ b/src/cartservice/src/cartstore/ValkeyCartStore.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace cartservice.cartstore;
 
-public class RedisCartStore : ICartStore
+public class ValkeyCartStore : ICartStore
 {
     private readonly ILogger _logger;
     private const string CartFieldName = "cart";
@@ -25,13 +25,13 @@ public class RedisCartStore : ICartStore
 
     private readonly ConfigurationOptions _redisConnectionOptions;
 
-    public RedisCartStore(ILogger<RedisCartStore> logger, string redisAddress)
+    public ValkeyCartStore(ILogger<ValkeyCartStore> logger, string valkeyAddress)
     {
         _logger = logger;
         // Serialize empty cart into byte array.
         var cart = new Oteldemo.Cart();
         _emptyCartBytes = cart.ToByteArray();
-        _connectionString = $"{redisAddress},ssl=false,allowAdmin=true,abortConnect=false";
+        _connectionString = $"{valkeyAddress},ssl=false,allowAdmin=true,abortConnect=false";
 
         _redisConnectionOptions = ConfigurationOptions.Parse(_connectionString);
 

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -14,7 +14,8 @@ receivers:
     targets:
       - endpoint: http://frontendproxy:${env:ENVOY_PORT}
   redis:
-    endpoint: "redis-cart:6379"
+    endpoint: "valkey-cart:6379"
+    username: "valkey"
     collection_interval: 10s
 
 exporters:


### PR DESCRIPTION
# Changes

This PR replaces Redis with Valkey.

Redis has recently changed its licensing and Valkey was created by the community to continue the project as an Open Source driven project.
[Valkey/about](https://valkey.io/about/):
> The transition garnered substantial backing from leading tech corporations including AWS, Google, Oracle, Ericsson, and Snap, with the Linux Foundation stepping in to provide a stable platform for this new direction.

[Linux Foundation Launches Open Source Valkey Community](https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community).

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
