### PR TITLE
Fix opensearch healthcheck

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -657,7 +657,7 @@ services:
     ports:
       - "9200"
     healthcheck:
-      test: curl -s http://localhost:9200/_cluster/health | grep '"status":"green"'
+      test: curl -s http://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
       start_period: 10s
       interval: 5s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -799,7 +799,7 @@ services:
     ports:
       - "9200"
     healthcheck:
-      test: curl -s http://localhost:9200/_cluster/health | grep '"status":"green"'
+      test: curl -s http://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
       start_period: 10s
       interval: 5s
       timeout: 10s


### PR DESCRIPTION
# Changes

It seems that opensearch stays in `yellow` state after initialising as green.
This adds `yellow` status back as a healthy option.
