### PR TITLE
[chore] remove -service and _service suffixes

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -54,7 +54,7 @@ services:
   # Cart service
   cart:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-cart
-    container_name: cart-service
+    container_name: cart
     build:
       context: ./
       dockerfile: ${CART_DOCKERFILE}
@@ -131,7 +131,7 @@ services:
   # Currency service
   currency:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-currency
-    container_name: currency-service
+    container_name: currency
     build:
       context: ./
       dockerfile: ${CURRENCY_DOCKERFILE}
@@ -159,7 +159,7 @@ services:
   # Email service
   email:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-email
-    container_name: email-service
+    container_name: email
     build:
       context: ./src/email
       cache_from:
@@ -355,7 +355,7 @@ services:
   # Payment service
   payment:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-payment
-    container_name: payment-service
+    container_name: payment
     build:
       context: ./
       dockerfile: ${PAYMENT_DOCKERFILE}
@@ -411,7 +411,7 @@ services:
   # Quote service
   quote:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-quote
-    container_name: quote-service
+    container_name: quote
     build:
       context: ./
       dockerfile: ${QUOTE_DOCKERFILE}
@@ -439,7 +439,7 @@ services:
   # Recommendation service
   recommendation:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-recommendation
-    container_name: recommendation-service
+    container_name: recommendation
     build:
       context: ./
       dockerfile: ${RECOMMENDATION_DOCKERFILE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
   # Cart service
   cart:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-cart
-    container_name: cart-service
+    container_name: cart
     build:
       context: ./
       dockerfile: ${CART_DOCKERFILE}
@@ -169,7 +169,7 @@ services:
   # Currency service
   currency:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-currency
-    container_name: currency-service
+    container_name: currency
     build:
       context: ./
       dockerfile: ${CURRENCY_DOCKERFILE}
@@ -197,7 +197,7 @@ services:
   # Email service
   email:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-email
-    container_name: email-service
+    container_name: email
     build:
       context: ./
       dockerfile: ${EMAIL_DOCKERFILE}
@@ -431,7 +431,7 @@ services:
   # Payment service
   payment:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-payment
-    container_name: payment-service
+    container_name: payment
     build:
       context: ./
       dockerfile: ${PAYMENT_DOCKERFILE}
@@ -493,7 +493,7 @@ services:
   # Quote service
   quote:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-quote
-    container_name: quote-service
+    container_name: quote
     build:
       context: ./
       dockerfile: ${QUOTE_DOCKERFILE}
@@ -521,7 +521,7 @@ services:
   # Recommendation service
   recommendation:
     image: ${IMAGE_NAME}:${DEMO_VERSION}-recommendation
-    container_name: recommendation-service
+    container_name: recommendation
     build:
       context: ./
       dockerfile: ${RECOMMENDATION_DOCKERFILE}

--- a/src/ad/Dockerfile
+++ b/src/ad/Dockerfile
@@ -32,4 +32,4 @@ ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumenta
 ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
 
 EXPOSE ${AD_PORT}
-ENTRYPOINT [ "./build/install/opentelemetry-demo-ad-service/bin/Ad" ]
+ENTRYPOINT [ "./build/install/opentelemetry-demo-ad/bin/Ad" ]

--- a/src/ad/README.md
+++ b/src/ad/README.md
@@ -21,7 +21,7 @@ To run the Ad Service:
 ```sh
 export AD_PORT=8080
 export FEATURE_FLAG_GRPC_SERVICE_ADDR=featureflagservice:50053
-./build/install/opentelemetry-demo-ad-service/bin/Ad
+./build/install/opentelemetry-demo-ad/bin/Ad
 ```
 
 ### Upgrading Gradle

--- a/src/ad/settings.gradle
+++ b/src/ad/settings.gradle
@@ -1,2 +1,2 @@
 
-rootProject.name = 'opentelemetry-demo-ad-service'
+rootProject.name = 'opentelemetry-demo-ad'

--- a/src/currency/CMakeLists.txt
+++ b/src/currency/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(currency-service)
+project(currency)
 
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG REQUIRED)

--- a/test/README.md
+++ b/test/README.md
@@ -25,9 +25,9 @@ make run-tracetesting SERVICES_TO_TEST="service-1 service-2 ..."
 docker compose run traceBasedTests "service-1 service-2 ..."
 ```
 
-For instance, if you need to run the tests for `ad-service` and
-`payment-service`, you can run them with:
+For instance, if you need to run the tests for `ad` and `payment`, you can run
+them with:
 
 ```sh
-make run-tracetesting SERVICES_TO_TEST="ad-service payment-service"
+make run-tracetesting SERVICES_TO_TEST="ad payment"
 ```

--- a/test/tracetesting/ad/all.yaml
+++ b/test/tracetesting/ad/all.yaml
@@ -3,7 +3,7 @@
 
 type: TestSuite
 spec:
-  id: ad-service-all
+  id: ad-all
   name: 'Ad Service'
   description: Run all Ad Service tests enabled in sequence
   steps:

--- a/test/tracetesting/currency/all.yaml
+++ b/test/tracetesting/currency/all.yaml
@@ -3,7 +3,7 @@
 
 type: TestSuite
 spec:
-  id: currency-service-all
+  id: currency-all
   name: 'Currency Service'
   description: Run all Currency Service tests enabled in sequence
   steps:

--- a/test/tracetesting/recommendation/all.yaml
+++ b/test/tracetesting/recommendation/all.yaml
@@ -3,7 +3,7 @@
 
 type: TestSuite
 spec:
-  id: recommendation-service-all
+  id: recommendation-all
   name: 'Recommendation Service'
   description: Run all Recommendation Service tests enabled in sequence
   steps:

--- a/test/tracetesting/run.bash
+++ b/test/tracetesting/run.bash
@@ -54,8 +54,8 @@ spec:
       value: $RECOMMENDATION_ADDR
     - key: SHIPPING_ADDR
       value: $SHIPPING_ADDR
-    - key: KAFKA_SERVICE_ADDR
-      value: $KAFKA_SERVICE_ADDR
+    - key: KAFKA_ADDR
+      value: $KAFKA_ADDR
 EOF
 }
 

--- a/test/tracetesting/shipping/all.yaml
+++ b/test/tracetesting/shipping/all.yaml
@@ -3,7 +3,7 @@
 
 type: TestSuite
 spec:
-  id: shipping-service-all
+  id: shipping-all
   name: 'Shipping Service'
   description: Run all Shipping Service tests enabled in sequence
   steps:


### PR DESCRIPTION
# Changes

This is the last piece needed to close out #1788 

removes the `-service` suffix from containers in docker-compose
removes the `-service` suffix from some containers in the trace test suite
removes `_SERVICE` from some environment variables used in the trace test suite

After these changes I ran `make run-tracetesting` and all tests completed successfully.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
