### PR TITLE
add last9 as an o11y backend in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ keeping it up to date for you.
 
 |                           |                |                                  |
 |---------------------------|----------------|----------------------------------|
-| [AlibabaCloud LogService] | [Google Cloud] |  [Sentry]                        |
-| [AppDynamics]             | [Grafana Labs] |  [ServiceNow Cloud Observability]|
-| [Aspecto]                 | [Guance]       |  [SigNoz]                        |
-| [Axiom]                   | [Honeycomb.io] |  [Splunk]                        |
-| [Axoflow]                 | [Instana]      |  [Sumo Logic]                    |
-| [Azure Data Explorer]     | [Kloudfuse]    |  [TelemetryHub]                  |
-| [Coralogix]               | [Liatrio]      |  [Teletrace]                     |
-| [Dash0]                   | [Logz.io]      |  [Tracetest]                     |
-| [Datadog]                 | [New Relic]    |  [Uptrace]                       |
-| [Dynatrace]               | [OpenSearch]   |                                  |
-| [Elastic]                 | [Oracle]       |                                  |
+| [AlibabaCloud LogService] | [Google Cloud] |  [Oracle]                        |
+| [AppDynamics]             | [Grafana Labs] |  [Sentry]                        |
+| [Aspecto]                 | [Guance]       |  [ServiceNow Cloud Observability]|
+| [Axiom]                   | [Honeycomb.io] |  [SigNoz]                        |
+| [Axoflow]                 | [Instana]      |  [Splunk]                        |
+| [Azure Data Explorer]     | [Kloudfuse]    |  [Sumo Logic]                    |
+| [Coralogix]               | [Last9]        |  [TelemetryHub]                  |
+| [Dash0]                   | [Liatrio]      |  [Teletrace]                     |
+| [Datadog]                 | [Logz.io]      |  [Tracetest]                     |
+| [Dynatrace]               | [New Relic]    |  [Uptrace]                       |
+| [Elastic]                 | [OpenSearch]   |                                  |
 
 ## Contributing
 
@@ -126,6 +126,7 @@ Emeritus:
 [Honeycomb.io]: https://github.com/honeycombio/opentelemetry-demo
 [Instana]: https://github.com/instana/opentelemetry-demo
 [Kloudfuse]: https://github.com/kloudfuse/opentelemetry-demo
+[Last9]: https://last9.io/docs/integrations-opentelemetry-demo/
 [Liatrio]: https://github.com/liatrio/opentelemetry-demo
 [Logz.io]: https://logz.io/learn/how-to-run-opentelemetry-demo-with-logz-io/
 [New Relic]: https://github.com/newrelic/opentelemetry-demo


### PR DESCRIPTION
# Changes

Please provide a brief description of the changes here.

Adding [Last9](https://last9.io) as an o11y backend with link to the guide to send OTel demo data to Last9.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
