### PR TITLE
Remove manual garbage collection from GetAds endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ the release.
   ([#2352]((https://github.com/open-telemetry/opentelemetry-demo/pull/2352)))
 * [image-provider] Update to latest version of nginx and alpine
   ([#2369](https://github.com/open-telemetry/opentelemetry-demo/pull/2369))
+* [load-generator] Fix Playwright wait until load state error 
+  ([#2374](https://github.com/open-telemetry/opentelemetry-demo/pull/2374))
 
 ## 2.0.2
 

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import oteldemo.Demo.Ad;
 import oteldemo.Demo.AdRequest;
 import oteldemo.Demo.AdResponse;
-import oteldemo.problempattern.GarbageCollectionTrigger;
 import oteldemo.problempattern.CPULoad;
 import dev.openfeature.contrib.providers.flagd.FlagdOptions;
 import dev.openfeature.contrib.providers.flagd.FlagdProvider;
@@ -133,7 +132,6 @@ public final class AdService {
   private static class AdServiceImpl extends oteldemo.AdServiceGrpc.AdServiceImplBase {
     
     private static final String AD_FAILURE = "adFailure";
-    private static final String AD_MANUAL_GC_FEATURE_FLAG = "adManualGc";
     private static final String AD_HIGH_CPU_FEATURE_FLAG = "adHighCpu";
     private static final Client ffClient = OpenFeatureAPI.getInstance().getClient();
     
@@ -206,11 +204,6 @@ public final class AdService {
           throw new StatusRuntimeException(Status.UNAVAILABLE);
         }
 
-        if (ffClient.getBooleanValue(AD_MANUAL_GC_FEATURE_FLAG, false, evaluationContext)) {
-          logger.warn("Feature Flag " + AD_MANUAL_GC_FEATURE_FLAG + " enabled, performing a manual gc now");
-          GarbageCollectionTrigger gct = new GarbageCollectionTrigger();
-          gct.doExecute();
-        }
 
         AdResponse reply = AdResponse.newBuilder().addAllAds(allAds).build();
         responseObserver.onNext(reply);

--- a/src/load-generator/locustfile.py
+++ b/src/load-generator/locustfile.py
@@ -248,8 +248,10 @@ if browser_traffic_enabled:
                     page.on("console", lambda msg: print(msg.text))
                     await page.route('**/*', add_baggage_header)
                     await page.goto("/", wait_until="domcontentloaded")
-                    await page.click('p:has-text("Roof Binoculars")', wait_until="domcontentloaded")
-                    await page.click('button:has-text("Add To Cart")', wait_until="domcontentloaded")
+                    await page.click('p:has-text("Roof Binoculars")')
+                    await page.wait_for_load_state("domcontentloaded")
+                    await page.click('button:has-text("Add To Cart")')
+                    await page.wait_for_load_state("domcontentloaded")
                     await page.wait_for_timeout(2000)  # giving the browser time to export the traces
                     logging.info("Product added to cart successfully")
                 except Exception as e:


### PR DESCRIPTION
This PR removes the manual garbage collection trigger from the GetAds endpoint to address performance issues.

## Problem
The GetAds endpoint contained code that would trigger manual garbage collection when the  feature flag was enabled. This caused severe performance degradation:
- 10 forced GC cycles per request
- Creation of up to 500,000 objects with expensive finalizers
- Each finalizer sleeping for 500ms

## Solution
Removed the manual GC trigger code and associated imports/constants from the AdService.

## Changes
- Removed  import
- Removed  constant
- Removed the code block that checks the feature flag and triggers GC

This restores normal performance to the GetAds endpoint.