### PR TITLE
[chore] Add Shenoy to Demo Approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Cedric Ziel](https://github.com/cedricziel), Grafana Labs
+- [Shenoy Pratik](https://github.com/ps48), AWS OpenSearch
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
# Changes

Shenoy (@ps48) is an active contributor and member of the OTel Demo.

He is an active member on the SIG meetings and has contributions on the Demo: https://github.com/open-telemetry/opentelemetry-demo/issues?q=is%3Apr+author%3Aps48

This PR adds him to the list of Approvers.