### PR TITLE
Fix RUNTIME_IDENTIFIER for accountingservice

### DIFF
--- a/src/accountingservice/Dockerfile
+++ b/src/accountingservice/Dockerfile
@@ -7,10 +7,10 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["/src/accountingservice/", "AccountingService/"]
 COPY ["/pb/demo.proto", "AccountingService/proto/"]
-RUN dotnet restore "./AccountingService/AccountingService.csproj" -r linux-musl-$TARGETARCH
+RUN dotnet restore "./AccountingService/AccountingService.csproj" -r linux-$TARGETARCH
 WORKDIR "/src/AccountingService"
 
-RUN dotnet build "./AccountingService.csproj" -r linux-musl-$TARGETARCH -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./AccountingService.csproj" -r linux-$TARGETARCH -c $BUILD_CONFIGURATION -o /app/build
 
 # -----------------------------------------------------------------------------
 

--- a/src/accountingservice/Dockerfile
+++ b/src/accountingservice/Dockerfile
@@ -15,8 +15,9 @@ RUN dotnet build "./AccountingService.csproj" -r linux-$TARGETARCH -c $BUILD_CON
 # -----------------------------------------------------------------------------
 
 FROM builder AS publish
+ARG TARGETARCH
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./AccountingService.csproj" --use-current-runtime -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./AccountingService.csproj" -r linux-$TARGETARCH -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # -----------------------------------------------------------------------------
 

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /usr/src/app/
 COPY ./src/cartservice/ ./
 COPY ./pb/ ./pb/
 
-RUN dotnet restore ./src/cartservice.csproj -r linux-musl-$TARGETARCH
+RUN dotnet restore ./src/cartservice.csproj -r linux-$TARGETARCH
 
-RUN dotnet publish ./src/cartservice.csproj -r linux-musl-$TARGETARCH --no-restore -o /cartservice
+RUN dotnet publish ./src/cartservice.csproj -r linux-$TARGETARCH --no-restore -o /cartservice
 
 # -----------------------------------------------------------------------------
 

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /usr/src/app/
 COPY ./src/cartservice/ ./
 COPY ./pb/ ./pb/
 
-RUN dotnet restore ./src/cartservice.csproj -r linux-$TARGETARCH
+RUN dotnet restore ./src/cartservice.csproj -r linux-musl-$TARGETARCH
 
-RUN dotnet publish ./src/cartservice.csproj -r linux-$TARGETARCH --no-restore -o /cartservice
+RUN dotnet publish ./src/cartservice.csproj -r linux-musl-$TARGETARCH --no-restore -o /cartservice
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
# Changes

Fix #1798 - the issue is that the .NET Docker images are Debian based, however, the runtime identifier (RID) passed on the build step is targeting `musl` based distros, e.g.: Alpine. Fixing the RID avoids the error mentioned on #1798. 
