### PR TITLE
Set OTLP receiver endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ IMAGE_NAME=ghcr.io/open-telemetry/demo
 DEMO_VERSION=latest
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.102.1
+COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.104.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.10.2
 GRAFANA_IMAGE=grafana/grafana:10.4.3
 JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ the release.
   ([#1634](https://github.com/open-telemetry/opentelemetry-demo/pull/1634))
 * [otel-col] Add docker stats receiver
   ([#1650](https://github.com/open-telemetry/opentelemetry-demo/pull/1650))
+* [otel-col] Set OTLP receiver endpoint to avoid breaking changes
+  ([#1662](https://github.com/open-telemetry/opentelemetry-demo/pull/1662))
 
 ## 1.10.0
 

--- a/docker-compose-tests_include-override.yml
+++ b/docker-compose-tests_include-override.yml
@@ -5,6 +5,11 @@ services:
 
   otelcol:
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-tracetest.yml" ]
+    environment:
+      - ENVOY_PORT
+      - OTEL_COLLECTOR_HOST
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
     volumes:
       - ${DOCKER_SOCK}:/var/run/docker.sock:ro
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -596,6 +596,9 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - OTEL_COLLECTOR_HOST
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
 
   # Prometheus
   prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -706,6 +706,9 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - OTEL_COLLECTOR_HOST
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
 
   # Prometheus
   prometheus:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -5,7 +5,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: otelcol:4317
       http:
+        endpoint: otelcol:4318
         cors:
           allowed_origins:
             - "http://*"

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -5,9 +5,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: otelcol:4317
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_GRPC}
       http:
-        endpoint: otelcol:4318
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_HTTP}
         cors:
           allowed_origins:
             - "http://*"


### PR DESCRIPTION
# Changes

The default endpoints for all servers in the OTel Collector have changed to use localhost instead of 0.0.0.0.
If we keep the default, it won't work for Docker compose anymore.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
