### PR TITLE
[chore] Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     directories:
       - "/src/**/*"
     exclude-paths:
-      - "/src/react-native-app/**"
+      - "src/react-native-app/**"
     groups:
       gradle-production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
# Changes

Fixes

Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/2/exclude-paths/0' should be relative to the repository root.
Please update the config file to conform with Dependabot's specification.

from https://github.com/open-telemetry/opentelemetry-demo/network/updates

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
