### PR TITLE
feat: propagate cartservice exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ the release.
   ([#1733](https://github.com/open-telemetry/opentelemetry-demo/pull/1733))
 * [flagd-ui] Add UI for managing Flagd feature flags
   ([#1725](https://github.com/open-telemetry/opentelemetry-demo/pull/1725))
+* [cartservice] Propagate GetCart exception
+  ([#1744](https://github.com/open-telemetry/opentelemetry-demo/pull/1744))
 
 ## 1.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ the release.
   ([#1733](https://github.com/open-telemetry/opentelemetry-demo/pull/1733))
 * [flagd-ui] Add UI for managing Flagd feature flags
   ([#1725](https://github.com/open-telemetry/opentelemetry-demo/pull/1725))
-* [cartservice] Propagate GetCart exception
+* [cartservice] Propagate cartservice exceptions
   ([#1744](https://github.com/open-telemetry/opentelemetry-demo/pull/1744))
 
 ## 1.11.1

--- a/src/cartservice/src/services/CartService.cs
+++ b/src/cartservice/src/services/CartService.cs
@@ -33,8 +33,18 @@ public class CartService : Oteldemo.CartService.CartServiceBase
         activity?.SetTag("app.product.id", request.Item.ProductId);
         activity?.SetTag("app.product.quantity", request.Item.Quantity);
 
-        await _cartStore.AddItemAsync(request.UserId, request.Item.ProductId, request.Item.Quantity);
-        return Empty;
+        try
+        {
+            await _cartStore.AddItemAsync(request.UserId, request.Item.ProductId, request.Item.Quantity);
+
+            return Empty;
+        }
+        catch (RpcException ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
     }
 
     public override async Task<Cart> GetCart(GetCartRequest request, ServerCallContext context)

--- a/src/cartservice/src/services/CartService.cs
+++ b/src/cartservice/src/services/CartService.cs
@@ -43,15 +43,24 @@ public class CartService : Oteldemo.CartService.CartServiceBase
         activity?.SetTag("app.user.id", request.UserId);
         activity?.AddEvent(new("Fetch cart"));
 
-        var cart = await _cartStore.GetCartAsync(request.UserId);
-        var totalCart = 0;
-        foreach (var item in cart.Items)
+        try
         {
-            totalCart += item.Quantity;
-        }
-        activity?.SetTag("app.cart.items.count", totalCart);
+            var cart = await _cartStore.GetCartAsync(request.UserId);
+            var totalCart = 0;
+            foreach (var item in cart.Items)
+            {
+                totalCart += item.Quantity;
+            }
+            activity?.SetTag("app.cart.items.count", totalCart);
 
-        return cart;
+            return cart;
+        }
+        catch (RpcException ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
     }
 
     public override async Task<Empty> EmptyCart(EmptyCartRequest request, ServerCallContext context)


### PR DESCRIPTION
# Changes

Propagate Grpc expections; the `EmptyCart` method already sets the error in the span, but these two other methods aren't. A common propagated error is when the service cannot establish a connection with the Valkey database.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
~~* [] Appropriate documentation updates in the [docs][]~~
~~* [ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
