### PR TITLE
Ensure we handle the scenario the payment service code expects there to be an active span

### DIFF
--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -16,6 +16,8 @@ async function chargeServiceHandler(call, callback) {
   if (!span)
   {
     span = tracer.startSpan('chargeServiceHandler');
+    // Mark this new span as active
+    tracer.setSpan(tracer.context.active(), span)
     startedSpan = true;
   }
 

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -4,12 +4,20 @@ const grpc = require('@grpc/grpc-js')
 const protoLoader = require('@grpc/proto-loader')
 const health = require('grpc-js-health-check')
 const opentelemetry = require('@opentelemetry/api')
+const tracer = opentelemetry.trace.getTracer(process.env.OTEL_SERVICE_NAME);
 
 const charge = require('./charge')
 const logger = require('./logger')
 
 async function chargeServiceHandler(call, callback) {
-  const span = opentelemetry.trace.getActiveSpan();
+  // Check if we have an active span if not start a new one
+  let span = opentelemetry.trace.getActiveSpan();
+  let startedSpan = false;
+  if (!span)
+  {
+    span = tracer.startSpan('chargeServiceHandler');
+    startedSpan = true;
+  }
 
   try {
     const amount = call.request.amount
@@ -26,7 +34,10 @@ async function chargeServiceHandler(call, callback) {
 
     span.recordException(err)
     span.setStatus({ code: opentelemetry.SpanStatusCode.ERROR })
-
+    // Make sure we cleanup by closing the span if we started it.
+    if (startedSpan) {
+      span.end();
+    }
     callback(err)
   }
 }


### PR DESCRIPTION
I am proposing a very minor change to handle when auto-instrumentation is disabled( similar to #2124 ) for the payment service. In this scenario, an exception is raised but I would expect it to be handled gracefully.

# Changes

Added some very simple logic to check if the current active span is undefined, if it is we create a new span & mark this as the active span. 

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
