### PR TITLE
[chore] adds a clean-images Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,17 @@ build-multiplatform-and-push:
     # Because buildx bake does not support --env-file yet, we need to load it into the environment first.
 	set -a; . ./.env.override; set +a && docker buildx bake -f docker-compose.yml --push --set "*.platform=linux/amd64,linux/arm64"
 
+.PHONY: clean-images
+clean-images:
+	@docker rmi $(shell docker images --filter=reference="ghcr.io/open-telemetry/demo:latest-*" -q); \
+    if [ $$? -ne 0 ]; \
+    then \
+    	echo; \
+        echo "Failed to removed 1 or more OpenTelemetry Demo images."; \
+        echo "Check to ensure the Demo is not running by executing: make stop"; \
+        false; \
+    fi
+
 .PHONY: run-tests
 run-tests:
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose-tests.yml run frontendTests


### PR DESCRIPTION
# Changes

It adds a `clean-images` target, removing all demo images only. This is much less impactful to someone's system than running `docker system prune—a` when you are having issues with image cache.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
