### PR TITLE
[otel-col] Add docker stats receiver

### DIFF
--- a/.env
+++ b/.env
@@ -22,6 +22,7 @@ TRACETEST_IMAGE=kubeshop/tracetest:v1.3.0
 ENV_PLATFORM=local
 
 # OpenTelemetry Collector
+DOCKER_SOCK=/var/run/docker.sock
 OTEL_COLLECTOR_HOST=otelcol
 OTEL_COLLECTOR_PORT_GRPC=4317
 OTEL_COLLECTOR_PORT_HTTP=4318

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ the release.
   ([#1610](https://github.com/open-telemetry/opentelemetry-demo/pull/1610))
 * [Valkey] Replace Redis with Valkey
   ([#1619](https://github.com/open-telemetry/opentelemetry-demo/pull/1619))
-* ([recommendation] updated flag name to match flagd configuration
+* [recommendation] updated flag name to match flagd configuration
   ([#1634](https://github.com/open-telemetry/opentelemetry-demo/pull/1634))
+* [otel-col] Add docker stats receiver
+  ([#1650](https://github.com/open-telemetry/opentelemetry-demo/pull/1650))
 
 ## 1.10.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -583,7 +583,9 @@ services:
           memory: 200M
     restart: unless-stopped
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
+    user: 0:0
     volumes:
+      - ${DOCKER_SOCK}:/var/run/docker.sock:ro
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -693,7 +693,9 @@ services:
           memory: 200M
     restart: unless-stopped
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
+    user: 0:0
     volumes:
+      - ${DOCKER_SOCK}:/var/run/docker.sock
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -695,7 +695,7 @@ services:
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
     user: 0:0
     volumes:
-      - ${DOCKER_SOCK}:/var/run/docker.sock
+      - ${DOCKER_SOCK}:/var/run/docker.sock:ro
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml
     ports:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -13,10 +13,20 @@ receivers:
   httpcheck/frontendproxy:
     targets:
       - endpoint: http://frontendproxy:${env:ENVOY_PORT}
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
   redis:
     endpoint: "valkey-cart:6379"
     username: "valkey"
     collection_interval: 10s
+  # Collector metrics
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otelcol'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
 
 exporters:
   debug:
@@ -48,7 +58,7 @@ service:
       processors: [batch]
       exporters: [otlp, debug, spanmetrics]
     metrics:
-      receivers: [httpcheck/frontendproxy, redis, otlp, spanmetrics]
+      receivers: [docker_stats, httpcheck/frontendproxy, otlp, prometheus, redis, spanmetrics]
       processors: [batch]
       exporters: [otlphttp/prometheus, debug]
     logs:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -23,10 +23,10 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-      - job_name: 'otelcol'
-        scrape_interval: 10s
-        static_configs:
-        - targets: ['0.0.0.0:8888']
+        - job_name: 'otelcol'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['0.0.0.0:8888']
 
 exporters:
   debug:


### PR DESCRIPTION
# Changes

This PR adds the `docker_stats` receiver to the demo.
This receiver is meant to be used only when running locally on Docker.

For that to work we need privileged access to docker sock:

```yaml
    user: 0:0
    volumes:
      - ${DOCKER_SOCK}:/var/run/docker.sock
```

I've also added Prometheus receiver to get internal Collector Metrics.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] ~~Appropriate documentation updates in the [docs][]~~
* [x] ~~Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
