### PR TITLE
[cartservice] Record seconds instead of ticks for custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ the release.
   ([#2114](https://github.com/open-telemetry/opentelemetry-demo/pull/2114))
 * [flagd-ui] increase memory to 100MB
   ([#2120](https://github.com/open-telemetry/opentelemetry-demo/pull/2120))
+* [cartservice] change custom metrics to use seconds
+  ([#2135](https://github.com/open-telemetry/opentelemetry-demo/pull/2135))
 
 ## 2.0.1
 

--- a/src/cart/src/cartstore/ValkeyCartStore.cs
+++ b/src/cart/src/cartstore/ValkeyCartStore.cs
@@ -32,14 +32,14 @@ public class ValkeyCartStore : ICartStore
         unit: "s",
         advice: new InstrumentAdvice<double>
         {
-            HistogramBucketBoundaries = [ 500000, 600000, 700000, 800000, 900000, 1000000, 1100000 ]
+            HistogramBucketBoundaries = [ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]
         });
     private static readonly Histogram<double> getCartHistogram = CartMeter.CreateHistogram(
         "app.cart.get_cart.latency",
         unit: "s",
         advice: new InstrumentAdvice<double>
         {
-            HistogramBucketBoundaries = [ 300000, 400000, 500000, 600000, 700000, 800000, 900000 ]
+            HistogramBucketBoundaries = [ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]
         });
     private readonly ConfigurationOptions _redisConnectionOptions;
 

--- a/src/cart/src/cartstore/ValkeyCartStore.cs
+++ b/src/cart/src/cartstore/ValkeyCartStore.cs
@@ -27,15 +27,17 @@ public class ValkeyCartStore : ICartStore
 
     private static readonly ActivitySource CartActivitySource = new("OpenTelemetry.Demo.Cart");
     private static readonly Meter CartMeter = new Meter("OpenTelemetry.Demo.Cart");
-    private static readonly Histogram<long> addItemHistogram = CartMeter.CreateHistogram<long>(
+    private static readonly Histogram<double> addItemHistogram = CartMeter.CreateHistogram(
         "app.cart.add_item.latency",
-        advice: new InstrumentAdvice<long>
+        unit: "s",
+        advice: new InstrumentAdvice<double>
         {
             HistogramBucketBoundaries = [ 500000, 600000, 700000, 800000, 900000, 1000000, 1100000 ]
         });
-    private static readonly Histogram<long> getCartHistogram = CartMeter.CreateHistogram<long>(
+    private static readonly Histogram<double> getCartHistogram = CartMeter.CreateHistogram(
         "app.cart.get_cart.latency",
-        advice: new InstrumentAdvice<long>
+        unit: "s",
+        advice: new InstrumentAdvice<double>
         {
             HistogramBucketBoundaries = [ 300000, 400000, 500000, 600000, 700000, 800000, 900000 ]
         });
@@ -165,7 +167,7 @@ public class ValkeyCartStore : ICartStore
         }
         finally
         {
-            addItemHistogram.Record(stopwatch.ElapsedTicks);
+            addItemHistogram.Record(stopwatch.Elapsed.TotalSeconds);
         }
     }
 
@@ -216,7 +218,7 @@ public class ValkeyCartStore : ICartStore
         }
         finally
         {
-            getCartHistogram.Record(stopwatch.ElapsedTicks);
+            getCartHistogram.Record(stopwatch.Elapsed.TotalSeconds);
         }
     }
 


### PR DESCRIPTION
# Changes

Change custom app metrics from ticks to seconds and adds units for metrics.

[Per the .NET docs, `ElapsedTicks`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch.elapsedticks?view=net-9.0#remarks):

> ... represents the number of elapsed ticks in the underlying timer mechanism. A tick is the smallest unit of time that the Stopwatch timer can measure. Use the Frequency field to convert the ElapsedTicks value into a number of seconds.

Uses same bucket boundaries as [http.server.request.duration](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration) and [messaging.client.operation.duration](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/#metric-messagingclientoperationduration) - happy to change this, seemed like a reasonable default.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
