### PR TITLE
[cart] Generate `service.instance.id` resource attribute by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ the release.
 * [flagd] Bump Flagd to v0.12.8 and get compliant `http.Server.request.duration`
   OTel metrics that can be used in the APM dashboard
   ([#2392](https://github.com/open-telemetry/opentelemetry-demo/pull/2392))
+* [cart] Enable automatic generation of `service.instance.id`
+  ([#2402](https://github.com/open-telemetry/opentelemetry-demo/pull/2402))
 
 ## 2.0.2
 

--- a/src/cart/src/Program.cs
+++ b/src/cart/src/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddSingleton(x =>
 
 Action<ResourceBuilder> appResourceBuilder =
     resource => resource
+        .AddService(builder.Environment.ApplicationName)
         .AddContainerDetector()
         .AddHostDetector();
 


### PR DESCRIPTION
# Changes

Resolves #2399 

Calls the `AddService` extension method for automatic generation of the `service.instance.id` attribute.

The `AddService` method has an argument named `autoGenerateServiceInstanceId` that defaults to true. This argument generates a `service.instance.id` value that is stable for the lifetime of the process.

[`AddService` requires passing a string for `service.name`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.12.0/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs#L37). Passing `builder.Environment.ApplicationName` sets the default `service.name` to the name of the assembly containing the service entrypoint. For this service it is the name is "cart" as cart.dll contains the entrypoint.

Screenshot of cart resource attributes after this change:
<img width="1521" height="699" alt="Screenshot 2025-07-27 201249" src="https://github.com/user-attachments/assets/cfbffdb0-180f-41ac-9cb4-f4b19c3025aa" />

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
