### PR TITLE
[chore] add Docker, Cargo, Bundler, .NET to Dependabot actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,11 @@ updates:
         dependency-type: "development"
     schedule:
       interval: "daily"
+  - pakage-ecosystem: "docker"
+    directories:
+      - "/src/**/*"
+    groups:
+      docker-production-dependencies:
+        dependency-type: "production"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,30 @@ updates:
         dependency-type: "production"
     schedule:
       interval: "daily"
+  - pakage-ecosystem: "dotnet-sdk"
+    directories:
+      - "/src/accounting/*"
+      - "/src/cart/src/*"
+    groups:
+      dotnet-sdk-production-dependencies:
+        dependency-type: "production"
+    schedule:
+      interval: "daily"
+  - pakage-ecosystem: "cargo"
+    directories:
+      - "/src/shipping/*"
+    groups:
+      cargo-production-dependencies:
+        dependency-type: "production"
+    schedule:
+      interval: "daily"
+  - pakage-ecosystem: "bundler"
+    directories:
+      - "/src/email/*"
+    groups:
+      bundler-production-dependencies:
+        dependency-type: "production"
+      bundler-development-dependencies:
+        dependency-type: "development"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# Changes

This PR updates the `dependabot.yml` file to include the various Dockerfiles in the OpenTelemetry Demo, so that they are using up to date image. This is in response to this discussion: https://github.com/open-telemetry/opentelemetry-demo/discussions/2147

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
