### PR TITLE
Update collector telemetry push to OTLP/HTTP

### DIFF
--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -138,5 +138,5 @@ service:
             timeout: 5000
             exporter:
               otlp:
-                protocol: grpc
-                endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_GRPC}
+                protocol: http/protobuf
+                endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_HTTP}


### PR DESCRIPTION
## Changes

Updated collector telemetry push to OTLP/HTTP rather than OTLP/GRPC endpoint. 

Resolves issue https://github.com/open-telemetry/opentelemetry-demo/issues/2182. Also, I see Grafana dashboards is already updated to point to the new collector metrics over the deprecated ones. 

## Current issue:

OTel collector has a bug in the telemetry push, even for un-authenticated otlp/grpc push the telemtery pusher is checking for TLS veirfication. More details here: https://github.com/open-telemetry/opentelemetry-collector/issues/12701

### TLS issue in OTel Collector logs: 
<img width="1168" alt="Screenshot 2025-05-14 at 10 37 16 PM" src="https://github.com/user-attachments/assets/10a8a64a-6495-43cb-adfa-662ed7b3f800" />
<img width="1180" alt="Screenshot 2025-05-14 at 10 37 26 PM" src="https://github.com/user-attachments/assets/30ee01cb-d2b7-4e3e-8fa7-e43983a53806" />

### Before code change below is the Grafana dashboard:
<img width="1640" alt="Screenshot 2025-05-14 at 10 38 35 PM" src="https://github.com/user-attachments/assets/4c06e52b-5236-4ad3-8c20-03654be80224" />

### After code change:
Updating the endpoint to OTLP/HTTP resolves the issue and the collector dashboards is populated with the required metrics in the Grafana dashboard:

<img width="1642" alt="Screenshot 2025-05-14 at 10 53 05 PM" src="https://github.com/user-attachments/assets/d771f0d3-2356-4397-9fef-52d1376acf99" />

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]