### PR TITLE
[chore] add jaeger and postgresql to helm-update-required label

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -33,7 +33,9 @@ jobs:
               - 'docker-compose*.yml'
               - 'src/flagd/**'
               - 'src/grafana/**'
+              - 'src/jaeger/**'
               - 'src/otel-collector/**'
+              - 'src/postgresql/**'
               - 'src/prometheus/**'
 
       - name: "Add Label: docs-update-required"


### PR DESCRIPTION
# Changes

- Updates the GitHub Action to add the `helm-update-required` label so it will include the jaeger and postgresql config files, which are copied into the Helm chart.

This depends on #2867 to be merged first