### PR TITLE
fix(frontend): switch off the http instrumentation to avoid duplicate spans

### DIFF
--- a/src/frontend/utils/telemetry/Instrumentation.js
+++ b/src/frontend/utils/telemetry/Instrumentation.js
@@ -82,7 +82,10 @@ const sdk = new opentelemetry.NodeSDK({
       '@opentelemetry/instrumentation-fs': {
         enabled: false,
       },
-    })
+      '@opentelemetry/instrumentation-http': {
+        disableIncomingRequestInstrumentation: true,
+      }
+    }),
   ],
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),

--- a/src/frontend/utils/telemetry/Instrumentation.js
+++ b/src/frontend/utils/telemetry/Instrumentation.js
@@ -11,9 +11,72 @@ const {awsEc2Detector, awsEksDetector} = require('@opentelemetry/resource-detect
 const {containerDetector} = require('@opentelemetry/resource-detector-container');
 const {gcpDetector} = require('@opentelemetry/resource-detector-gcp');
 const {envDetector, hostDetector, osDetector, processDetector} = require('@opentelemetry/resources');
+const {ConsoleSpanExporter, BatchSpanProcessor} = require('@opentelemetry/sdk-trace-node');
+const {Span} = require('@opentelemetry/api');
+
+class SpanNameProcessor {
+      /**
+       * Forces to export all finished spans
+       */
+      forceFlush() {}
+
+      /**
+       * Called when a {@link Span} is started, if the `span.isRecording()`
+       * returns true.
+       * @param span the Span that just started.
+       */
+      onStart(span, parentContext) {
+        // bail if no nextjs context
+        if (!span.attributes['next.span_type'] || !span.attributes['next.span_name']) {
+            return;
+        }
+
+        const oldSpanName = span.name;
+
+        // if span name contains query parameters, strip them
+        const spanName = span.name.split("?")[0];
+
+        // 'next.span_name': 'GET /_next/static/webpack/c0ba321a6e649482.webpack.hot-update.json',
+        // 'next.span_type': 'BaseServer.handleRequest',
+        // 'http.method': 'GET',
+        // 'http.target': '/_next/static/webpack/c0ba321a6e649482.webpack.hot-update.json',
+        if (span.attributes['http.target'] && span.attributes['http.target'].includes('/_next/static')) {
+            spanName = `${span.attributes['http.method']} ${span.attributes['/_next/static']}`;
+        }
+
+        if (span.attributes['http.target'] && span.attributes['http.target'].includes('/_next/images')) {
+            spanName = `${span.attributes['http.method']} ${span.attributes['/_next/images']}`;
+        }
+
+        if (span.attributes['http.target'] && span.attributes['http.target'].includes('/_next/data')) {
+            spanName = `${span.attributes['http.method']} ${span.attributes['/_next/data']}`;
+        }
+
+        span.setAttribute('next.span_name', spanName);
+
+        span.updateName(spanName);
+
+        console.debug(`Span name ${oldSpanName} updated to ${spanName}`);
+      }
+
+      /**
+       * Called when a {@link ReadableSpan} is ended, if the `span.isRecording()`
+       * returns true.
+       * @param span the Span that just ended.
+       */
+      onEnd(span) {}
+
+      /**
+       * Shuts down the processor. Called when SDK is shut down. This is an
+       * opportunity for processor to do any cleanup required.
+       */
+      shutdown() {}
+}
+
+// use console exporter when OTEL_TRACES_EXPORTER is set to "console"
+const traceExporter = process.env.OTEL_TRACES_EXPORTER === 'console' ? new ConsoleSpanExporter() : new OTLPTraceExporter();
 
 const sdk = new opentelemetry.NodeSDK({
-  traceExporter: new OTLPTraceExporter(),
   instrumentations: [
     getNodeAutoInstrumentations({
       // disable fs instrumentation to reduce noise
@@ -36,6 +99,13 @@ const sdk = new opentelemetry.NodeSDK({
     awsEc2Detector,
     gcpDetector,
   ],
+  spanProcessors: [
+    new SpanNameProcessor(),
+    new BatchSpanProcessor(traceExporter, {
+      maxQueueSize: 4096, // default 2048
+      maxExportBatchSize: 1024, // default 512
+    }),
+  ]
 });
 
 sdk.start();

--- a/src/frontend/utils/telemetry/Instrumentation.js
+++ b/src/frontend/utils/telemetry/Instrumentation.js
@@ -73,8 +73,7 @@ class SpanNameProcessor {
       shutdown() {}
 }
 
-// use console exporter when OTEL_TRACES_EXPORTER is set to "console"
-const traceExporter = process.env.OTEL_TRACES_EXPORTER === 'console' ? new ConsoleSpanExporter() : new OTLPTraceExporter();
+const traceExporter = process.env.OTEL_TRACES_EXPORTER === 'otlp' ? new OTLPTraceExporter() : new ConsoleSpanExporter();
 
 const sdk = new opentelemetry.NodeSDK({
   instrumentations: [


### PR DESCRIPTION
NOTE: this is a followup of #2190 in relation to #2189 

# Changes

Turn off instrumentation for incoming http requests in frontend. This avoids creating duplicate spans.

Needs to be thoroughly validated.