### PR TITLE
[accounting] Bump OTel .NET Auto to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ the release.
   ([#1936](https://github.com/open-telemetry/opentelemetry-demo/pull/1936))
 * [chore] Generate protobuf code for Typescript service - Frontend
   ([#1954](https://github.com/open-telemetry/opentelemetry-demo/pull/1954))
+* [accounting] bump OpenTelemetry .NET Automatic Instrumentation to 1.10.0
+  ([#1998](https://github.com/open-telemetry/opentelemetry-demo/pull/1998))
 
 ## 1.12.0
 

--- a/src/accounting/Accounting.csproj
+++ b/src/accounting/Accounting.csproj
@@ -17,7 +17,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Changes

[accounting] Bump OTel .NET Auto to 1.10.0 - https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.10.0

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* ~~[ ] Appropriate documentation updates in the [docs][]~~ N/A
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~ N/A 

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
