### PR TITLE
[quote] Updated open-telemetry/exporter-otlp to 1.2.1 which includes the fix for IS_REMOTE flag feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ the release.
 
 ## Unreleased
 
-* [quote] Updated open-telemetry/exporter-otlp to 1.2.1 which includes the fix for IS_REMOTE flag feature
-  ([#2112](https://github.com/open-telemetry/opentelemetry-demo/pull/2112))
 * [frontend] Update OpenTelemetry Browser SDK initialization
   ([#2092](https://github.com/open-telemetry/opentelemetry-demo/pull/2092))
+* [quote] Updated open-telemetry/exporter-otlp to 1.2.1 which includes the
+  fix for `IS_REMOTE` flag feature
+  ([#2112](https://github.com/open-telemetry/opentelemetry-demo/pull/2112))
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [quote] Updated open-telemetry/exporter-otlp to 1.2.1 which includes the fix for IS_REMOTE flag feature
+  ([#2112](https://github.com/open-telemetry/opentelemetry-demo/pull/2112))
 * [frontend] Update OpenTelemetry Browser SDK initialization
   ([#2092](https://github.com/open-telemetry/opentelemetry-demo/pull/2092))
 

--- a/src/quote/composer.json
+++ b/src/quote/composer.json
@@ -9,7 +9,7 @@
         "monolog/monolog": "3.8.1",
         "open-telemetry/api": "1.2.2",
         "open-telemetry/sdk": "1.2.2",
-        "open-telemetry/exporter-otlp": "1.2.0",
+        "open-telemetry/exporter-otlp": "1.2.1",
         "open-telemetry/opentelemetry-auto-slim": "1.0.7",
         "open-telemetry/detector-container": "1.0.0",
         "open-telemetry/opentelemetry-logger-monolog": "1.0.0",


### PR DESCRIPTION
Updated open-telemetry/exporter-otlp to 1.2.1 for PHP quote service (1.2.1 include fix for IS_REMOTE flag feature)

# Changes

Updated open-telemetry/exporter-otlp to 1.2.1 for PHP quote service (1.2.1 include fix for IS_REMOTE flag feature - https://github.com/open-telemetry/opentelemetry-php/pull/1522)

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* N/A - [ ] Appropriate documentation updates in the [docs][]
* N/A - [ ] Appropriate Helm chart updates in the [helm-charts][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
