### PR TITLE
Adds SigNoz as a observability backend to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ keeping it up to date for you.
 
 |                           |                |                                  |
 |---------------------------|----------------|----------------------------------|
-| [AlibabaCloud LogService] | [Google Cloud] | [Oracle]                         |
-| [AppDynamics]             | [Grafana Labs] | [Sentry]                         |
-| [Aspecto]                 | [Guance]       | [ServiceNow Cloud Observability] |                       
-| [Axiom]                   | [Honeycomb.io] | [SigNoz]                         |
-| [Axoflow]                 | [Instana]      | [Splunk]                         |
-| [Azure Data Explorer]     | [Kloudfuse]    | [Sumo Logic]                     |
-| [Coralogix]               | [Liatrio]      | [TelemetryHub]                   |
-| [Dash0]                   | [Logz.io]      | [Teletrace]                      |
-| [Datadog]                 | [New Relic]    | [Tracetest]                      |
-| [Dynatrace]               | [OpenSearch]   | [Uptrace]                        |
-| [Elastic]                 |                |                                  |
+| [AlibabaCloud LogService] | [Google Cloud] |  [Sentry]                        |
+| [AppDynamics]             | [Grafana Labs] |  [ServiceNow Cloud Observability]|
+| [Aspecto]                 | [Guance]       |  [SigNoz]                        |                       
+| [Axiom]                   | [Honeycomb.io] |  [Splunk]                        |
+| [Axoflow]                 | [Instana]      |  [Sumo Logic]                    |
+| [Azure Data Explorer]     | [Kloudfuse]    |  [TelemetryHub]                  |
+| [Coralogix]               | [Liatrio]      |  [Teletrace]                     |
+| [Dash0]                   | [Logz.io]      |  [Tracetest]                     |
+| [Datadog]                 | [New Relic]    |  [Uptrace]                       |
+| [Dynatrace]               | [OpenSearch]   |                                  |
+| [Elastic]                 | [Oracle]       |                                  |
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ keeping it up to date for you.
 
 |                           |                |                                  |
 |---------------------------|----------------|----------------------------------|
-| [AlibabaCloud LogService] | [Elastic]      | [OpenSearch]                     |
-| [AppDynamics]             | [Google Cloud] | [Oracle]                         |
-| [Aspecto]                 | [Grafana Labs] | [Sentry]                         |
-| [Axiom]                   | [Guance]       | [ServiceNow Cloud Observability] |
-| [Axoflow]                 | [Honeycomb.io] | [Splunk]                         |
-| [Azure Data Explorer]     | [Instana]      | [Sumo Logic]                     |
-| [Coralogix]               | [Kloudfuse]    | [TelemetryHub]                   |
-| [Dash0]                   | [Liatrio]      | [Teletrace]                      |
-| [Datadog]                 | [Logz.io]      | [Tracetest]                      |
-| [Dynatrace]               | [New Relic]    | [Uptrace]                        |
+| [AlibabaCloud LogService] | [Google Cloud] | [Oracle]                         |
+| [AppDynamics]             | [Grafana Labs] | [Sentry]                         |
+| [Aspecto]                 | [Guance]       | [ServiceNow Cloud Observability] |                       
+| [Axiom]                   | [Honeycomb.io] | [SigNoz]                         |
+| [Axoflow]                 | [Instana]      | [Splunk]                         |
+| [Azure Data Explorer]     | [Kloudfuse]    | [Sumo Logic]                     |
+| [Coralogix]               | [Liatrio]      | [TelemetryHub]                   |
+| [Dash0]                   | [Logz.io]      | [Teletrace]                      |
+| [Datadog]                 | [New Relic]    | [Tracetest]                      |
+| [Dynatrace]               | [OpenSearch]   | [Uptrace]                        |
+| [Elastic]                 |                |                                  |
+
 
 ## Contributing
 
@@ -138,3 +140,4 @@ Emeritus:
 [Teletrace]: https://github.com/teletrace/opentelemetry-demo
 [Tracetest]: https://github.com/kubeshop/opentelemetry-demo
 [Uptrace]: https://github.com/uptrace/uptrace/tree/master/example/opentelemetry-demo
+[SigNoz]: https://signoz.io/blog/opentelemetry-demo/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ keeping it up to date for you.
 |---------------------------|----------------|----------------------------------|
 | [AlibabaCloud LogService] | [Google Cloud] |  [Sentry]                        |
 | [AppDynamics]             | [Grafana Labs] |  [ServiceNow Cloud Observability]|
-| [Aspecto]                 | [Guance]       |  [SigNoz]                        |                       
+| [Aspecto]                 | [Guance]       |  [SigNoz]                        |
 | [Axiom]                   | [Honeycomb.io] |  [Splunk]                        |
 | [Axoflow]                 | [Instana]      |  [Sumo Logic]                    |
 | [Azure Data Explorer]     | [Kloudfuse]    |  [TelemetryHub]                  |
@@ -69,7 +69,6 @@ keeping it up to date for you.
 | [Datadog]                 | [New Relic]    |  [Uptrace]                       |
 | [Dynatrace]               | [OpenSearch]   |                                  |
 | [Elastic]                 | [Oracle]       |                                  |
-
 
 ## Contributing
 
@@ -134,10 +133,10 @@ Emeritus:
 [Oracle]: https://github.com/oracle-quickstart/oci-o11y-solutions/blob/main/knowledge-content/opentelemetry-demo
 [Sentry]: https://github.com/getsentry/opentelemetry-demo
 [ServiceNow Cloud Observability]: https://docs.lightstep.com/otel/quick-start-operator#send-data-from-the-opentelemetry-demo
+[SigNoz]: https://signoz.io/blog/opentelemetry-demo/
 [Splunk]: https://github.com/signalfx/opentelemetry-demo
 [Sumo Logic]: https://www.sumologic.com/blog/common-opentelemetry-demo-application/
 [TelemetryHub]: https://github.com/TelemetryHub/opentelemetry-demo/tree/telemetryhub-backend
 [Teletrace]: https://github.com/teletrace/opentelemetry-demo
 [Tracetest]: https://github.com/kubeshop/opentelemetry-demo
 [Uptrace]: https://github.com/uptrace/uptrace/tree/master/example/opentelemetry-demo
-[SigNoz]: https://signoz.io/blog/opentelemetry-demo/


### PR DESCRIPTION
This PR adds SigNoz as another observability backend and links it to a blog, which helps get started with SigNoz using the OTel Demo App.

# Changes

I've added SigNoz, as another option for an observability backend and linked it to a detailed blog, which helps setup SigNoz with the OTel Demo App. 
FYI:
[SigNoz](https://signoz.io/) is an OpenTelemetry-native observability backend and is completely open-source!

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
