### PR TITLE
[chore] - update demo dependencies

### DIFF
--- a/.env
+++ b/.env
@@ -7,18 +7,18 @@ DEMO_VERSION=latest
 
 # Build Args
 TRACETEST_IMAGE_VERSION=v1.7.1
-OTEL_JAVA_AGENT_VERSION=2.9.0
-OPENTELEMETRY_CPP_VERSION=1.17.0
+OTEL_JAVA_AGENT_VERSION=2.10.0
+OPENTELEMETRY_CPP_VERSION=1.18.0
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=otel/opentelemetry-collector-contrib:0.113.0
-FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.11.4
-GRAFANA_IMAGE=grafana/grafana:11.3.0
-JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.62.0
+COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.116.1
+FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.11.5
+GRAFANA_IMAGE=grafana/grafana:11.4.0
+JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.64.0
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
 OPENSEARCH_IMAGE=opensearchproject/opensearch:2.18.0
-POSTGRES_IMAGE=postgres:17.0
-PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v2.55.1
+POSTGRES_IMAGE=postgres:17.2
+PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.0.1
 VALKEY_IMAGE=valkey/valkey:8.0-alpine
 TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ the release.
   ([#1842](https://github.com/open-telemetry/opentelemetry-demo/pull/1842))
 * [react-native-app] Add React Native example app
   ([#1781](https://github.com/open-telemetry/opentelemetry-demo/pull/1781))
+* [chore] Update demo Dependencies (Collector, Grafana, FlagD, Jaeger, Prometheus)
+  ([#1855](https://github.com/open-telemetry/opentelemetry-demo/pull/1855))
 
 ## 1.12.0
 

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -624,8 +624,8 @@ services:
       - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
+      - --web.enable-otlp-receiver
       - --enable-feature=exemplar-storage
-      - --enable-feature=otlp-write-receiver
     volumes:
       - ./src/prometheus/prometheus-config.yaml:/etc/prometheus/prometheus-config.yaml
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -768,8 +768,8 @@ services:
       - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
+      - --web.enable-otlp-receiver
       - --enable-feature=exemplar-storage
-      - --enable-feature=otlp-write-receiver
     volumes:
       - ./src/prometheus/prometheus-config.yaml:/etc/prometheus/prometheus-config.yaml
     deploy:

--- a/src/prometheus/prometheus-config.yaml
+++ b/src/prometheus/prometheus-config.yaml
@@ -2,13 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 global:
-  evaluation_interval: 30s
   scrape_interval: 5s
+  scrape_timeout: 3s
+  evaluation_interval: 30s
+
+otlp:
+  promote_resource_attributes:
+    - service.instance.id
+    - service.name
+    - service.namespace
+    - cloud.availability_zone
+    - cloud.region
+    - container.name
+    - deployment.environment.name
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets:
+          - 'otel-collector:8888'
+
 storage:
   tsdb:
     out_of_order_time_window: 30m
-scrape_configs:
-- job_name: otel-collector
-  static_configs:
-  - targets:
-    - 'otel-collector:8888'


### PR DESCRIPTION
# Changes

Update demo dependencies. The big change here is to Prometheus 3.x, which includes standard support for OTLP ingest.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
