### PR TITLE
chore: use public registries without rate limits

### DIFF
--- a/.env
+++ b/.env
@@ -12,13 +12,13 @@ OPENTELEMETRY_CPP_VERSION=1.24.0
 COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.146.1
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.14.2
 GRAFANA_IMAGE=grafana/grafana:12.3.3
-JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.14.1
+JAEGERTRACING_IMAGE=quay.io/jaegertracing/jaeger:2.14.1
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
-OPENSEARCH_IMAGE=opensearchproject/opensearch:3.5.0
+OPENSEARCH_IMAGE=public.ecr.aws/opensearchproject/opensearch:3.5.0
 OPENSEARCH_DOCKERFILE=./src/opensearch/Dockerfile
 POSTGRES_IMAGE=postgres:17.8
 PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.9.1
-VALKEY_IMAGE=valkey/valkey:9.0.2-alpine3.23
+VALKEY_IMAGE=ghcr.io/valkey-io/valkey:9.0.2-alpine3.23
 TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
 
 # Demo Platform

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -775,6 +775,7 @@ services:
 
   # OpenSearch
   opensearch:
+    images: ${IMAGE_NAME}:${DEMO_VERSION}-opensearch
     container_name: opensearch
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -949,6 +949,7 @@ services:
 
   # OpenSearch
   opensearch:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-opensearch
     container_name: opensearch
     build:
       context: ./


### PR DESCRIPTION
Moves away from using Docker Hub registry where possible to avoid rate limits on image pulls. This moves the Jaeger, OpenSearch, and Valkey image references to public registries without auth requirements or rate limits.

Also fixes the image name for locally built OpenSearch images to align with all other services in the demo.