### PR TITLE
[chore] exclude platform.openai.com and gnu.org from link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,6 +7,7 @@ user_agent = "Mozilla/5.0 (compatible; lychee link checker)"
 exclude = [
   "^http://localhost",
   "^https://calendar\\.google\\.com/calendar",
+  "^https://platform\\.openai\\.com",
 ]
 
 exclude_path = [

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,6 +7,7 @@ user_agent = "Mozilla/5.0 (compatible; lychee link checker)"
 exclude = [
   "^http://localhost",
   "^https://calendar\\.google\\.com/calendar",
+  "^https://www\\.gnu\\.org",
   "^https://platform\\.openai\\.com",
 ]
 


### PR DESCRIPTION
## Summary

- Exclude `https://platform.openai.com` from the lychee link checker.
- OpenAI returns `403 Forbidden` to lychee's requests (e.g. `https://platform.openai.com/docs/api-reference/chat/create` referenced from `src/llm/README.md`), causing the `lychee` CI job to fail on unrelated PRs — see run [24763179995](https://github.com/open-telemetry/opentelemetry-demo/actions/runs/24763179995/job/72454654702).

## Test plan

- [ ] CI `lychee` job passes on this PR.