### PR TITLE
[chore] specify npm folders to avoid reactive native updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,9 @@ updates:
       interval: "daily"
   - package-ecosystem: "npm"
     directories:
-      - "/src/**/*"
+      - "/src/flagd-ui/*"
+      - "/src/frontend/*"
+      - "/src/payment/*"
     groups:
       npm-production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
# Changes

This PR specify the js and typescript folders, to avoid `**/*` bumps, which were bumping react-native deps and breaking the service.
