### PR TITLE
[cart] Update dependencies: .NET SDK, instrumentation, gRPC, Redis driver, OpenFeature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ the release.
   ([#2114](https://github.com/open-telemetry/opentelemetry-demo/pull/2114))
 * [flagd-ui] increase memory to 100MB
   ([#2120](https://github.com/open-telemetry/opentelemetry-demo/pull/2120))
+* [cart] Updated .NET SDK, instrumentation, Redis driver, and OpenFeature libraries
+  to latest releases
+  ([#2400](https://github.com/open-telemetry/opentelemetry-demo/pull/2400))
 
 ## 2.0.1
 

--- a/src/cart/src/Program.cs
+++ b/src/cart/src/Program.cs
@@ -17,7 +17,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using OpenFeature;
 using OpenFeature.Contrib.Providers.Flagd;
-using OpenFeature.Contrib.Hooks.Otel;
+using OpenFeature.Hooks;
 
 var builder = WebApplication.CreateBuilder(args);
 string valkeyAddress = builder.Configuration["VALKEY_ADDR"];
@@ -75,7 +75,7 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .SetExemplarFilter(ExemplarFilterType.TraceBased)
         .AddOtlpExporter());
-OpenFeature.Api.Instance.AddHooks(new TracingHook());
+OpenFeature.Api.Instance.AddHooks(new TraceEnricherHook());
 builder.Services.AddGrpc();
 builder.Services.AddGrpcHealthChecks()
     .AddCheck("Sample", () => HealthCheckResult.Healthy());

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
-    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.71.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -17,16 +17,16 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.11.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.11.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
     <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.0" />

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -29,8 +29,7 @@
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
-    <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.0" />
-    <PackageReference Include="OpenFeature" Version="2.3.1" />
+    <PackageReference Include="OpenFeature" Version="2.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+    <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.3" />
     <PackageReference Include="OpenFeature" Version="2.7.0" />
   </ItemGroup>
 

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
     <PackageReference Include="OpenFeature" Version="2.7.0" />
   </ItemGroup>
 

--- a/src/cart/tests/cart.tests.csproj
+++ b/src/cart/tests/cart.tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
# Changes

Updates SDK and instrumentation libraries to latest releases referencing version 1.12.0

gRPC and Redis driver versions are minor releases.

When updating OpenFeature, found that `OpenFeature.Contrib.Hooks.Otel` has been deprecated. [Modified project to use supported version with minor breaking changes](https://www.nuget.org/packages/OpenFeature.Contrib.Hooks.Otel/0.2.1?_src=template#readme-body-tab).

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
