### PR TITLE
Add required jaeger env var

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -553,6 +553,7 @@ services:
       - "${OTEL_COLLECTOR_PORT_GRPC}"
     environment:
       - METRICS_STORAGE_TYPE=prometheus
+      - COLLECTOR_OTLP_GRPC_HOST_PORT=${JAEGER_SERVICE_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
     logging: *logging
 
   # Grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -663,6 +663,7 @@ services:
       - "${OTEL_COLLECTOR_PORT_GRPC}"
     environment:
       - METRICS_STORAGE_TYPE=prometheus
+      - COLLECTOR_OTLP_GRPC_HOST_PORT=${JAEGER_SERVICE_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
     logging: *logging
 
   # Grafana


### PR DESCRIPTION
# Changes

PR https://github.com/open-telemetry/opentelemetry-demo/pull/1683 broke Jaeger as https://github.com/jaegertracing/jaeger/releases/tag/v1.59.0 had a breaking change.

This PR adds the missing env var to Jaeger.

@puckpuck we need this env var before getting #1687 merged and released.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
