### PR TITLE
Remove Helios from demo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,18 @@ We welcome any vendor to fork the project to demonstrate their services and
 adding a link below. The community is committed to maintaining the project and
 keeping it up to date for you.
 
-|                                         |                             |                                                                |
-|-----------------------------------------|-----------------------------|----------------------------------------------------------------|
-| [AlibabaCloud LogService][AlibabaCloud] | [Elastic][Elastic]          | [New Relic][NewRelic]                                          |
-| [AppDynamics][AppDynamics]              | [Google Cloud][GoogleCloud] | [OpenSearch][OpenSearch]                                       |
-| [Aspecto][Aspecto]                      | [Grafana Labs][GrafanaLabs] | [Sentry][Sentry]                                               |
-| [Axiom][Axiom]                          | [Guance][Guance]            | [ServiceNow Cloud Observability][ServiceNowCloudObservability] |
-| [Axoflow][Axoflow]                      | [Helios][Helios]            | [Splunk][Splunk]                                               |
-| [Azure Data Explorer][Azure]            | [Honeycomb.io][Honeycombio] | [Sumo Logic][SumoLogic]                                        |
-| [Coralogix][Coralogix]                  | [Instana][Instana]          | [TelemetryHub][TelemetryHub]                                   |
-| [Dash0][Dash0]                          | [Kloudfuse][Kloudfuse]      | [Teletrace][Teletrace]                                         |
-| [Datadog][Datadog]                      | [Liatrio][Liatrio]          | [Tracetest][Tracetest]                                         |
-| [Dynatrace][Dynatrace]                  | [Logz.io][Logzio]           | [Uptrace][Uptrace]                                             |
+|                           |                |                                  |
+|---------------------------|----------------|----------------------------------|
+| [AlibabaCloud LogService] | [Elastic]      | [OpenSearch]                     |
+| [AppDynamics]             | [Google Cloud] | [Sentry]                         |
+| [Aspecto]                 | [Grafana Labs] | [ServiceNow Cloud Observability] |
+| [Axiom]                   | [Guance]       | [Splunk]                         |
+| [Axoflow]                 | [Honeycomb.io] | [Sumo Logic]                     |
+| [Azure Data Explorer]     | [Instana]      | [TelemetryHub]                   |
+| [Coralogix]               | [Kloudfuse]    | [Teletrace]                      |
+| [Dash0]                   | [Liatrio]      | [Tracetest]                      |
+| [Datadog]                 | [Logz.io]      | [Uptrace]                        |
+| [Dynatrace]               | [New Relic]    |                                  |
 
 ## Contributing
 
@@ -108,32 +108,31 @@ Emeritus:
 
 <!-- Links for Demos featuring the Astronomy Shop section -->
 
-[AlibabaCloud]: https://github.com/aliyun-sls/opentelemetry-demo
+[AlibabaCloud LogService]: https://github.com/aliyun-sls/opentelemetry-demo
 [AppDynamics]: https://www.appdynamics.com/blog/cloud/how-to-observe-opentelemetry-demo-app-in-appdynamics-cloud/
 [Aspecto]: https://github.com/aspecto-io/opentelemetry-demo
 [Axiom]: https://play.axiom.co/axiom-play-qf1k/dashboards/otel.traces.otel-demo-traces
 [Axoflow]: https://axoflow.com/opentelemetry-support-in-more-detail-in-axosyslog-and-syslog-ng/
-[Azure]: https://github.com/Azure/Azure-kusto-opentelemetry-demo
+[Azure Data Explorer]: https://github.com/Azure/Azure-kusto-opentelemetry-demo
 [Coralogix]: https://coralogix.com/blog/configure-otel-demo-send-telemetry-data-coralogix
 [Dash0]: https://github.com/dash0hq/opentelemetry-demo
 [Datadog]: https://docs.datadoghq.com/opentelemetry/guide/otel_demo_to_datadog
 [Dynatrace]: https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/
 [Elastic]: https://github.com/elastic/opentelemetry-demo
-[GoogleCloud]: https://github.com/GoogleCloudPlatform/opentelemetry-demo
-[GrafanaLabs]: https://github.com/grafana/opentelemetry-demo
+[Google Cloud]: https://github.com/GoogleCloudPlatform/opentelemetry-demo
+[Grafana Labs]: https://github.com/grafana/opentelemetry-demo
 [Guance]: https://github.com/GuanceCloud/opentelemetry-demo
-[Helios]: https://otelsandbox.gethelios.dev
-[Honeycombio]: https://github.com/honeycombio/opentelemetry-demo
+[Honeycomb.io]: https://github.com/honeycombio/opentelemetry-demo
 [Instana]: https://github.com/instana/opentelemetry-demo
 [Kloudfuse]: https://github.com/kloudfuse/opentelemetry-demo
 [Liatrio]: https://github.com/liatrio/opentelemetry-demo
-[Logzio]: https://logz.io/learn/how-to-run-opentelemetry-demo-with-logz-io/
-[NewRelic]: https://github.com/newrelic/opentelemetry-demo
+[Logz.io]: https://logz.io/learn/how-to-run-opentelemetry-demo-with-logz-io/
+[New Relic]: https://github.com/newrelic/opentelemetry-demo
 [OpenSearch]: https://github.com/opensearch-project/opentelemetry-demo
 [Sentry]: https://github.com/getsentry/opentelemetry-demo
-[ServiceNowCloudObservability]: https://docs.lightstep.com/otel/quick-start-operator#send-data-from-the-opentelemetry-demo
+[ServiceNow Cloud Observability]: https://docs.lightstep.com/otel/quick-start-operator#send-data-from-the-opentelemetry-demo
 [Splunk]: https://github.com/signalfx/opentelemetry-demo
-[SumoLogic]: https://www.sumologic.com/blog/common-opentelemetry-demo-application/
+[Sumo Logic]: https://www.sumologic.com/blog/common-opentelemetry-demo-application/
 [TelemetryHub]: https://github.com/TelemetryHub/opentelemetry-demo/tree/telemetryhub-backend
 [Teletrace]: https://github.com/teletrace/opentelemetry-demo
 [Tracetest]: https://github.com/kubeshop/opentelemetry-demo


### PR DESCRIPTION
# Changes

This PR remove the Helios link from the "Demos featuring the Astronomy Shop" section.
[Snyk acquired Helios](https://snyk.io/blog/welcoming-helios-to-snyk/) and the link to showcase the demo is not available anymore.
Snyk and the team are more than welcome to add a new link later on, but the broken link is making the `markdownlint` check to fail.

The PR also simplifies the table, just adding a reference for the link.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
