### PR TITLE
fix: remove nonexistent `wait_until` param from playwright page API call

### DIFF
--- a/src/load-generator/locustfile.py
+++ b/src/load-generator/locustfile.py
@@ -248,8 +248,10 @@ if browser_traffic_enabled:
                     page.on("console", lambda msg: print(msg.text))
                     await page.route('**/*', add_baggage_header)
                     await page.goto("/", wait_until="domcontentloaded")
-                    await page.click('p:has-text("Roof Binoculars")', wait_until="domcontentloaded")
-                    await page.click('button:has-text("Add To Cart")', wait_until="domcontentloaded")
+                    await page.click('p:has-text("Roof Binoculars")')
+                    await page.wait_for_load_state("domcontentloaded")
+                    await page.click('button:has-text("Add To Cart")')
+                    await page.wait_for_load_state("domcontentloaded")
                     await page.wait_for_timeout(2000)  # giving the browser time to export the traces
                     logging.info("Product added to cart successfully")
                 except Exception as e:


### PR DESCRIPTION
# Changes

The Python Playwright 1.53 `page.click` api does not have the `wait_until` parameter (docs: https://devdocs.io/playwright/api/class-page#page-click). Instead, it provides a `wait_for_load_state` function (https://devdocs.io/playwright/api/class-page#page-wait-for-load-state). This adds the `wait_for_load_state` calls. Without these calls, the API does not wait for the corresponding browser events, as intended.