### PR TITLE
[frontend] update browser tracer provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ the release.
   ([#2072](https://github.com/open-telemetry/opentelemetry-demo/pull/2072))
 * [grafana] Update dashboards with service map
   ([#2085](https://github.com/open-telemetry/opentelemetry-demo/pull/2085))
+* [frontend] Update OpenTelemetry Browser SDK initialization
+  ([#2092](https://github.com/open-telemetry/opentelemetry-demo/pull/2092))
 
 ## 2.0.0
 

--- a/src/frontend/utils/telemetry/FrontendTracer.ts
+++ b/src/frontend/utils/telemetry/FrontendTracer.ts
@@ -7,11 +7,10 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { Resource, browserDetector } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SessionIdProcessor } from './SessionIdProcessor';
 import { detectResourcesSync } from '@opentelemetry/resources/build/src/detect-resources';
-import { ZoneContextManager } from '@opentelemetry/context-zone';
 
 const {
   NEXT_PUBLIC_OTEL_SERVICE_NAME = '',
@@ -19,34 +18,38 @@ const {
   IS_SYNTHETIC_REQUEST = '',
 } = typeof window !== 'undefined' ? window.ENV : {};
 
-const FrontendTracer = () => {
-  let resource = new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: NEXT_PUBLIC_OTEL_SERVICE_NAME,
-  });
+const FrontendTracer = async () => {
+  const { ZoneContextManager } = await import('@opentelemetry/context-zone');
 
+  let resource = new Resource({
+    [SEMRESATTRS_SERVICE_NAME]: NEXT_PUBLIC_OTEL_SERVICE_NAME,
+  });
   const detectedResources = detectResourcesSync({ detectors: [browserDetector] });
   resource = resource.merge(detectedResources);
-  const provider = new WebTracerProvider({ resource });
 
-  provider.addSpanProcessor(new SessionIdProcessor());
-
-  provider.addSpanProcessor(
-    new BatchSpanProcessor(
-      new OTLPTraceExporter({
-        url: NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || 'http://localhost:4318/v1/traces',
-      }),
-      {
-        scheduledDelayMillis: 500,
-      }
-    )
-  );
+  const provider = new WebTracerProvider({
+    resource,
+    spanProcessors: [
+      new SessionIdProcessor(),
+      new BatchSpanProcessor(
+        new OTLPTraceExporter({
+          url: NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || 'http://localhost:4318/v1/traces',
+        }),
+        {
+          scheduledDelayMillis: 500,
+        }
+      ),
+    ],
+  });
 
   const contextManager = new ZoneContextManager();
 
   provider.register({
     contextManager,
     propagator: new CompositePropagator({
-      propagators: [new W3CBaggagePropagator(), new W3CTraceContextPropagator()],
+      propagators: [
+        new W3CBaggagePropagator(),
+        new W3CTraceContextPropagator()],
     }),
   });
 


### PR DESCRIPTION
# Changes

Fixes #2080 

Updates code to use updated semantic convention constant and use the `spanProcessors` option of the tracer provider, moving away from deprecated calls.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
