### PR TITLE
[load-generator] optimize build

### DIFF
--- a/src/load-generator/Dockerfile
+++ b/src/load-generator/Dockerfile
@@ -15,8 +15,8 @@ RUN pip install --prefix="/reqs" -r requirements.txt
 FROM base
 WORKDIR /usr/src/app/
 COPY --from=builder /reqs /usr/local
-COPY ./src/load-generator/locustfile.py .
-COPY ./src/load-generator/people.json .
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install --with-deps chromium
+COPY ./src/load-generator/locustfile.py .
+COPY ./src/load-generator/people.json .
 ENTRYPOINT ["locust", "--skip-log-setup"]


### PR DESCRIPTION
# Changes

Re-orders some build steps so Playwright is included before local code is copied. This allows docker to leverage cache for Playwright to perform faster builds between code changes.
