### PR TITLE
[chore] update release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,13 +296,16 @@ Maintainers can create a new release when desired by following these steps.
    notes.
 3. After images for the new release are built and published, create a new Pull
    Request that updates the `CHANGELOG.md` with the new version leaving the
-   `Unreleased` section for the next release.
+   `Unreleased` section for the next release. Merge the Pull Request.
 4. Create a new Pull Request to update the deployment of the demo in the
    [OpenTelemetry Helm
-   Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo.
+   Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo. Merge the Pull Request.
 5. After the Helm chart is released, create a new Pull Request which updates the
-   Demo's Kubernetes manifest by running `make generate-kubernetes-manifests`
-   and committing the changes.
+   Demo's Kubernetes manifest by running `make generate-kubernetes-manifests`.
+   Merge the Pull Request.
+6. Create a new Tag for the _new_ version with a suffix of `-k8s`. This tag
+   will be used to deploy the new version of the demo to Kubernetes using the 
+   supplied manifests.
 
 [docs]: https://opentelemetry.io/docs/demo/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,12 +299,13 @@ Maintainers can create a new release when desired by following these steps.
    `Unreleased` section for the next release. Merge the Pull Request.
 4. Create a new Pull Request to update the deployment of the demo in the
    [OpenTelemetry Helm
-   Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo. Merge the Pull Request.
+   Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo.
+   Merge the Pull Request.
 5. After the Helm chart is released, create a new Pull Request which updates the
    Demo's Kubernetes manifest by running `make generate-kubernetes-manifests`.
    Merge the Pull Request.
 6. Create a new Tag for the _new_ version with a suffix of `-k8s`. This tag
-   will be used to deploy the new version of the demo to Kubernetes using the 
+   will be used to deploy the new version of the demo to Kubernetes using the
    supplied manifests.
 
 [docs]: https://opentelemetry.io/docs/demo/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ keeping it up to date for you.
 
 To get involved with the project see our [CONTRIBUTING](CONTRIBUTING.md)
 documentation. Our [SIG Calls](CONTRIBUTING.md#join-a-sig-call) are every other
-Monday at 8:30 AM PST and anyone is welcome.
+Wednesday at 8:30 AM PST and anyone is welcome.
 
 ## Project leadership
 


### PR DESCRIPTION
# Changes

Updates the release process to add a final step: creating a tag with a `-k8s` suffix. This tag will contain Kubernetes manifests for the given release that are not part of the primary release's tag/branch.