### PR TITLE
[recommendation]: replace debian base image with alpine image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ the release.
   ([#2161](https://github.com/open-telemetry/opentelemetry-demo/pull/2161))
 * [chore] bump dependent images
   ([#2179](https://github.com/open-telemetry/opentelemetry-demo/pull/2179))
+* [recommendation] change image from bookworm to alpine to reduce size
+  ([#2164](https://github.com/open-telemetry/opentelemetry-demo/pull/2164))
 
 ## 2.0.2
 

--- a/src/recommendation/Dockerfile
+++ b/src/recommendation/Dockerfile
@@ -2,31 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM python:3.12-slim-bookworm AS base
+FROM python:3.12-alpine3.21 AS build-venv
 
-#
-# Fetch requirements
-#
-FROM base AS builder
-RUN apt-get -qq update \
-    && apt-get install -y --no-install-recommends g++ \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add gcc g++ linux-headers
 
-WORKDIR /usr/src/app/
-COPY ./src/recommendation/requirements.txt ./
+COPY ./src/recommendation/requirements.txt requirements.txt
 
-RUN pip install --upgrade pip
-RUN pip install --prefix="/reqs" -r requirements.txt
+RUN python -m venv venv && \
+    venv/bin/pip install --no-cache-dir -r requirements.txt
 
-#
-# Runtime
-#
-FROM base AS runtime
-WORKDIR /usr/src/app/
-COPY --from=builder /reqs /usr/local
-COPY ./src/recommendation/ ./
+RUN venv/bin/opentelemetry-bootstrap -a install
 
-RUN opentelemetry-bootstrap -a install
+FROM python:3.12-alpine3.21
+
+COPY --from=build-venv /venv/ /venv/
+
+WORKDIR /app
+
+COPY ./src/recommendation/demo_pb2_grpc.py demo_pb2_grpc.py
+COPY ./src/recommendation/demo_pb2.py demo_pb2.py
+COPY ./src/recommendation/logger.py logger.py
+COPY ./src/recommendation/metrics.py metrics.py
+COPY ./src/recommendation/recommendation_server.py recommendation_server.py
 
 EXPOSE ${RECOMMENDATION_PORT}
-ENTRYPOINT [ "opentelemetry-instrument", "python", "recommendation_server.py" ]
+ENTRYPOINT [ "/venv/bin/opentelemetry-instrument", "/venv/bin/python", "recommendation_server.py" ]

--- a/src/recommendation/requirements.txt
+++ b/src/recommendation/requirements.txt
@@ -1,5 +1,5 @@
-grpcio-health-checking==1.70.0
-grpcio==1.70.0
+grpcio-health-checking==1.71.0
+grpcio==1.71.0
 opentelemetry-distro==0.51b0
 opentelemetry-exporter-otlp-proto-grpc==1.30.0
 python-dotenv==1.0.1


### PR DESCRIPTION
# Changes

This PR updates the Python based images to a `distroless` image as the final base image instead of the existing `slim-bookworm`. This results in a smaller image overall.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
