### PR TITLE
docs: add minimal mode documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ your preferred deployment method:
 - [Docker](https://opentelemetry.io/docs/demo/docker_deployment/)
 - [Kubernetes](https://opentelemetry.io/docs/demo/kubernetes_deployment/)
 
+## Running in minimal mode
+
+The demo can be run with a reduced set of services, consuming significantly
+less memory (~3 GB instead of ~6 GB). Minimal mode excludes Kafka and its
+dependent services (Accounting, Fraud Detection) as well as the Flagd UI,
+while keeping all core demo functionality intact.
+
+To start the demo in minimal mode:
+
+```shell
+make start-minimal
+```
+
+Or using Docker Compose directly:
+
+```shell
+docker compose -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
+```
+
+To stop the demo (works for both full and minimal mode):
+
+```shell
+make stop
+```
+
 ## Documentation
 
 For detailed documentation, see [Demo Documentation][docs]. If you're curious


### PR DESCRIPTION
## Summary

- Adds a "Running in minimal mode" section to the README documenting how to start the demo with reduced resource requirements
- Documents `make start-minimal` and the equivalent `docker compose` command
- Notes the excluded services (Kafka, Accounting, Fraud Detection, Flagd UI) and reduced memory usage (~3 GB vs ~6 GB)

Fixes #970

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm `make start-minimal` command matches Makefile targets
- [ ] Confirm `docker compose -f docker-compose.minimal.yml` command works