### PR TITLE
[chore] streamline opensearch healthcheck

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -657,7 +657,7 @@ services:
     ports:
       - "9200"
     healthcheck:
-      test: curl -s http://localhost:9200/_cluster/health | grep status | grep -q '\\(green\\|yellow\\)'
+      test: curl -s http://localhost:9200/_cluster/health | grep '"status":"green"'
       start_period: 10s
       interval: 5s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -768,7 +768,7 @@ services:
     ports:
       - "9200"
     healthcheck:
-      test: curl -s http://localhost:9200/_cluster/health | grep -q '"status":"green"'
+      test: curl -s http://localhost:9200/_cluster/health | grep '"status":"green"'
       start_period: 10s
       interval: 5s
       timeout: 10s


### PR DESCRIPTION
# Changes

`compose` and `compose.minimal` were different.
I've also validate it locally and with this test:
`curl -s http://localhost:9200/_cluster/health | grep status | grep -q '\\(green\\|yellow\\)'`
I was getting status `unhealthy` even though the `status:green` was there.