### PR TITLE
Bump Flagd and get semconv compliant OTel metrics

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ OPENTELEMETRY_CPP_VERSION=1.21.0
 
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.129.1
-FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.5
+FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.8
 GRAFANA_IMAGE=grafana/grafana:12.0.2
 JAEGERTRACING_IMAGE=jaegertracing/all-in-one:1.70.0
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,10 @@ the release.
   ([#2369](https://github.com/open-telemetry/opentelemetry-demo/pull/2369))
 * [load-generator] Fix Playwright wait until load state error
   ([#2374](https://github.com/open-telemetry/opentelemetry-demo/pull/2374))
-
+* [flagd] Bump Flagd to v0.12.8 and get compliant `http.Server.request.duration`
+  OTel metrics that can be used in the APM dashboard
+  ([#2392](https://github.com/open-telemetry/opentelemetry-demo/pull/2392))
+  
 ## 2.0.2
 
 * [frontend] Update OpenTelemetry Browser SDK initialization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ the release.
 * [flagd] Bump Flagd to v0.12.8 and get compliant `http.Server.request.duration`
   OTel metrics that can be used in the APM dashboard
   ([#2392](https://github.com/open-telemetry/opentelemetry-demo/pull/2392))
-  
+
 ## 2.0.2
 
 * [frontend] Update OpenTelemetry Browser SDK initialization


### PR DESCRIPTION
# Changes

Bump Flagd to [v0.12.8](https://github.com/open-feature/flagd/releases/tag/flagd%2Fv0.12.8) and get compliant `http.Server.request.duration` OTel metrics that can be used in the APM dashboard.

<img width="1437" alt="OpenTelemetry Demo APM dashboard showing Flagd health" src="https://github.com/user-attachments/assets/4cdd03ed-8573-431b-a66f-b8049ddea2b4" />

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
