### PR TITLE
[cartservice] Update cart service to fail when cartServiceFailure is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ the release.
   ([#1733](https://github.com/open-telemetry/opentelemetry-demo/pull/1733))
 * [flagd-ui] Add UI for managing Flagd feature flags
   ([#1725](https://github.com/open-telemetry/opentelemetry-demo/pull/1725))
+* [cartservice] Update cart service to fail when cartServiceFailure is enabled
+  ([#1748](https://github.com/open-telemetry/opentelemetry-demo/pull/1748))
 
 ## 1.11.1
 

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.302 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.403 AS builder
 ARG TARGETARCH
 
 WORKDIR /usr/src/app/
@@ -30,7 +30,7 @@ RUN dotnet publish ./src/cartservice.csproj -v d -r linux-musl-$TARGETARCH --no-
 # -----------------------------------------------------------------------------
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-alpine3.20
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.10-alpine3.20
 
 WORKDIR /usr/src/app/
 COPY --from=builder /cartservice/ ./

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -15,22 +15,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
-    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.63.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.66.0" />
+    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.66.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.15" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.7" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.8" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.2" />
-    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
-    <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.1.9" />
-    <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.1.4" />
-    <PackageReference Include="OpenFeature" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
+    <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
+    <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.0" />
+    <PackageReference Include="OpenFeature" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/src/services/CartService.cs
+++ b/src/cartservice/src/services/CartService.cs
@@ -62,8 +62,7 @@ public class CartService : Oteldemo.CartService.CartServiceBase
 
         try
         {
-            // Throw 1/10 of the time to simulate a failure when the feature flag is enabled
-            if (await _featureFlagHelper.GetBooleanValue("cartServiceFailure", false) && random.Next(10) == 0)
+            if (await _featureFlagHelper.GetBooleanValueAsync("cartServiceFailure", false))
             {
                 await _badCartStore.EmptyCartAsync(request.UserId);
             }


### PR DESCRIPTION
# Changes

This PR changes the behaviour of `cartServiceFailure`.
When enabled, the `emptyCart`will fail 100% of the calls.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs](https://github.com/open-telemetry/opentelemetry.io/pull/5444)
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
