### PR TITLE
Update GitHub Actions workflows to reflect repository ownership change

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,5 +16,5 @@ jobs:
     permissions:
       contents: read
       packages: write
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: github.repository == 'tsuga-dev/opentelemetry-demo'
     uses: ./.github/workflows/component-build-images.yml

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -21,7 +21,7 @@ on:
         type: string
       ghcr_repo:
         description: GHCR repository
-        default: 'ghcr.io/open-telemetry/demo'
+        default: 'ghcr.io/tsuga-dev/otel-demo'
         required: false
         type: string
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   fossa:
+    if: github.repository == 'open-telemetry/opentelemetry-demo'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v5.0.1

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/component-build-images.yml
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: github.repository == 'tsuga-dev/opentelemetry-demo'
     with:
       push: true
       version: nightly-${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/component-build-images.yml
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: github.repository == 'tsuga-dev/opentelemetry-demo'
     with:
       push: true
       version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
- Updated repository references in build-images.yml, nightly-release.yml, and release.yml from 'open-telemetry/opentelemetry-demo' to 'tsuga-dev/opentelemetry-demo'.
- Changed default GHCR repository in component-build-images.yml from 'ghcr.io/open-telemetry/demo' to 'ghcr.io/tsuga-dev/otel-demo'.
- Added conditional check for repository in fossa.yml to match the new repository name.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
