### PR TITLE
[chore] use otel-linux-arm64 runners for trace testing

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: otel-linux-arm64
     name: "Run CI"
     if: github.event.review.state == 'APPROVED'
     steps:


### PR DESCRIPTION
It uses the `otel-linux-arm64` runners for the integration tests workflow. This prevents the error caused by running out of disk space when using the default GitHub runners.

There are other risks here, as these runners have less memory and run on ARM64 instead of AMD64, but they do offer much more disk space.