### PR TITLE
[chore] Remove docker from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,6 @@ updates:
         dependency-type: "production"
     schedule:
       interval: "daily"
-  - package-ecosystem: "docker"
-    directories:
-      - "/src/**/*"
-    groups:
-      docker-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "gomod"
     directories:
       - "/src/**/*"


### PR DESCRIPTION
# Changes

Dependabot PRs on docker are bumping versions to latest instead of LTS versions:
https://github.com/open-telemetry/opentelemetry-demo/pull/1900

There are a couple of issues asking for this feature on dependabot repo, but this doesn't seem to get any attention from the community: 
- https://github.com/dependabot/dependabot-core/issues/2247
- https://github.com/dependabot/dependabot-core/issues/2651

Dependabot can be configured to bump major, minor or patch version, but excluding major updates is not the same as updating just to LTS.