### PR TITLE
Add Kopai to the vendors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ keeping it up to date for you.
 
 |                           |                |                                  |
 |---------------------------|----------------|----------------------------------|
-| [AlibabaCloud LogService] | [Google Cloud] | [Parseable]                      |
-| [Apache Doris]            | [Grafana Labs] | [Sentry]                         |
-| [AppDynamics]             | [Guance]       | [ServiceNow Cloud Observability] |
-| [Aspecto]                 | [Honeycomb.io] | [SigNoz]                         |
-| [Axiom]                   | [Instana]      | [Splunk]                         |
-| [Axoflow]                 | [Kloudfuse]    | [Sumo Logic]                     |
-| [Azure Data Explorer]     | [Last9]        | [TelemetryHub]                   |
-| [Causely]                 | [Liatrio]      | [Teletrace]                      |
-| [ClickStack]              | [Logz.io]      | [Tinybird]                       |
-| [Coralogix]               | [New Relic]    | [Tracetest]                      |
-| [Dash0]                   | [Oodle]        | [Tsuga]                          |
-| [Datadog]                 | [OpenObserve]  | [Uptrace]                        |
-| [Dynatrace]               | [OpenSearch]   | [VictoriaMetrics]                |
-| [Elastic]                 | [Oracle]       |                                  |
+| [AlibabaCloud LogService] | [Google Cloud] | [Oracle]                         |
+| [Apache Doris]            | [Grafana Labs] | [Parseable]                      |
+| [AppDynamics]             | [Guance]       | [Sentry]                         |
+| [Aspecto]                 | [Honeycomb.io] | [ServiceNow Cloud Observability] |
+| [Axiom]                   | [Instana]      | [SigNoz]                         |
+| [Axoflow]                 | [Kloudfuse]    | [Splunk]                         |
+| [Azure Data Explorer]     | [Kopai]        | [Sumo Logic]                     |
+| [Causely]                 | [Last9]        | [TelemetryHub]                   |
+| [ClickStack]              | [Liatrio]      | [Teletrace]                      |
+| [Coralogix]               | [Logz.io]      | [Tinybird]                       |
+| [Dash0]                   | [New Relic]    | [Tracetest]                      |
+| [Datadog]                 | [Oodle]        | [Tsuga]                          |
+| [Dynatrace]               | [OpenObserve]  | [Uptrace]                        |
+| [Elastic]                 | [OpenSearch]   | [VictoriaMetrics]                |
 
 ## Contributing
 
@@ -138,6 +138,7 @@ For more information about the emeritus role, see the [community repository](htt
 [Honeycomb.io]: https://github.com/honeycombio/opentelemetry-demo
 [Instana]: https://github.com/instana/opentelemetry-demo
 [Kloudfuse]: https://github.com/kloudfuse/opentelemetry-demo
+[Kopai]: https://github.com/kopai-app/opentelemetry-demo/tree/main/kopai
 [Last9]: https://last9.io/docs/integrations-opentelemetry-demo/
 [Liatrio]: https://github.com/liatrio/opentelemetry-demo
 [Logz.io]: https://logz.io/learn/how-to-run-opentelemetry-demo-with-logz-io/


### PR DESCRIPTION
# Changes

Adding Kopai to the list of vendors. It contains a link to our fork demonstrating the use of @kopai/app all-in-one local backend.

[@kopai/app](https://github.com/kopai-app/kopai-mono/tree/main/packages/app) is open-source and requires only node.js runtime on the host machine to run. I hope it will help with the adoption of OpenTelemetry and make testing instrumentation of apps and libraries easier.