### PR TITLE
chore: Add yamllint to `make all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ the release.
 
 * [accountingservice] allow running the container with non root user
   ([#1692](https://github.com/open-telemetry/opentelemetry-demo/pull/1692))
+* [chore] Add yamllint to `make all`
+  ([#1707](https://github.com/open-telemetry/opentelemetry-demo/pull/1707))
 
 ## 1.11.1
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ markdownlint:
 .PHONY: install-yamllint
 install-yamllint:
     # Using a venv is recommended
-	yamllint --version >/dev/null 2>&1 || pip install -U yamllint~=${YAMLLINT_VERSION}
+	yamllint --version >/dev/null 2>&1 || pip install -U yamllint~=$(YAMLLINT_VERSION)
 
 .PHONY: yamllint
 yamllint: install-yamllint

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ DOCKER_COMPOSE_ENV=--env-file .env --env-file .env.override
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
 SEMCONVGEN_VERSION=0.11.0
+YAMLLINT_VERSION=1.30.0
 
-# TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all
-all: install-tools markdownlint misspell
+all: install-tools markdownlint misspell yamllint
 
 $(MISSPELL):
 	cd $(TOOLS_DIR) && go build -o $(MISSPELL_BINARY) github.com/client9/misspell/cmd/misspell
@@ -44,10 +44,10 @@ markdownlint:
 .PHONY: install-yamllint
 install-yamllint:
     # Using a venv is recommended
-	pip install -U yamllint~=1.30.0
+	yamllint --version >/dev/null 2>&1 || pip install -U yamllint~=${YAMLLINT_VERSION}
 
 .PHONY: yamllint
-yamllint:
+yamllint: install-yamllint
 	yamllint .
 
 .PHONY: checklicense


### PR DESCRIPTION
# Changes

Add yamllint to `make all`, and adjust the logic for installing yamllint.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
