### PR TITLE
Refactor: Replace OpenSearch with Elasticsearch 9.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -13,9 +13,9 @@ COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.8
 GRAFANA_IMAGE=grafana/grafana:12.2.0
 JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.10.0
-# must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
-OPENSEARCH_IMAGE=opensearchproject/opensearch:3.2.0
-OPENSEARCH_DOCKERFILE=./src/opensearch/Dockerfile
+# must also update version field in src/grafana/provisioning/datasources/elasticsearch.yaml
+ELASTICSEARCH_IMAGE=elasticsearch:9.2.0
+ELASTICSEARCH_DOCKERFILE=./src/elasticsearch/Dockerfile
 POSTGRES_IMAGE=postgres:17.6 # used only for TraceTest
 PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.5.0
 VALKEY_IMAGE=valkey/valkey:8.1.3-alpine

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -114,8 +114,8 @@ jobs:
             tag_suffix: load-generator
             context: ./
             setup-qemu: true
-          - file: ./src/opensearch/Dockerfile
-            tag_suffix: opensearch
+          - file: ./src/elasticsearch/Dockerfile
+            tag_suffix: elasticsearch
             context: ./
             setup-qemu: true
           - file: ./src/payment/Dockerfile

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -674,7 +674,7 @@ services:
           memory: 120M
     restart: unless-stopped
     environment:
-      - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource"
+      - "GF_INSTALL_PLUGINS=grafana-elasticsearch-datasource"
     volumes:
       - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./src/grafana/provisioning/:/etc/grafana/provisioning/
@@ -704,7 +704,7 @@ services:
     depends_on:
       jaeger:
         condition: service_started
-      opensearch:
+      elasticsearch:
         condition: service_healthy
     logging: *logging
     environment:
@@ -745,14 +745,14 @@ services:
       - "${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
     logging: *logging
 
-  # OpenSearch
-  opensearch:
-    container_name: opensearch
+  # Elasticsearch
+  elasticsearch:
+    container_name: elasticsearch
     build:
       context: ./
-      dockerfile: ${OPENSEARCH_DOCKERFILE}
+      dockerfile: ${ELASTICSEARCH_DOCKERFILE}
       cache_from:
-        - ${IMAGE_NAME}:${IMAGE_VERSION}-opensearch
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-elasticsearch
     deploy:
       resources:
         limits:
@@ -763,9 +763,9 @@ services:
       - node.name=demo-node
       - bootstrap.memory_lock=true
       - discovery.type=single-node
-      - OPENSEARCH_JAVA_OPTS=-Xms400m -Xmx400m
-      - DISABLE_INSTALL_DEMO_CONFIG=true
-      - DISABLE_SECURITY_PLUGIN=true
+      - ES_JAVA_OPTS=-Xms400m -Xmx400m
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
       # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
       - _JAVA_OPTIONS
     ulimits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -849,7 +849,7 @@ services:
           memory: 120M
     restart: unless-stopped
     environment:
-      - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource"
+      - "GF_INSTALL_PLUGINS=grafana-elasticsearch-datasource"
     volumes:
       - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./src/grafana/provisioning/:/etc/grafana/provisioning/
@@ -879,7 +879,7 @@ services:
     depends_on:
       jaeger:
         condition: service_started
-      opensearch:
+      elasticsearch:
         condition: service_healthy
     logging: *logging
     environment:
@@ -920,14 +920,14 @@ services:
       - "${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
     logging: *logging
 
-  # OpenSearch
-  opensearch:
-    container_name: opensearch
+  # Elasticsearch
+  elasticsearch:
+    container_name: elasticsearch
     build:
       context: ./
-      dockerfile: ${OPENSEARCH_DOCKERFILE}
+      dockerfile: ${ELASTICSEARCH_DOCKERFILE}
       cache_from:
-        - ${IMAGE_NAME}:${IMAGE_VERSION}-opensearch
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-elasticsearch
     deploy:
       resources:
         limits:
@@ -938,9 +938,9 @@ services:
       - node.name=demo-node
       - bootstrap.memory_lock=true
       - discovery.type=single-node
-      - OPENSEARCH_JAVA_OPTS=-Xms400m -Xmx400m
-      - DISABLE_INSTALL_DEMO_CONFIG=true
-      - DISABLE_SECURITY_PLUGIN=true
+      - ES_JAVA_OPTS=-Xms400m -Xmx400m
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
       # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
       - _JAVA_OPTIONS
     ulimits:

--- a/src/elasticsearch/Dockerfile
+++ b/src/elasticsearch/Dockerfile
@@ -1,0 +1,8 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+FROM elasticsearch:9.2.0
+
+# Elasticsearch 9.x is designed to be lightweight and efficient
+# No additional plugin removal needed for demo purposes
+# Security will be disabled via environment variables in docker-compose

