### PR TITLE
[otel-collector] Add support for OpenSearch dynamic index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ the release.
   ([#2331](https://github.com/open-telemetry/opentelemetry-demo/pull/2331))
 * [cart] Upgrade OpenFeature and add new telemetry Hooks
   ([#2332](https://github.com/open-telemetry/opentelemetry-demo/pull/2332))
+* [otel-collector] Add support for OpenSearch dynamic index
+  ([#2363](https://github.com/open-telemetry/opentelemetry-demo/pull/2363))
 * [checkout] Add OTel grpc Logs to checkout
   ([#2336](https://github.com/open-telemetry/opentelemetry-demo/pull/2336))
 * [payment] Send logs to otel-collector via pino-opentelemetry-transport

--- a/src/grafana/provisioning/dashboards/demo/demo-dashboard.json
+++ b/src/grafana/provisioning/dashboards/demo/demo-dashboard.json
@@ -473,7 +473,7 @@
               "type": "count"
             }
           ],
-          "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
+          "query": "search source=otel-logs-*\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
           "queryType": "PPL",
           "refId": "A",
           "timeField": "observedTimestamp"
@@ -606,7 +606,7 @@
               "type": "raw_data"
             }
           ],
-          "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| sort - observedTimestamp \n| head 100",
+          "query": "search source=otel-logs-*\n| where resource.service.name=\"${service}\"\n| sort - observedTimestamp \n| head 100",
           "queryType": "PPL",
           "refId": "A",
           "timeField": "observedTimestamp"

--- a/src/grafana/provisioning/datasources/opensearch.yaml
+++ b/src/grafana/provisioning/datasources/opensearch.yaml
@@ -12,7 +12,7 @@ datasources:
     editable: true
     isDefault: false
     jsonData:
-      database: otel
+      database: otel-logs-*
       flavor: opensearch
       logLevelField: severity.text.keyword
       logMessageField: body

--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -94,7 +94,8 @@ exporters:
     tls:
       insecure: true
   opensearch:
-    logs_index: otel
+    logs_index: otel-logs
+    logs_index_time_format: "yyyy-MM-dd"
     http:
       endpoint: "http://opensearch:9200"
       tls:


### PR DESCRIPTION
# Changes

This PR enhances the OpenTelemetry Collector configuration, Grafana data source, and Grafana dashboards to leverage dynamic index naming supported by the [OpenSearch exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter) introduced in `opentelemetry-collector-contrib v1.29.0`.

Previously, all telemetry data was ingested into a single static index named `otel`. With this update, the index name is dynamically generated using a UTC-based timestamp format specified in the Collector configuration. For example, log data will now be indexed into time-partitioned indices such as `otel-logs-2025-07-15`.

#### Update index name with the date suffix:
<img width="1069" height="85" alt="Screenshot 2025-07-15 at 11 25 56 AM" src="https://github.com/user-attachments/assets/da13d31d-9c88-4731-8e6e-a95c115246ed" />


#### PPL Query on OpenSearch Logs with new index name
<img width="1294" height="1289" alt="Screenshot 2025-07-15 at 11 16 03 AM" src="https://github.com/user-attachments/assets/9baa4b00-a79c-4caf-9ae9-add847db5b80" />


#### Grafana Demo dashboards with updated query/index name
<img width="1289" height="951" alt="Screenshot 2025-07-15 at 11 11 43 AM" src="https://github.com/user-attachments/assets/54507ab0-9c11-4f09-9562-8ca6ea317a07" />




## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]


Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
