### PR TITLE
Add custom attribute for payment address in checkout service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [checkout] Add app.payment.service.address span attribute to chargeCard for improved payment routing observability
+  ([#3203](https://github.com/open-telemetry/opentelemetry-demo/pull/3203))
 * [product-catalog] Enrich DB spans and metrics with `server.address` and `server.port`
   attributes extracted from the DSN via `otelsql.AttributesFromDSN`
   ([#3154](https://github.com/open-telemetry/opentelemetry-demo/pull/3154))

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -543,11 +543,14 @@ func (cs *checkout) convertCurrency(ctx context.Context, from *pb.Money, toCurre
 
 func (cs *checkout) chargeCard(ctx context.Context, amount *pb.Money, paymentInfo *pb.CreditCardInfo) (string, error) {
 	paymentService := cs.paymentSvcClient
+	paymentAddr := cs.paymentSvcAddr
 	if cs.isFeatureFlagEnabled(ctx, "paymentUnreachable") {
-		badAddress := "badAddress:50051"
-		c := mustCreateClient(badAddress)
+		paymentAddr = "badAddress:50051"
+		c := mustCreateClient(paymentAddr)
 		paymentService = pb.NewPaymentServiceClient(c)
 	}
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.String("app.payment.service.address", paymentAddr))
 
 	paymentResp, err := paymentService.Charge(ctx, &pb.ChargeRequest{
 		Amount:     amount,


### PR DESCRIPTION
# Changes

**Summary**

Adds an OpenTelemetry span attribute `app.payment.service.address` to the chargeCard function in the checkout service to improve observability of payment service routing.

Changes in src/checkout/main.go:

- Added `app.payment.service.address` span attribute to every call through chargeCard, recording which gRPC endpoint was targeted for the payment charge request
- When the paymentUnreachable feature flag is disabled, the attribute reflects the configured payment service address (from `PAYMENT_ADDR`)
- When the `paymentUnreachable` feature flag is enabled, the attribute reflects the injected bad address (`badAddress:50051`), making fault injection clearly visible in traces

Attribute naming follows OpenTelemetry semantic conventions, using the `app.payment.*` namespace consistent with other checkout service span attributes (e.g., `app.payment.transaction.id`).

**Motivation**

Previously, the paymentUnreachable feature flag would silently redirect traffic to a bad address with no trace-level indication of which endpoint was called. This change makes payment service routing observable in every request, which is especially valuable when diagnosing failures caused by fault injection.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
