### PR TITLE
[ad]: replace ubuntu image with alpine image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ the release.
   ([#2352]((https://github.com/open-telemetry/opentelemetry-demo/pull/2352)))
 * [image-provider] Update to latest version of nginx and alpine
   ([#2369](https://github.com/open-telemetry/opentelemetry-demo/pull/2369))
+* [ad] replace ubuntu image with alpine image
+  ([#2370](https://github.com/open-telemetry/opentelemetry-demo/pull/2370))
 
 ## 2.0.2
 

--- a/src/ad/Dockerfile
+++ b/src/ad/Dockerfile
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM --platform=${BUILDPLATFORM} eclipse-temurin:21-jdk AS builder
+FROM --platform=${BUILDPLATFORM} eclipse-temurin:21-jdk-alpine-3.21 AS builder
+
+RUN apk update && \
+    apk add gcompat
+
 ARG _JAVA_OPTIONS
 WORKDIR /usr/src/app/
 
@@ -16,11 +20,11 @@ RUN ./gradlew downloadRepos
 COPY ./src/ad/ ./
 COPY ./pb/ ./proto
 RUN chmod +x ./gradlew
-RUN ./gradlew installDist -PprotoSourceDir=./proto
+RUN LD_PRELOAD=/lib/libgcompat.so.0 ./gradlew installDist -PprotoSourceDir=./proto
 
 # -----------------------------------------------------------------------------
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-alpine-3.21
 
 ARG OTEL_JAVA_AGENT_VERSION
 ARG _JAVA_OPTIONS


### PR DESCRIPTION
# Changes

This PR replaces the ubuntu back eclipse terminun images with the alpine counterparts.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
