### PR TITLE
ci: restrict image push and FOSSA to open-telemetry repo

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -184,13 +184,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
+        if: ${{ inputs.push && !github.event.repository.fork }}
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
+        if: ${{ inputs.push && !github.event.repository.fork }}
       - name: Set up QEMU
         if: ${{ matrix.file_tag.setup-qemu }}
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -209,7 +209,7 @@ jobs:
           context: ${{ matrix.file_tag.context }}
           file: ${{ matrix.file_tag.file }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
+          push: ${{ inputs.push && !github.event.repository.fork }}
           build-args: |
             OTEL_JAVA_AGENT_VERSION=${{ env.OTEL_JAVA_AGENT_VERSION }}
             OPENTELEMETRY_CPP_VERSION=${{ env.OPENTELEMETRY_CPP_VERSION }}

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -184,13 +184,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ inputs.push }}
+        if: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ inputs.push }}
+        if: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
       - name: Set up QEMU
         if: ${{ matrix.file_tag.setup-qemu }}
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -209,7 +209,7 @@ jobs:
           context: ${{ matrix.file_tag.context }}
           file: ${{ matrix.file_tag.file }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push }}
+          push: ${{ inputs.push && github.repository == 'open-telemetry/opentelemetry-demo' }}
           build-args: |
             OTEL_JAVA_AGENT_VERSION=${{ env.OTEL_JAVA_AGENT_VERSION }}
             OPENTELEMETRY_CPP_VERSION=${{ env.OPENTELEMETRY_CPP_VERSION }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   fossa:
+    if: github.repository == 'open-telemetry/opentelemetry-demo'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v5.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   fossa:
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v5.0.1


### PR DESCRIPTION
## Summary

- Image builds in `component-build-images.yml` now run in all forks (useful for Dockerfile validation), but GHCR login, Docker Hub login, and the actual image push are gated on `github.repository == 'open-telemetry/opentelemetry-demo'` to avoid missing-secret failures in forks
- FOSSA scanning job is similarly guarded since it requires an org-level API key unavailable in forks

## Problem

Forks of this repo experience CI failures on every push to `main`:
- `Checks` / `build_and_push_images` — fails with `Username and password required` because `DOCKER_USERNAME`/`DOCKER_PASSWORD` org secrets are not available in forks
- `FOSSA scanning` — fails with `Input required and not supplied: api-key` for the same reason

## Test plan

- [ ] Verify `Checks` workflow passes on push to `main` in a fork (build runs, push is skipped)
- [ ] Verify `FOSSA scanning` job is skipped in forks
- [ ] Verify both workflows still function correctly in the upstream repo
- [x] Manually verified changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)