### PR TITLE
[otel-col] Add host metrics receiver

### DIFF
--- a/.env
+++ b/.env
@@ -22,6 +22,7 @@ TRACETEST_IMAGE=kubeshop/tracetest:v1.3.0
 ENV_PLATFORM=local
 
 # OpenTelemetry Collector
+HOST_FILESYSTEM=/
 DOCKER_SOCK=/var/run/docker.sock
 OTEL_COLLECTOR_HOST=otelcol
 OTEL_COLLECTOR_PORT_GRPC=4317

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ the release.
   ([#1666](https://github.com/open-telemetry/opentelemetry-demo/pull/1666))
 * [frontend] Update nodejs to latest LTS and bump dependencies
   ([#1670](https://github.com/open-telemetry/opentelemetry-demo/pull/1670))
+* [otel-col] Add host metrics receiver
+  ([#1675](https://github.com/open-telemetry/opentelemetry-demo/pull/1675))
 
 ## 1.11.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -585,6 +585,7 @@ services:
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
     user: 0:0
     volumes:
+      - ${HOST_FILESYSTEM}:/hostfs:ro
       - ${DOCKER_SOCK}:/var/run/docker.sock:ro
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml
@@ -596,6 +597,7 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - HOST_FILESYSTEM
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -695,6 +695,7 @@ services:
     command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
     user: 0:0
     volumes:
+      - ${HOST_FILESYSTEM}:/hostfs:ro
       - ${DOCKER_SOCK}:/var/run/docker.sock:ro
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml
@@ -706,6 +707,7 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - HOST_FILESYSTEM
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -69,6 +69,9 @@ receivers:
             - tracefs
           match_type: strict
       memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
       network:
       paging:
       processes:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -26,6 +26,9 @@ receivers:
     root_path: /hostfs
     scrapers:
       cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
       disk:
       load:
       filesystem:

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -21,6 +21,58 @@ receivers:
     endpoint: "valkey-cart:6379"
     username: "valkey"
     collection_interval: 10s
+  # Host metrics
+  hostmetrics:
+    root_path: /hostfs
+    scrapers:
+      cpu:
+      disk:
+      load:
+      filesystem:
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/k3s/containerd/*
+            - /var/lib/docker/*
+            - /var/lib/kubelet/*
+            - /snap/*
+          match_type: regexp
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+          match_type: strict
+      memory:
+      network:
+      paging:
+      processes:
+      process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
   # Collector metrics
   prometheus:
     config:
@@ -68,7 +120,7 @@ service:
       processors: [transform, batch]
       exporters: [otlp, debug, spanmetrics]
     metrics:
-      receivers: [docker_stats, httpcheck/frontendproxy, otlp, prometheus, redis, spanmetrics]
+      receivers: [hostmetrics, docker_stats, httpcheck/frontendproxy, otlp, prometheus, redis, spanmetrics]
       processors: [batch]
       exporters: [otlphttp/prometheus, debug]
     logs:


### PR DESCRIPTION
# Changes

This PR adds the hostmetrics receiver to the demo.

Related issue: https://github.com/open-telemetry/opentelemetry-demo/issues/1653

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
~~* [ ] Appropriate documentation updates in the [docs][]~~
~~* [ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
