### PR TITLE
[chore] clarify new release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,6 @@ Maintainers can create a new release when desired by following these steps.
    Demo's Kubernetes manifest by running `make generate-kubernetes-manifests`
    and committing the changes.
 
-
 [docs]: https://opentelemetry.io/docs/demo/
 
 By following this guide, you'll have a smoother onboarding experience as a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,20 +286,24 @@ make build-multiplatform-and-push
 
 Maintainers can create a new release when desired by following these steps.
 
-- [Create a new
-  release](https://github.com/open-telemetry/opentelemetry-demo/releases/new),
-  creating a new tag in the format `x.x.x` based on main. Automatically generate
-  release notes. Prepend a summary of the major changes to the release notes.
-- After images for the new release are built and published, create a new Pull
-  Request that updates the `IMAGE_VERSION` environment variable in `.env` to the
-  _new_ version number, and update the `CHANGELOG.md` with the new version
-  leaving the `Unreleased` section for the next release.
-- Create a new Pull Request to update the deployment of the demo in the
-  [OpenTelemetry Helm
-  Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo.
-- After the Helm chart is released, create a new Pull Request which updates the
-  Demo's Kubernetes manifest by running `make generate-kubernetes-manifests` and
-  committing the changes.
+1. Create a Pull Request that updates the `IMAGE_VERSION` environment variable
+   in `.env` to the _new_ version number based on the format `x.x.x` and merge
+   it.
+2. [Create a new
+   release](https://github.com/open-telemetry/opentelemetry-demo/releases/new),
+   creating a new tag for the _new_ version number based on main. Automatically
+   generate release notes. Prepend a summary of the major changes to the release
+   notes.
+3. After images for the new release are built and published, create a new Pull
+   Request that updates the `CHANGELOG.md` with the new version leaving the
+   `Unreleased` section for the next release.
+4. Create a new Pull Request to update the deployment of the demo in the
+   [OpenTelemetry Helm
+   Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo.
+5. After the Helm chart is released, create a new Pull Request which updates the
+   Demo's Kubernetes manifest by running `make generate-kubernetes-manifests`
+   and committing the changes.
+
 
 [docs]: https://opentelemetry.io/docs/demo/
 


### PR DESCRIPTION
Update the .env file before making a release. This way, when the new tag is added, the proper version will be included in the .env file. This allows people to cleanly pull a specific demo release and build against it as expected.

The downside is that if someone pulls from the main and tries to do a build after step 1 is complete but before step 2 is complete, they may have issues.