### PR TITLE
[Fix] Postgresql container

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Demo App version
-IMAGE_VERSION=2.1.2
+IMAGE_VERSION=2.1.3
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 DEMO_VERSION=latest
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -711,7 +711,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 35M
+          memory: 80M
     restart: unless-stopped
     ports:
       - ${POSTGRES_PORT}

--- a/src/postgres/Dockerfile
+++ b/src/postgres/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:17-alpine3.22
+FROM postgres:17.6
 
 COPY ./src/postgres/init.sql /docker-entrypoint-initdb.d/init.sql
 


### PR DESCRIPTION
# Changes

The used container for postgres didn't have `sh`, and it crashed in crashloop.