--- a/src/grafana/provisioning/dashboards/demo/apm-dashboard.json
+++ b/src/grafana/provisioning/dashboards/demo/apm-dashboard.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "APM dashboard for monitoring OpenTelemetry-based services.  \n\nInstrument your applications using OpenTelemetry SDKs and send traces, metrics, and logs to Jaeger for traces, a Prometheus-compatible database for metrics, and OpenSearch for logs. This dashboard provides a centralized view of your application's health and performance. ",
+  "description": "APM dashboard for monitoring OpenTelemetry-based services.  \n\nInstrument your applications using OpenTelemetry SDKs and send traces, metrics, and logs to Jaeger for traces, a Prometheus-compatible database for metrics, and Elasticsearch for logs. This dashboard provides a centralized view of your application's health and performance. ",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -1706,8 +1706,8 @@
     },
     {
       "datasource": {
-        "type": "grafana-opensearch-datasource",
-        "uid": "${opensearch_datasource}"
+        "type": "elasticsearch",
+        "uid": "${elasticsearch_datasource}"
       },
       "description": "Logs of the service, filtered by `service.name`, `service.namespace`, and `deployment.environment.name`.\n\nTo explore the logs, open the menu clicking on the icon `⋮` of this panel and click on `Explore`.",
       "fieldConfig": {
@@ -2050,14 +2050,14 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "OpenSearch",
+          "text": "Elasticsearch",
           "value": "webstore-logs"
         },
         "description": "OpenTelemetry logs.",
         "label": "Logs",
-        "name": "opensearch_datasource",
+        "name": "elasticsearch_datasource",
         "options": [],
-        "query": "grafana-opensearch-datasource",
+        "query": "elasticsearch",
         "refresh": 1,
         "regex": "",
         "type": "datasource"
@@ -2067,7 +2067,7 @@
           "text": ".*",
           "value": ".*"
         },
-        "description": "Waiting to implement support of the optional value of `deployment.environment.name` in the OpenSearch and Jager panels, hide variable.",
+        "description": "Waiting to implement support of the optional value of `deployment.environment.name` in the Elasticsearch and Jager panels, hide variable.",
         "hide": 2,
         "label": "Environment",
         "name": "deployment_environment_name",
@@ -2134,7 +2134,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "APM Dashboard (Jaeger, Prometheus, OpenSearch)",
+  "title": "APM Dashboard (Jaeger, Prometheus, Elasticsearch)",
   "uid": "febljk0a32qyoa",
   "version": 1
 }

--- a/src/grafana/provisioning/dashboards/demo/demo-dashboard.json
+++ b/src/grafana/provisioning/dashboards/demo/demo-dashboard.json
@@ -380,7 +380,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-opensearch-datasource",
+        "type": "elasticsearch",
         "uid": "webstore-logs"
       },
       "description": "",
@@ -463,7 +463,7 @@
             }
           ],
           "datasource": {
-            "type": "grafana-opensearch-datasource",
+            "type": "elasticsearch",
             "uid": "webstore-logs"
           },
           "format": "table",
@@ -498,7 +498,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-opensearch-datasource",
+        "type": "elasticsearch",
         "uid": "webstore-logs"
       },
       "fieldConfig": {
@@ -590,7 +590,7 @@
           "alias": "",
           "bucketAggs": [],
           "datasource": {
-            "type": "grafana-opensearch-datasource",
+            "type": "elasticsearch",
             "uid": "webstore-logs"
           },
           "format": "table",

--- a/src/grafana/provisioning/datasources/elasticsearch.yaml
+++ b/src/grafana/provisioning/datasources/elasticsearch.yaml
@@ -4,18 +4,17 @@
 apiVersion: 1
 
 datasources:
-  - name: OpenSearch
+  - name: Elasticsearch
     uid: webstore-logs
-    type: grafana-opensearch-datasource
-    url: http://opensearch:9200/
+    type: elasticsearch
+    url: http://elasticsearch:9200/
     access: proxy
     editable: true
     isDefault: false
     jsonData:
       database: otel-logs-*
-      flavor: opensearch
+      index: otel-logs-*
       logLevelField: severity.text.keyword
       logMessageField: body
-      pplEnabled: true
       timeField: observedTimestamp
-      version: 3.2.0
+      esVersion: "9.2.0"

--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -127,11 +127,11 @@ exporters:
     endpoint: "http://prometheus:9090/api/v1/otlp"
     tls:
       insecure: true
-  opensearch:
+  elasticsearch:
     logs_index: otel-logs
     logs_index_time_format: "yyyy-MM-dd"
     http:
-      endpoint: "http://opensearch:9200"
+      endpoint: "http://elasticsearch:9200"
       tls:
         insecure: true
 processors:
@@ -167,7 +167,7 @@ service:
     logs:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [opensearch, debug]
+      exporters: [elasticsearch, debug]
   telemetry:
     metrics:
       level: detailed


### PR DESCRIPTION
This commit refactors the OpenTelemetry demo to use Elasticsearch 9.2.0 instead of OpenSearch 3.2.0 for log storage and retrieval.

Changes include:
- Updated .env to use elasticsearch:9.2.0 Docker image
- Created new src/elasticsearch/Dockerfile
- Updated docker-compose.yml and docker-compose.minimal.yml to:
  - Replace opensearch service with elasticsearch service
  - Update service dependencies from opensearch to elasticsearch
  - Configure Elasticsearch with xpack.security.enabled=false
  - Update Grafana plugin from grafana-opensearch-datasource to grafana-elasticsearch-datasource
- Updated OTEL collector configuration:
  - Changed exporter from opensearch to elasticsearch
  - Updated endpoint from http://opensearch:9200 to http://elasticsearch:9200
- Updated Grafana datasource configuration:
  - Renamed datasource file from opensearch.yaml to elasticsearch.yaml
  - Changed datasource type from grafana-opensearch-datasource to elasticsearch
  - Updated datasource URL and settings for Elasticsearch 9.2.0
- Updated Grafana dashboards (apm-dashboard.json, demo-dashboard.json):
  - Changed datasource type from grafana-opensearch-datasource to elasticsearch
  - Updated variable references from opensearch_datasource to elasticsearch_datasource
  - Updated dashboard titles and descriptions
- Updated build workflow to build elasticsearch image instead of opensearch

Elasticsearch 9.2.0 is the latest stable version and provides improved performance and compatibility with OpenTelemetry log exports.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
