### PR TITLE
Added OTLP Access logs for the frontend proxy

### DIFF
--- a/src/frontendproxy/envoy.tmpl.yaml
+++ b/src/frontendproxy/envoy.tmpl.yaml
@@ -65,6 +65,97 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                access_log:
+                  - name: envoy.access_loggers.open_telemetry
+                    typed_config:
+                      "@type": "type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig"
+                      common_config: 
+                        log_name: "otel_envoy_accesslog"
+                        grpc_service: 
+                          envoy_grpc: 
+                            cluster_name: opentelemetry_collector_grpc
+                        transport_api_version: "V3"
+                      body:
+                        string_value: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
+                      resource_attributes:
+                        values:
+                          - key: "service.name"
+                            value: 
+                              string_value: "frontend-proxy"
+                          - key: "hostname"
+                            value: 
+                              string_value: "%HOSTNAME%"
+                      attributes:
+                        values:
+                        - key: "user_agent.original"
+                          value: 
+                            string_value: "%REQ(USER-AGENT)%"
+                        - key: "x_forwarded_for"
+                          value: 
+                            string_value: "%REQ(X-FORWARDED-FOR)%"
+                        - key: "x_request_id"
+                          value: 
+                            string_value: "%REQ(X-REQUEST-ID)%"
+                        - key: "http.request.start_time"
+                          value: 
+                            string_value: "%START_TIME%"
+                        - key: "server.address"
+                          value: 
+                            string_value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                        - key: "http.request.body_size"
+                          value: 
+                            string_value: "%BYTES_RECEIVED%"
+                        - key: "http.request.headers_size"
+                          value: 
+                            string_value: "%REQUEST_HEADERS_BYTES%"
+                        - key: "http.response.body_size"
+                          value: 
+                            string_value: "%BYTES_SENT%"
+                        - key: "http.response.headers_size"
+                          value: 
+                            string_value: "%RESPONSE_HEADERS_BYTES%"
+                        - key: "http.response.status_code"
+                          value: 
+                            string_value: "%RESPONSE_CODE%"
+                        - key: "http.total_duration"
+                          value: 
+                            string_value: "%DURATION%"
+                        - key: "url.template"
+                          value: 
+                            string_value: "%ROUTE_NAME%"
+                        - key: "upstream.host"
+                          value: 
+                            string_value: "%UPSTREAM_HOST%"
+                        - key: "upstream.cluster"
+                          value: 
+                            string_value: "%UPSTREAM_CLUSTER%"
+                        - key: "destination.address"
+                          value: 
+                            string_value: "%UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                        - key: "source.address"
+                          value: 
+                            string_value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                        - key: "http.protocol"
+                          value: 
+                            string_value: "%PROTOCOL%"
+                        - key: "http.connection_id"
+                          value: 
+                            string_value: "%CONNECTION_ID%"
+                        - key: "http.request.id"
+                          value: 
+                            string_value: "%STREAM_ID%"
+                        - key: "http.request.method"  
+                          value: 
+                            string_value: "%REQ(:METHOD)%"
+                        - key: "url.path"
+                          value: 
+                            string_value: "%REQ(:URL_PATH)%"
+                        - key: "url.query"
+                          value: 
+                            string_value: "%REQ(:QUERY)%"
+                        - key: "url.full"
+                          value: 
+                            string_value: "%REQ(:SCHEME)%://%REQ(:AUTHORITY)%%REQ(:PATH)%"
 
   clusters:
     - name: opentelemetry_collector_grpc


### PR DESCRIPTION
# Changes

This adds an `access_log` filter that sends Access Logs from the Frontend Proxy as logs to the collector.

I've tried to keep as close to the semantic conventions as I could for them. I've used Span/Trace semantics for things that made sense.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
