### PR TITLE
[chore] update memory limits

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -756,7 +756,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 800M
+          memory: 1G
     restart: unless-stopped
     environment:
       - cluster.name=demo-cluster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -931,7 +931,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 800M
+          memory: 1G
     restart: unless-stopped
     environment:
       - cluster.name=demo-cluster


### PR DESCRIPTION
# Changes

updates memory limits to better support the demo running over a long period of time (7+ days). Also updates Prometheus retention to 7d (from 1h), which is fine even with the lower memory limit. This change in retention will align with K8s deployments.