### PR TITLE
[accounting] move dbcontext to local scope - fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [accounting] fix memory leak with dbcontext
+  ([#2876](https://github.com/open-telemetry/opentelemetry-demo/pull/2876))
+
 ## 2.2.0
 
 * [feat] add ipv6 support


### PR DESCRIPTION
# Changes

This fixes the memory leak in the accounting service by moving the dbcontext to local scope. This is the recommended approach to create and dispose of DBContext instance per Entity Framework best practices.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
