### PR TITLE
[chore] Move Roger to maintainer and inactive approvers to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,12 @@ Wednesday at 8:30 AM PST and anyone is welcome.
 - [Juliano Costa](https://github.com/julianocosta89), Datadog
 - [Mikko Viitanen](https://github.com/mviitane), Dynatrace
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
+- [Roger Coll](https://github.com/rogercoll), Elastic
 
 [Approvers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver)
 ([@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers)):
 
 - [Cedric Ziel](https://github.com/cedricziel) Grafana Labs
-- [Penghan Wang](https://github.com/wph95), AppDynamics
-- [Reiley Yang](https://github.com/reyang), Microsoft
-- [Roger Coll](https://github.com/rogercoll), Elastic
-- [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
 Emeritus:
 
@@ -100,6 +97,9 @@ Emeritus:
 - [Carter Socha](https://github.com/cartersocha)
 - [Michael Maxwell](https://github.com/mic-max)
 - [Morgan McLean](https://github.com/mtwo)
+- [Penghan Wang](https://github.com/wph95), AppDynamics
+- [Reiley Yang](https://github.com/reyang), Microsoft
+- [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
# Changes

Fix #2185.

This PR also moves @rogercoll to maintainer of the Demo.
Roger has been an active approver and contributor to the Demo:

- [Approvals](https://github.com/open-telemetry/opentelemetry-demo/pulls?q=is%3Apr+review%3Aapproved+is%3Aclosed+reviewed-by%3Arogercoll+)
- [Contributions](https://github.com/open-telemetry/opentelemetry-demo/pulls?q=is%3Apr+author%3Arogercoll+is%3Aclosed)