### PR TITLE
[grafana] Update OpenSearch logs index in APM Dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ the release.
   ([#2369](https://github.com/open-telemetry/opentelemetry-demo/pull/2369))
 * [load-generator] Fix Playwright wait until load state error
   ([#2374](https://github.com/open-telemetry/opentelemetry-demo/pull/2374))
-* [grafana] Update OpenSearch logs index in APM Dashboards 
+* [grafana] Update OpenSearch logs index in APM Dashboards
   ([#2419](https://github.com/open-telemetry/opentelemetry-demo/pull/2419))
 * [flagd] Bump Flagd to v0.12.8 and get compliant `http.Server.request.duration`
   OTel metrics that can be used in the APM dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ the release.
   ([#2369](https://github.com/open-telemetry/opentelemetry-demo/pull/2369))
 * [load-generator] Fix Playwright wait until load state error
   ([#2374](https://github.com/open-telemetry/opentelemetry-demo/pull/2374))
+* [grafana] Update OpenSearch logs index in APM Dashboards 
+  ([#2419](https://github.com/open-telemetry/opentelemetry-demo/pull/2419))
 * [flagd] Bump Flagd to v0.12.8 and get compliant `http.Server.request.duration`
   OTel metrics that can be used in the APM dashboard
   ([#2392](https://github.com/open-telemetry/opentelemetry-demo/pull/2392))

--- a/src/grafana/provisioning/dashboards/demo/apm-dashboard.json
+++ b/src/grafana/provisioning/dashboards/demo/apm-dashboard.json
@@ -1624,7 +1624,7 @@
               "type": "logs"
             }
           ],
-          "query": "search source=otel | where resource.service.name=\"$service_name\" and resource.service.namespace=\"$service_namespace\" | fields @timestamp, severity.text, body, instrumentationScope.name\n",
+          "query": "search source=otel-logs-* | where resource.service.name=\"$service_name\" and resource.service.namespace=\"$service_namespace\" | fields @timestamp, severity.text, body, instrumentationScope.name\n",
           "queryType": "PPL",
           "refId": "B",
           "timeField": "observedTimestamp"


### PR DESCRIPTION
# Changes

The APM Dashboards in Grafana point have a visualization table to show service logs from OpenSearch. This PR fixes the index-pattern pointing to OTel logs index in OpenSearch

<img width="1581" height="937" alt="Screenshot 2025-08-02 at 11 14 20 AM" src="https://github.com/user-attachments/assets/77422392-91d2-4128-a306-593b08ecb668" />

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
