### PR TITLE
Add VictoriaMetrics to demos table

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ keeping it up to date for you.
 | [Coralogix]               | [Liatrio]      | [Teletrace]                      |
 | [Dash0]                   | [Logz.io]      | [Tracetest]                      |
 | [Datadog]                 | [New Relic]    | [Uptrace]                        |
+| [VictoriaMetrics]         |                |                                  |
 
 ## Contributing
 
@@ -149,3 +150,4 @@ For more information about the emeritus role, see the [community repository](htt
 [Teletrace]: https://github.com/teletrace/opentelemetry-demo
 [Tracetest]: https://github.com/kubeshop/opentelemetry-demo
 [Uptrace]: https://github.com/uptrace/uptrace/tree/master/example/opentelemetry-demo
+[VictoriaMetrics]: https://github.com/VictoriaMetrics-Community/opentelemetry-demo


### PR DESCRIPTION
# Changes

Add VictoriaMetrics as a vendor to demos table with link to the opentelemetry demo adapted for VictoriaMetrics apps.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
