### PR TITLE
[chore] [cart] Bump not-stable dotnet-contrib packages

### DIFF
--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -20,13 +20,13 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.10.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.10.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.11.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.11.0-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
     <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.0" />


### PR DESCRIPTION
# Changes

[cart] Bump not-stable dotnet-contrib packages

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~ N/A, it is not handled by dependabot for some reasons. I would skip it as in dependabot PRs.
* ~~[ ] Appropriate documentation updates in the [docs][]~~ N/A
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~ N/A

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
