### PR TITLE
[chore] Promote Cyrille to maintainer and move Mikko to approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Wednesday at 8:30 AM PST and anyone is welcome.
 
 ### Maintainers
 
+- [Cyrille Le Clerc](https://github.com/cyrille-leclerc), Grafana Labs
 - [Juliano Costa](https://github.com/julianocosta89), Datadog
-- [Mikko Viitanen](https://github.com/mviitane), Dynatrace
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 - [Roger Coll](https://github.com/rogercoll), Elastic
 
@@ -94,6 +94,7 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Cedric Ziel](https://github.com/cedricziel), Grafana Labs
+- [Mikko Viitanen](https://github.com/mviitane), Dynatrace
 - [Shenoy Pratik](https://github.com/ps48), AWS OpenSearch
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).


### PR DESCRIPTION
# Changes

Cyrille has been actively contributing to the Demo for the last 6 months +, and has shown interest and commitment to the future of the project.
This PR promotes him to maintainer:

- Contributions to the Demo: https://github.com/open-telemetry/opentelemetry-demo/pulls?q=is%3Apr+is%3Aclosed+author%3Acyrille-leclerc
- Contributions to Demo Helm chart: https://github.com/open-telemetry/opentelemetry-helm-charts/pulls?q=is%3Apr+is%3Aclosed+author%3Acyrille-leclerc+demo

---

This PR also moves @mviitane to approver, as discussed in Slack. We agreed that Mikko can move back as maintainer whenever he gets more time to invest in the Demo again.