### PR TITLE
[chore] remove docker from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,14 +62,6 @@ updates:
         dependency-type: "development"
     schedule:
       interval: "daily"
-  - package-ecosystem: "docker"
-    directories:
-      - "/src/**/*"
-    groups:
-      docker-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "cargo"
     directories:
       - "/src/shipping/*"


### PR DESCRIPTION
# Changes

Dependabot doesn't consider LTS versions when sending docker updates, a couple of examples:

- Updates `dotnet/aspnet` from `8.0` to `9.0`
- Updates `dotnet/sdk` from `8.0` to `9.0`
- Updates `node` from `22-alpine` to `24-alpine` 

This PR removed docker from dependabot