### PR TITLE
Added missing Trace propagation to accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ process content of "Unreleased" section content will generate release notes for
 the release.
 
 ## Unreleased
-
+* [accounting] Added Trace extract on Kafka message for correlation
+  ([#2414](https://github.com/open-telemetry/opentelemetry-demo/pull/2414))
 * [chore] add GOMEMLIMIT to all Go services
   ([#2148](https://github.com/open-telemetry/opentelemetry-demo/pull/2148))
 * [product-catalog] Simplify span event name

--- a/src/accounting/Accounting.csproj
+++ b/src/accounting/Accounting.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
 		<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.12.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
 #Reason for change
 In its current 2.02 version, accounting  service is not using RPC trace context propagation, causing every message to become a new trace. 
 
<img width="173" height="268" alt="image" src="https://github.com/user-attachments/assets/739421e9-a4f9-44bb-b26e-51ae701fa2f9" />

After implementing  an extract on each message consume,  the accounting span is now correctly  connected  with the Checkout service via  Kafka   using RPC trace context propagation.

<img width="243" height="343" alt="image" src="https://github.com/user-attachments/assets/31fe38e8-0ab7-42d6-a438-49b43e9ad406" />

# Changes

Added the OpenTelemetry.api to Accounting.csproj
Extended the Modified StartListening loop to extract the trace header info and add it to the parent context 
Updating ChangeLog.md with relevant info

#Doc Changes
Raising PR on the Demo documentation  to indicate that accounting now has RPC Context Propagation
https://opentelemetry.io/docs/demo/telemetry-features/trace-coverage/
