### PR TITLE
Add Apache Doris demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ keeping it up to date for you.
 
 |                           |                |                                  |
 |---------------------------|----------------|----------------------------------|
-| [AlibabaCloud LogService] | [Google Cloud] |  [Oracle]                        |
+| [AlibabaCloud LogService] | [Elastic]      |  [OpenSearch]                    |
+| [Apache Doris]            | [Google Cloud] |  [Oracle]                        |
 | [AppDynamics]             | [Grafana Labs] |  [Sentry]                        |
 | [Aspecto]                 | [Guance]       |  [ServiceNow Cloud Observability]|
 | [Axiom]                   | [Honeycomb.io] |  [SigNoz]                        |
@@ -68,7 +69,6 @@ keeping it up to date for you.
 | [Dash0]                   | [Liatrio]      |  [Teletrace]                     |
 | [Datadog]                 | [Logz.io]      |  [Tracetest]                     |
 | [Dynatrace]               | [New Relic]    |  [Uptrace]                       |
-| [Elastic]                 | [OpenSearch]   |                                  |
 
 ## Contributing
 
@@ -111,6 +111,7 @@ Emeritus:
 
 [AlibabaCloud LogService]: https://github.com/aliyun-sls/opentelemetry-demo
 [AppDynamics]: https://community.appdynamics.com/t5/Knowledge-Base/How-to-observe-OpenTelemetry-demo-app-in-Splunk-AppDynamics/ta-p/58584
+[Apache Doris]: https://github.com/apache/doris-opentelemetry-demo
 [Aspecto]: https://github.com/aspecto-io/opentelemetry-demo
 [Axiom]: https://play.axiom.co/axiom-play-qf1k/dashboards/otel.traces.otel-demo-traces
 [Axoflow]: https://axoflow.com/opentelemetry-support-in-more-detail-in-axosyslog-and-syslog-ng/


### PR DESCRIPTION
# Changes


[Apache Doris](https://doris.apache.org/) is a modern OLAP database for real-time analytics. It delivers lightning-fast analytics on real-time data at scale. Doris is popular and its community is very active, with 13.4k github stars, 676 contributors and more than 5000 enterprise users.

One of its major user cases is logging and observability. It's already in the eco-system of [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter) as a storage backend. And the [doris-opentelemetry-demo](https://github.com/apache/doris-opentelemetry-demo) project is created to for Doris backend based on the latest offical opentelemetry-demo.

This PR try to add Apache Doris demo link in `README.md`. 


## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
