### PR TITLE
[chore] frontend: update Dockerfile to reduce final image size by 15%

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,22 +1,29 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:22-alpine AS deps
+FROM node:22-alpine AS builder
 RUN apk add --no-cache libc6-compat
+
+USER node
 
 WORKDIR /app
 
 COPY ./src/frontend/package*.json ./
-RUN npm ci
-
-FROM node:22-alpine AS builder
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+RUN npm clean-install --no-audit --no-progress
 COPY ./src/frontend/protos ./protos
 COPY ./src/frontend .
 
 RUN npm run build
+
+FROM node:22-alpine AS deps
+
+USER node
+
+WORKDIR /app
+COPY --chown=node:node --from=builder /home/node/.npm/ /home/node/.npm/
+COPY ./src/frontend/package*.json ./
+RUN NODE_ENV=production npm clean-install --prefer-offline --no-audit --no-progress
+
 
 FROM node:22-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
# Changes

Currently, all the dev dependencies are included in the final image.

Reworking the first two stages, we can reduce the final image by ~15%

```
╰─➤  docker images otel-demo-frontend
REPOSITORY           TAG       IMAGE ID       CREATED          SIZE
otel-demo-frontend   fix       0a53d5f0fdcc   14 minutes ago   707MB
otel-demo-frontend   orig      a863b800e2ab   19 minutes ago   823MB
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
