### PR TITLE
ci: use github.event.repository.fork syntax instead of repo name check

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -17,7 +17,7 @@ jobs:
   assign-reviewers:
     permissions:
       pull-requests: write  # required for assigning reviewers to PRs
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b  # v0.2.0

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,5 +16,5 @@ jobs:
     permissions:
       contents: read
       packages: write
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: ${{ !github.event.repository.fork }}
     uses: ./.github/workflows/component-build-images.yml

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/component-build-images.yml
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: ${{ !github.event.repository.fork }}
     with:
       push: true
       version: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/component-build-images.yml
-    if: github.repository == 'open-telemetry/opentelemetry-demo'
+    if: ${{ !github.event.repository.fork }}
     with:
       push: true
       version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- Replace `github.repository == 'open-telemetry/opentelemetry-demo'` with `!github.event.repository.fork` across all workflows that used the old pattern
- Affected workflows: `assign-reviewers.yml`, `build-images.yml`, `nightly-release.yml`, `release.yml`

This is a follow-up to #3238 which introduced the `!github.event.repository.fork` pattern. This PR applies the same standard to the existing workflows that still used the hardcoded repo name check.

## Test plan

- [ ] Verify guarded jobs are skipped in forks
- [ ] Verify guarded jobs still run in the upstream repo
- [x] Manually verified changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)