### PR TITLE
Update grafana to 12.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ OPENTELEMETRY_CPP_VERSION=1.21.0
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.133.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.8
-GRAFANA_IMAGE=grafana/grafana:12.1.0
+GRAFANA_IMAGE=grafana/grafana:12.2.0
 JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.10.0
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
 OPENSEARCH_IMAGE=opensearchproject/opensearch:3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ the release.
 
 * [chore] Use pre-built nginx otel image
   ([#2614](https://github.com/open-telemetry/opentelemetry-demo/pull/2614))
+* [grafana] Update grafana version to 12.2.0
+  ([#2615](https://github.com/open-telemetry/opentelemetry-demo/pull/2615))
 
 ## 2.1.3
 


### PR DESCRIPTION
# Changes

This PR upgrades the Grafana version from 12.1.0 to 12.2.0.

Why? 
There is a bug in Grafana 12.1.0 related to the jaeger data source, where the data source doesn't respect subpaths in the jaeger url. This is causing jaeger to fail in this demo with the following error: `failed to decode Jaeger response: invalid character '<' looking for beginning of value`.

I fixed this bug a while back in grafana, and its available in 12.2.0 https://github.com/grafana/grafana/pull/109045.

Fixes #2589

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
