### PR TITLE
[flagd-ui] fix application start order for mix release

### DIFF
--- a/src/flagd-ui/mix.exs
+++ b/src/flagd-ui/mix.exs
@@ -15,7 +15,10 @@ defmodule FlagdUi.MixProject do
       deps: deps(),
       releases: [
         flagd_ui: [
-          applications: [opentelemetry: :temporary]
+          applications: [
+            opentelemetry_exporter: :permanent,
+            opentelemetry: :temporary
+          ]
         ]
       ]
     ]


### PR DESCRIPTION
Sometimes the Flagd-UI doesn't wait for the OTEL exporter erlang application to start properly. As per official documentation, this should fix the issue.