### PR TITLE
[chore] release pre-work

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Demo App version
-IMAGE_VERSION=2.1.3
+IMAGE_VERSION=2.2.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
 DEMO_VERSION=latest
 


### PR DESCRIPTION
# Changes

Bump image version to `2.2.0`
