### PR TITLE
[frontend-proxy] Add redirects for web UI paths to ensure proper asset loading

### DIFF
--- a/src/frontend-proxy/envoy.tmpl.yaml
+++ b/src/frontend-proxy/envoy.tmpl.yaml
@@ -37,21 +37,29 @@ static_resources:
                       domains:
                         - "*"
                       routes:
-                        - match: { prefix: "/loadgen" }
+                        - match: { path: "/loadgen" }
+                          redirect: { path_redirect: "/loadgen/" }
+                        - match: { prefix: "/loadgen/" }
                           route: { cluster: loadgen, prefix_rewrite: "/" }
                         - match: { prefix: "/otlp-http/" }
                           route: { cluster: opentelemetry_collector_http, prefix_rewrite: "/" }
-                        - match: { prefix: "/jaeger" }
+                        - match: { path: "/jaeger" }
+                          redirect: { path_redirect: "/jaeger/" }
+                        - match: { prefix: "/jaeger/" }
                           route: { cluster: jaeger }
-                        - match: { prefix: "/grafana" }
+                        - match: { path: "/grafana" }
+                          redirect: { path_redirect: "/grafana/" }
+                        - match: { prefix: "/grafana/" }
                           route: { cluster: grafana }
                         - match: { prefix: "/images/" }
                           route: { cluster: image-provider, prefix_rewrite: "/" }
                         - match: { prefix: "/flagservice/" }
                           route: { cluster: flagservice, prefix_rewrite: "/", timeout: 0s }
-                        - match: { prefix: "/feature" }
+                        - match: { path: "/feature" }
+                          redirect: { path_redirect: "/feature/" }
+                        - match: { prefix: "/feature/" }
                           route: { cluster: flagd-ui }
-                        - match: { prefix: "/" }
+                        - match: { prefix: "/" } # Default/catch-all route - keep last since prefix:"/" matches everything
                           route: { cluster: frontend }
                 http_filters:
                   - name: envoy.filters.http.fault


### PR DESCRIPTION
Web UI services (loadgen, jaeger, grafana, flagd-ui) were not working properly when accessed without trailing slashes (e.g., `/loadgen` vs `/loadgen/`). 

The issue occurred because:
1. Requests like `/loadgen` would match the route and get rewritten to `/`
2. The web app would redirect to `/` (without the `/loadgen` prefix)  
3. Browser would request `/`, which matched the catch-all frontend route instead of staying on the intended service
4. Static assets (JS, CSS) would fail to load with 404 errors

## Solution
Added explicit redirects for web UI paths without trailing slashes:
- `/loadgen` → `/loadgen/`
- `/jaeger` → `/jaeger/` 
- `/grafana` → `/grafana/`
- `/feature` → `/feature/`

This ensures consistent URL structure and proper asset loading for Single Page Applications behind the reverse proxy.

## Changes
- Added path-specific redirect rules for web UIs
- Maintained existing API routes unchanged (already had trailing slashes)
- Added comment explaining route order importance


## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
