### PR TITLE
chore(grafana): bump image to 13.0.1 and provision default-email receiver

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ OPENTELEMETRY_CPP_VERSION=1.24.0
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.146.1
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.14.2
-GRAFANA_IMAGE=grafana/grafana:12.3.3
+GRAFANA_IMAGE=grafana/grafana:13.0.1
 JAEGERTRACING_IMAGE=quay.io/jaegertracing/jaeger:2.14.1
 # must also update version field in src/grafana/provisioning/datasources/opensearch.yaml
 OPENSEARCH_IMAGE=public.ecr.aws/opensearchproject/opensearch:3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ the release.
   ([#3236](https://github.com/open-telemetry/opentelemetry-demo/pull/3236))
 * [cart] Swap the deprecated `OpenFeature.Contrib.Providers.Flagd` package
   provider with the new `OpenFeature.Providers.Flagd` package. ([#3247](https://github.com/open-telemetry/opentelemetry-demo/pull/3247))
+* [grafana] Bump Grafana image to 13.0.1 and provision the
+  `grafana-default-email` contact point explicitly, since Grafana no longer
+  auto-seeds it (removed in 12.4+)
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,6 @@ the release.
 * [kubernetes] Removed generated Kubernetes manifests in favor of docs
   ([#3236](https://github.com/open-telemetry/opentelemetry-demo/pull/3236))
 * [cart] Swap the deprecated `OpenFeature.Contrib.Providers.Flagd` package
-<<<<<<< chore/bump-grafana-version
-  provider with the new `OpenFeature.Providers.Flagd` package. ([#3247](https://github.com/open-telemetry/opentelemetry-demo/pull/3247))
-* [grafana] Bump Grafana image to 13.0.1 and provision the
-  `grafana-default-email` contact point explicitly, since Grafana no longer
-  auto-seeds it (removed in 12.4+)
-=======
   provider with the new `OpenFeature.Providers.Flagd` package.
   ([#3247](https://github.com/open-telemetry/opentelemetry-demo/pull/3247))
 * [recommendation] Fix `recommendationCacheFailure` feature flag by
@@ -64,8 +58,10 @@ the release.
   ([#3260](https://github.com/open-telemetry/opentelemetry-demo/pull/3260))
 * [frontend] fix: handle undefined product images across multiple components
   ([#3291](https://github.com/open-telemetry/opentelemetry-demo/pull/3291))
->>>>>>> main
-
+* [grafana] Bump Grafana image to 13.0.1 and provision the
+  `grafana-default-email` contact point explicitly, since Grafana no longer
+  auto-seeds it (removed in 12.4+)
+  
 ## 2.2.0
 
 * [feat] add ipv6 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ the release.
 * [grafana] Bump Grafana image to 13.0.1 and provision the
   `grafana-default-email` contact point explicitly, since Grafana no longer
   auto-seeds it (removed in 12.4+)
-  
+
 ## 2.2.0
 
 * [feat] add ipv6 support

--- a/src/grafana/provisioning/alerting/default-email.yaml
+++ b/src/grafana/provisioning/alerting/default-email.yaml
@@ -1,0 +1,21 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: grafana-default-email
+    receivers:
+      - uid: grafana-default-email-uid
+        type: email
+        settings:
+          addresses: admin@example.com
+
+policies:
+  - orgId: 1
+    receiver: grafana-default-email
+    group_by:
+      - grafana_folder
+      - alertname


### PR DESCRIPTION
## Summary

- Bump `GRAFANA_IMAGE` from `grafana/grafana:12.3.3` to `grafana/grafana:13.0.1`.
- Add `src/grafana/provisioning/alerting/default-email.yaml` to provision the `grafana-default-email` contact point and default notification policy.

## Why the extra provisioning file?

Starting with Grafana 12.4, the default `grafana-default-email` contact point is no longer auto-seeded (see [grafana/grafana#82639](https://github.com/grafana/grafana/issues/82639)). `src/grafana/provisioning/alerting/cart-service-alerting.yml` still references that receiver under `notification_settings`, so without the new file Grafana 13 refuses to provision the rule and crash-loops with:

```
Failed to provision alerting  error="alert rules: invalid alert rule\nreceiver grafana-default-email does not exist"
```

Provisioning the receiver from file restores the prior behavior without having to edit the existing rule file or change the default notification routing. I used `admin@example.com` as the placeholder address, matching the demo-only nature of the setup.

Other v13 changes reviewed ([v13 upgrade guide](https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v13.0/), [what's new](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/)) — none affect file-based alerting/datasource/dashboard provisioning used in this repo (e.g. numeric-id datasource references are already on `uid`).

## Test plan

- [x] `docker compose up --force-recreate --remove-orphans --detach` starts the full stack cleanly
- [x] `/grafana/api/health` returns 200
- [x] Grafana logs: `finished to provision alerting` / `finished to provision dashboards`, no provisioning errors
- [x] `/api/v1/provisioning/contact-points` returns `grafana-default-email` (provenance: file)
- [x] All 11 provisioned alert rules load and evaluate (state `inactive`, no query errors) against Prometheus