### PR TITLE
Remove query params and product ID from span names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [otel-col] strip high-cardinality segments of span names
+  ([#1668](https://github.com/open-telemetry/opentelemetry-demo/pull/1668))
 * [tests] run trace based tests concurrently
   ([#1659](https://github.com/open-telemetry/opentelemetry-demo/pull/1659))
 * [accountingservice] increase memory to 120MB

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -51,7 +51,7 @@ processors:
     error_mode: ignore
     trace_statements:
       - context: span
-        statements: 
+        statements:
           # could be removed when https://github.com/vercel/next.js/pull/64852 is fixed upstream
           - replace_pattern(name, "\\?.*", "")
           - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -47,6 +47,14 @@ exporters:
 
 processors:
   batch:
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements: 
+          # could be removed when https://github.com/vercel/next.js/pull/64852 is fixed upstream
+          - replace_pattern(name, "\\?.*", "")
+          - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
 
 connectors:
   spanmetrics:
@@ -55,7 +63,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [transform, batch]
       exporters: [otlp, debug, spanmetrics]
     metrics:
       receivers: [docker_stats, httpcheck/frontendproxy, otlp, prometheus, redis, spanmetrics]


### PR DESCRIPTION
# Changes

- adds a transform processor to the collector trace pipeline
- adds two rules for transforming span names:
  - Strip anything after a "?"
  - Replace productID with a token in "GET /api/products/{productID}" spans

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
~* [ ] Appropriate documentation updates in the [docs][]~
* [x] Appropriate Helm chart updates in the [helm-charts][]
