### PR TITLE
Use http cookies in addition to browser local storage on the Frontend 

### DIFF
--- a/src/frontend/gateways/Session.gateway.ts
+++ b/src/frontend/gateways/Session.gateway.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { v4 } from 'uuid';
+import { getCookie } from "cookies-next";
 
 interface ISession {
   userId: string;
@@ -10,7 +11,7 @@ interface ISession {
 
 const sessionKey = 'session';
 const defaultSession = {
-  userId: v4(),
+  userId: getCookie('USERID')?.toString() || v4(),
   currencyCode: 'USD',
 };
 

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { v4 } from 'uuid';
+ 
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next()
+
+  // If the SESSIONID cookie is not set, generate a new UUID and set it
+  if(!request.cookies.has('SESSIONID'))
+    response.cookies.set('SESSIONID', v4())
+
+  // Set the USERID cookie if it is not set
+  if(!request.cookies.has('USERID'))
+    response.cookies.set('USERID', v4())
+ 
+  return response
+}
+
+// Matching paths
+export const config = {
+  matcher: '/:path*',
+}

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { v4 } from 'uuid';


### PR DESCRIPTION
# Changes

As per #2174 introduced new middleware which initializes session and user id HTTP cookies if not already set, adapts existing session gateway code to initialize local storage session state to same value
