### PR TITLE
fix(docker): remove JDK-8345296 workaround now that fix is released

### DIFF
--- a/.env.arm64
+++ b/.env.arm64
@@ -1,1 +1,0 @@
-_JAVA_OPTIONS=-XX:UseSVE=0

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,6 @@ ADDLICENSE = $(TOOLS_DIR)/$(ADDLICENSE_BINARY)
 
 DOCKER_COMPOSE_CMD ?= docker compose
 DOCKER_COMPOSE_ENV=--env-file .env --env-file .env.override
-DOCKER_COMPOSE_BUILD_ARGS=
-
-# Java Workaround for macOS 15.2+ and M4 chips (see https://bugs.openjdk.org/browse/JDK-8345296)
-ifeq ($(shell uname -m),arm64)
-	ifeq ($(shell uname -s),Darwin)
-		DOCKER_COMPOSE_ENV+= --env-file .env.arm64
-		DOCKER_COMPOSE_BUILD_ARGS+= --build-arg=_JAVA_OPTIONS=-XX:UseSVE=0
-	endif
-endif
 
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
@@ -121,11 +112,11 @@ install-tools: $(MISSPELL) $(ADDLICENSE)
 
 .PHONY: build
 build:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build $(DOCKER_COMPOSE_BUILD_ARGS)
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build
 
 .PHONY: build-and-push
 build-and-push:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build $(DOCKER_COMPOSE_BUILD_ARGS) --push
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build --push
 
 # Create multiplatform builder for buildx
 .PHONY: create-multiplatform-builder
@@ -265,7 +256,7 @@ ifdef SERVICE
 endif
 
 ifdef service
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build $(DOCKER_COMPOSE_BUILD_ARGS) $(service)
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) stop $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) rm --force $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) create $(service)

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -45,8 +45,7 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.criticality=medium
       - OTEL_LOGS_EXPORTER=otlp
       - OTEL_SERVICE_NAME=ad
-      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
-      - _JAVA_OPTIONS
+
     depends_on:
       otel-collector:
         condition: service_started
@@ -795,8 +794,7 @@ services:
       - OPENSEARCH_JAVA_OPTS=-Xms400m -Xmx400m
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - DISABLE_SECURITY_PLUGIN=true
-      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
-      - _JAVA_OPTIONS
+
     ulimits:
       memlock:
         soft: -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,7 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.criticality=medium
       - OTEL_LOGS_EXPORTER=otlp
       - OTEL_SERVICE_NAME=ad
-      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
-      - _JAVA_OPTIONS
+
     depends_on:
       otel-collector:
         condition: service_started
@@ -744,8 +743,7 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.criticality=low
       - OTEL_SERVICE_NAME=kafka
       - KAFKA_HEAP_OPTS=-Xmx400m -Xms400m
-      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
-      - _JAVA_OPTIONS
+
     healthcheck:
       test: nc -z kafka 9092
       start_period: 10s
@@ -945,8 +943,7 @@ services:
       - OPENSEARCH_JAVA_OPTS=-Xms400m -Xmx400m
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - DISABLE_SECURITY_PLUGIN=true
-      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
-      - _JAVA_OPTIONS
+
     ulimits:
       memlock:
         soft: -1

--- a/src/ad/Dockerfile
+++ b/src/ad/Dockerfile
@@ -3,7 +3,6 @@
 
 
 FROM --platform=${BUILDPLATFORM} eclipse-temurin:21-jdk AS builder
-ARG _JAVA_OPTIONS
 WORKDIR /usr/src/app/
 
 COPY ./src/ad/gradlew* ./src/ad/settings.gradle* ./src/ad/build.gradle ./
@@ -23,8 +22,6 @@ RUN ./gradlew installDist -PprotoSourceDir=./proto
 FROM eclipse-temurin:21-jre
 
 ARG OTEL_JAVA_AGENT_VERSION
-ARG _JAVA_OPTIONS
-
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/ ./


### PR DESCRIPTION
## Summary

- Removes the `_JAVA_OPTIONS=-XX:UseSVE=0` workaround introduced in #1872 for [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296) (SVE crash on macOS 15.2+ with M4 chips)
- The upstream JDK fix was released nearly a year ago, making the workaround no longer necessary
- Affected services: `ad`, `kafka`, `opensearch`

### Files changed
- **Deleted** `.env.arm64`
- **Makefile**: removed `DOCKER_COMPOSE_BUILD_ARGS` variable and the `arm64/Darwin` conditional block
- **docker-compose.yml**: removed `_JAVA_OPTIONS` env passthrough from `ad`, `kafka`, and `opensearch`
- **docker-compose.minimal.yml**: removed `_JAVA_OPTIONS` env passthrough from `ad` and `opensearch`
- **src/ad/Dockerfile**: removed `ARG _JAVA_OPTIONS` from both build stages

## Test plan

- [x] Built `ad` image locally on Apple Silicon (arm64) macOS — builds and starts successfully without the workaround
- [x] Verified `kafka` and `opensearch` start cleanly with the env var removed
- [x] Manually tested demo end-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)