### PR TITLE
Remove tag from the docker logging used via docker compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [docker] Podman doesn't support the tag feature of docker logs,
+  for the otel-demo to support podman we need to remove the tag from docker logs.
+  [#3304](https://github.com/open-telemetry/opentelemetry-demo/pull/3304)
 * [telemetry-docs] Add a new service to provide telemetry documentation based
   on Weaver
   ([#2794](https://github.com/open-telemetry/opentelemetry-demo/pull/2794))

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -6,7 +6,6 @@ x-default-logging: &logging
   options:
     max-size: "5m"
     max-file: "2"
-    tag: "{{.Name}}"
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ x-default-logging: &logging
   options:
     max-size: "5m"
     max-file: "2"
-    tag: "{{.Name}}"
 
 networks:
   default:


### PR DESCRIPTION
# Changes

This is to work towards supporting podman in the otel-demo. If we run the demo with podman with the log tag included it fails due to podman not supporting this tag.

This work is working towards supporting running the demo via podman: see #3274 

Example using podman:

```bash
opentelemetry-demo main ❯ DOCKER_SOCK=${XDG_RUNTIME_DIR}/podman/podman.sock DOCKER_COMPOSE_CMD="podman compose" make start
podman compose --env-file .env --env-file .env.override up --force-recreate --remove-orphans --detach
>>>> Executing external compose provider "/usr/lib/docker/cli-plugins/docker-compose". Please see podman-compose(1) for how to disable this message. <<<<

[+] up 46/55
 ✔ Image quay.io/jaegertracing/jaeger:2.14.1           Pulled                                                                                                                   2.1s
 ✔ Image ghcr.io/valkey-io/valkey:9.0.2-alpine3.23     Pulled                                                                                                                   1.5s
 ✔ Image ghcr.io/open-telemetry/demo:latest-opensearch Pulled                                                                                                                   2.0s
 ✔ Network opentelemetry-demo                          Created                                                                                                                  0.0s
 ⠋ Container flagd                                     Starting                                                                                                                 1.6s
 ⠋ Container valkey-cart                               Starting                                                                                                                 1.6s
 ⠇ Container opensearch                                Starting                                                                                                                 1.6s
 ⠋ Container prometheus                                Starting                                                                                                                 1.6s
 ⠋ Container grafana                                   Starting                                                                                                                 1.6s
 ⠋ Container astronomy-db                              Starting                                                                                                                 1.6s
 ⠋ Container jaeger                                    Starting                                                                                                                 1.6s
 ⠋ Container kafka                                     Starting                                                                                                                 1.6s
 ⠋ Container telemetry-docs                            Starting                                                                                                                 1.6s
 ✔ Container llm                                       Created                                                                                                                  0.1s
 ✔ Container otel-collector                            Created                                                                                                                  0.0s
 ✔ Container shipping                                  Created                                                                                                                  0.3s
 ✔ Container quote                                     Created                                                                                                                  0.2s
 ✔ Container flagd-ui                                  Created                                                                                                                  0.1s
 ✔ Container currency                                  Created                                                                                                                  0.1s
 ✔ Container ad                                        Created                                                                                                                  0.2s
 ✔ Container product-catalog                           Created                                                                                                                  0.2s
 ✔ Container accounting                                Created                                                                                                                  0.2s
 ✔ Container email                                     Created                                                                                                                  0.2s
 ✔ Container payment                                   Created                                                                                                                  0.3s
 ✔ Container fraud-detection                           Created                                                                                                                  0.3s
 ✔ Container image-provider                            Created                                                                                                                  0.1s
 ✔ Container cart                                      Created                                                                                                                  0.1s
 ✔ Container product-reviews                           Created                                                                                                                  0.1s
 ✔ Container recommendation                            Created                                                                                                                  0.1s
 ✔ Container checkout                                  Created                                                                                                                  0.0s
 ✔ Container frontend                                  Created                                                                                                                  0.0s
 ✔ Container load-generator                            Created                                                                                                                  0.0s
 ✔ Container frontend-proxy                            Created                                                                                                                  0.0s
Error response from daemon: conmon failed: exit status 1
Error: executing /usr/lib/docker/cli-plugins/docker-compose --env-file .env --env-file .env.override up --force-recreate --remove-orphans --detach: exit status 1
make: *** [Makefile:189: start] Error 1
```

journal logs:

```bash
Apr 23 16:20:38 omarchy podman[3057366]: [conmon:e]: k8s-file doesn't support --log-tag
Apr 23 16:20:38 omarchy conmon[3057366]: conmon 375ef85cb41af28bb572 <error>: k8s-file doesn't support --log-tag
Apr 23 16:20:38 omarchy systemd[1209]: Started libpod-conmon-375ef85cb41af28bb5724a0a09f9b5eb3bf5fd41b4ab024b55dccbeeea09a9a5.scope.
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
Apr 23 16:20:38 omarchy podman[3057010]: time="2026-04-23T16:20:38+01:00" level=info msg="Request Failed(Internal Server Error): conmon failed: exit status 1"
```

## Removal of tag

After we remove the tag from logging we can successfully run the demo via podman:

```bash
opentelemetry-demo remove-tag-from-docker-logs ❯ DOCKER_SOCK=${XDG_RUNTIME_DIR}/podman/podman.sock DOCKER_COMPOSE_CMD="podman compose" make start
podman compose --env-file .env --env-file .env.override up --force-recreate --remove-orphans --detach
>>>> Executing external compose provider "/usr/lib/docker/cli-plugins/docker-compose". Please see podman-compose(1) for how to disable this message. <<<<

[+] up 30/30
 ✔ Network opentelemetry-demo Created                                                                                                                                           0.0s
 ✔ Container telemetry-docs   Started                                                                                                                                           1.3s
 ✔ Container flagd            Started                                                                                                                                           1.7s
 ✔ Container kafka            Healthy                                                                                                                                          19.4s
 ✔ Container astronomy-db     Started                                                                                                                                           1.5s
 ✔ Container opensearch       Healthy                                                                                                                                          17.7s
 ✔ Container jaeger           Started                                                                                                                                           1.7s
 ✔ Container prometheus       Started                                                                                                                                           1.4s
 ✔ Container valkey-cart      Started                                                                                                                                           1.3s
 ✔ Container grafana          Started                                                                                                                                           1.6s
 ✔ Container llm              Started                                                                                                                                           1.7s
 ✔ Container otel-collector   Started                                                                                                                                          17.5s
 ✔ Container accounting       Started                                                                                                                                          19.4s
 ✔ Container flagd-ui         Started                                                                                                                                          18.0s
 ✔ Container product-catalog  Started                                                                                                                                          17.9s
 ✔ Container email            Started                                                                                                                                          18.3s
 ✔ Container shipping         Started                                                                                                                                          18.2s
 ✔ Container ad               Started                                                                                                                                          18.9s
 ✔ Container quote            Started                                                                                                                                          18.4s
 ✔ Container image-provider   Started                                                                                                                                          17.9s
 ✔ Container payment          Started                                                                                                                                          19.0s
 ✔ Container cart             Started                                                                                                                                          18.1s
 ✔ Container currency         Started                                                                                                                                          18.8s
 ✔ Container fraud-detection  Started                                                                                                                                          19.4s
 ✔ Container product-reviews  Started                                                                                                                                          18.6s
 ✔ Container recommendation   Started                                                                                                                                          19.5s
 ✔ Container checkout         Started                                                                                                                                          19.4s
 ✔ Container frontend         Started                                                                                                                                          19.8s
 ✔ Container load-generator   Started                                                                                                                                          20.1s
 ✔ Container frontend-proxy   Started                                                                                                                                          20.5s

OpenTelemetry Demo is running.
Go to http://localhost:8080 for the demo UI.
Go to http://localhost:8080/jaeger/ui for the Jaeger UI.
Go to http://localhost:8080/grafana/ for the Grafana UI.
Go to http://localhost:8080/loadgen/ for the Load Generator UI.
Go to http://localhost:8080/feature/ to change feature flags.
Go to http://localhost:8080/telemetry/ for the Weaver generated telemetry documentation.
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
