### PR TITLE
Fix tag_suffix for accounting service

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         file_tag:
           - file: ./src/accounting/Dockerfile
-            tag_suffix: accounting
+            tag_suffix: accountingservice
             context: ./
             setup-qemu: true
           - file: ./src/adservice/Dockerfile


### PR DESCRIPTION
The Helm chart generates a kubernetes manifest that expects the suffix of the account service's image to be `accountingservice`.

https://github.com/open-telemetry/opentelemetry-demo/blob/fa7847efb691e323236955c6126d486cf2c1b558/kubernetes/opentelemetry-demo.yaml#L9533-L9535

Few options to fix this:

1. This PR
2. Fix the Helm chart to use the new name
3. Others?

I'd be happy to follow up on whatever solution people would prefer.

~~If people like the solution in this PR, I think it would also make sense to change the directory name and all contained files back to `accountingservice` for consistency - e.g., `/src/accounting` becomes `/src/accountingservice`. Thoughts?~~

I see now that there is an effort to remove the term `service` from the names of the services in #1788. I recommend leaving the tag_suffix for services untouched for now.