### PR TITLE
Fix frontend-proxy crashing when using start-minimal

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -272,6 +272,8 @@ services:
       - ENVOY_PORT
       - FLAGD_HOST
       - FLAGD_PORT
+      - FLAGD_UI_HOST
+      - FLAGD_UI_PORT
     depends_on:
       frontend:
         condition: service_started


### PR DESCRIPTION
# Changes

When using `make start-minimal` I was hitting an issue where the frontend-proxy container would start but then continually crash and restart with the following exception:
```
2024-11-06 17:03:02 [2024-11-06 22:03:02.686][8][critical][main] [source/server/server.cc:414] error initializing config '  envoy.yaml': Proto constraint validation failed (BootstrapValidationError.StaticResources: embedded message failed validation | caused by StaticResourcesValidationError.Clusters[5]: embedded message failed validation | caused by ClusterValidationError.LoadAssignment: embedded message failed validation | caused by ClusterLoadAssignmentValidationError.Endpoints[0]: embedded message failed validation | caused by LocalityLbEndpointsValidationError.LbEndpoints[0]: embedded message failed validation | caused by LbEndpointValidationError.Endpoint: embedded message failed validation | caused by EndpointValidationError.Address: embedded message failed validation | caused by AddressValidationError.SocketAddress: embedded message failed validation | caused by SocketAddressValidationError.Address: value length must be at least 1 characters): static_resources
```

But `make start` would be fine. Looking at the differences between the two it seemed to come down to the `FLAGD_UI_HOST` + `FLAGD_UI_PORT` env vars not being passed to the container in the minimal setup, when these are blank envoy complains because this block in `src/frontendproxy/envoy.tmpl.yaml` ends up rendering with invalid values:
```
    - name: flagdui
      type: STRICT_DNS
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: flagdui
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: ${FLAGD_UI_HOST}
                      port_value: ${FLAGD_UI_PORT}
```

Worth noting that a colleague of mine was able to run `make start-minimal` on their machine without issue, not really sure what would cause this to only happen in some environments since I would think everything is being isolated by the docker setup but it seemed safe to make this change in all cases especially since `FLAGD_HOST` + `FLAGD_PORT` were already being set for frontend-proxy in docker-compose.minimal.yml

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
