### PR TITLE
fix: only register otel during initialization

### DIFF
--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -128,10 +128,13 @@ func main() {
 		}
 		log.Println("Shutdown meter provider")
 	}()
-	openfeature.SetProvider(flagd.NewProvider())
 	openfeature.AddHooks(otelhooks.NewTracesHook())
+	err := openfeature.SetProvider(flagd.NewProvider())
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	err := runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
+	err = runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -128,12 +128,10 @@ func main() {
 		}
 		log.Println("Shutdown meter provider")
 	}()
-	err := openfeature.SetProvider(flagd.NewProvider())
-	if err != nil {
-		log.Fatal(err)
-	}
+	openfeature.SetProvider(flagd.NewProvider())
+	openfeature.AddHooks(otelhooks.NewTracesHook())
 
-	err = runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
+	err := runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -300,7 +298,7 @@ func (p *productCatalog) checkProductFailure(ctx context.Context, id string) boo
 	if id != "OLJCESPC7Z" {
 		return false
 	}
-	openfeature.AddHooks(otelhooks.NewTracesHook())
+
 	client := openfeature.NewClient("productCatalog")
 	failureEnabled, _ := client.BooleanValue(
 		ctx, "productCatalogFailure", false, openfeature.EvaluationContext{},


### PR DESCRIPTION
# Changes

Move the feature flag hook registration to the main method. This prevents the hook from being registered on every request.

This change brings the `product-catalog-service` in line with the `checkout-service`.

https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/checkoutservice/main.go#L163-L164

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

Resolves: #1735 
