### PR TITLE
fix(dependabot): exclude react-native-app from Gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
   - package-ecosystem: "gradle"
     directories:
       - "/src/**/*"
+    exclude-paths:
+      - "/src/react-native-app/**"
     groups:
       gradle-production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary

- Restores the `directories: ["/src/**/*"]` wildcard for Gradle so new services are picked up automatically
- Adds `exclude-paths: ["/src/react-native-app/**"]` to prevent Dependabot from bumping Gradle for the React Native app, which is incompatible with the latest Gradle version

## Context

PR #3257 (Dependabot Gradle group bump) causes issues with `src/react-native-app` but is fine for `src/ad` and `src/fraud-detection`. Rather than switching to an explicit directory list (which would require manual updates for future services), this uses `exclude-paths` to carve out only the problematic path.

## Test plan

- [ ] Verify Dependabot does not open Gradle update PRs for `src/react-native-app` on the next daily scan
- [ ] Verify Dependabot continues to open Gradle update PRs for `src/ad` and `src/fraud-detection`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)