### PR TITLE
[chore] Bump dependent images

### DIFF
--- a/.env
+++ b/.env
@@ -6,19 +6,19 @@ DEMO_VERSION=latest
 # Build Args
 TRACETEST_IMAGE_VERSION=v1.7.1
 OTEL_JAVA_AGENT_VERSION=2.21.0
-OPENTELEMETRY_CPP_VERSION=1.23.0
+OPENTELEMETRY_CPP_VERSION=1.24.0
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.139.0
+COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.142.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.9
-GRAFANA_IMAGE=grafana/grafana:12.2.0
-JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.11.0
+GRAFANA_IMAGE=grafana/grafana:12.3.1
+JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.12.0
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
-OPENSEARCH_IMAGE=opensearchproject/opensearch:3.3.2
+OPENSEARCH_IMAGE=opensearchproject/opensearch:3.4.0
 OPENSEARCH_DOCKERFILE=./src/opensearch/Dockerfile
 POSTGRES_IMAGE=postgres:17.6 # used only for TraceTest
-PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.7.3
-VALKEY_IMAGE=valkey/valkey:9.0.0-alpine3.22
+PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.8.1
+VALKEY_IMAGE=valkey/valkey:9.0.1-alpine3.23
 TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
 
 # Demo Platform

--- a/src/grafana/provisioning/datasources/opensearch.yaml
+++ b/src/grafana/provisioning/datasources/opensearch.yaml
@@ -18,4 +18,4 @@ datasources:
       logMessageField: body
       pplEnabled: true
       timeField: observedTimestamp
-      version: 3.3.2
+      version: 3.4.0

--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -141,6 +141,9 @@ exporters:
       tls:
         insecure: true
     sending_queue:
+      # Explicitly set due to bug: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45016
+      num_consumers: 10
+      queue_size: 1000
       batch:
 processors:
   memory_limiter:

--- a/src/postgres/Dockerfile
+++ b/src/postgres/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:17.6
+FROM postgres:18.1
 
 COPY ./src/postgres/init.sql /docker-entrypoint-initdb.d/init.sql
 


### PR DESCRIPTION
# Changes

Bump dependent images.
[Jaeger has a bug on 2.13](https://github.com/jaegertracing/jaeger-ui/issues/3203) with the UI, so I bumped to 2.12.


