### PR TITLE
Add profiling to the otel demo and use pyroscope as the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [profiling] Add profiling and use Pyroscope as the backend to ingest profiles.
+  This allows us to view profiles in Grafana.
+  [#3312](https://github.com/open-telemetry/opentelemetry-demo/pull/3312)
 * [docker] Podman doesn't support the tag feature of docker logs,
   for the otel-demo to support podman we need to remove the tag from docker logs.
   [#3304](https://github.com/open-telemetry/opentelemetry-demo/pull/3304)

--- a/Makefile
+++ b/Makefile
@@ -254,3 +254,7 @@ endif
 .PHONY: build-react-native-android
 build-react-native-android:
 	docker build -f src/react-native-app/android.Dockerfile --platform=linux/amd64 --output=. src/react-native-app
+
+.PHONY: start-profiling
+start-profiling:
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose.yml -f docker-compose-profiling.yml up --force-recreate --remove-orphans --detach

--- a/docker-compose-profiling.yml
+++ b/docker-compose-profiling.yml
@@ -1,30 +1,30 @@
 services:
-    otel-ebpf-profiler:
-      image: otel/opentelemetry-collector-ebpf-profiler:0.147.0
-      container_name: otel-ebpf-profiler
-      command:
-        - --config=/etc/ebpf-profiler-config.yaml
-        - --feature-gates=service.profilesSupport
-      privileged: true
-      pid: "host"
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock:ro
-        - ./src/otel-collector/otelcol-ebpf-profiling.yml:/etc/ebpf-profiler-config.yaml:ro
-        - /sys/kernel/debug:/sys/kernel/debug
-        - /sys/kernel/tracing:/sys/kernel/tracing
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
-        - /proc:/proc:ro
-      depends_on:
-        - pyroscope
-    pyroscope:
-      image: grafana/pyroscope:1.18.1
-      container_name: pyroscope
-      command:
-        - -config.file=/etc/pyroscope.yaml
-      volumes:
-        - ./src/pyroscope/config.yaml:/etc/pyroscope.yaml:ro
-      ports:
-        - "${PYROSCOPE_PORT:-4040}:4040"
-    grafana:
-      environment:
-        - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource,grafana-pyroscope-app"
+  otel-ebpf-profiler:
+    image: otel/opentelemetry-collector-ebpf-profiler:0.147.0
+    container_name: otel-ebpf-profiler
+    command:
+      - --config=/etc/ebpf-profiler-config.yaml
+      - --feature-gates=service.profilesSupport
+    privileged: true
+    pid: "host"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./src/otel-collector/otelcol-ebpf-profiling.yml:/etc/ebpf-profiler-config.yaml:ro
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /sys/kernel/tracing:/sys/kernel/tracing
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /proc:/proc:ro
+    depends_on:
+      - pyroscope
+  pyroscope:
+    image: grafana/pyroscope:1.18.1
+    container_name: pyroscope
+    command:
+      - -config.file=/etc/pyroscope.yaml
+    volumes:
+      - ./src/pyroscope/config.yaml:/etc/pyroscope.yaml:ro
+    ports:
+      - "${PYROSCOPE_PORT:-4040}:4040"
+  grafana:
+    environment:
+      - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource,grafana-pyroscope-app"

--- a/docker-compose-profiling.yml
+++ b/docker-compose-profiling.yml
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   otel-ebpf-profiler:
     image: otel/opentelemetry-collector-ebpf-profiler:0.147.0

--- a/docker-compose-profiling.yml
+++ b/docker-compose-profiling.yml
@@ -1,0 +1,30 @@
+services:
+    otel-ebpf-profiler:
+      image: otel/opentelemetry-collector-ebpf-profiler:0.147.0
+      container_name: otel-ebpf-profiler
+      command:
+        - --config=/etc/ebpf-profiler-config.yaml
+        - --feature-gates=service.profilesSupport
+      privileged: true
+      pid: "host"
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - ./src/otel-collector/otelcol-ebpf-profiling.yml:/etc/ebpf-profiler-config.yaml:ro
+        - /sys/kernel/debug:/sys/kernel/debug
+        - /sys/kernel/tracing:/sys/kernel/tracing
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+        - /proc:/proc:ro
+      depends_on:
+        - pyroscope
+    pyroscope:
+      image: grafana/pyroscope:1.18.1
+      container_name: pyroscope
+      command:
+        - -config.file=/etc/pyroscope.yaml
+      volumes:
+        - ./src/pyroscope/config.yaml:/etc/pyroscope.yaml:ro
+      ports:
+        - "${PYROSCOPE_PORT:-4040}:4040"
+    grafana:
+      environment:
+        - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource,grafana-pyroscope-app"

--- a/src/grafana/provisioning/datasources/pyroscope.yaml
+++ b/src/grafana/provisioning/datasources/pyroscope.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    uid: pyroscope
+    url: http://pyroscope:4040
+    isDefault: false
+    editable: true

--- a/src/grafana/provisioning/datasources/pyroscope.yaml
+++ b/src/grafana/provisioning/datasources/pyroscope.yaml
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: 1
 datasources:
   - name: Pyroscope

--- a/src/otel-collector/otelcol-ebpf-profiling.yml
+++ b/src/otel-collector/otelcol-ebpf-profiling.yml
@@ -15,4 +15,3 @@ service:
       receivers: [profiling]
       processors: [resourcedetection]
       exporters: [otlphttp/pyroscope]
-

--- a/src/otel-collector/otelcol-ebpf-profiling.yml
+++ b/src/otel-collector/otelcol-ebpf-profiling.yml
@@ -1,0 +1,18 @@
+receivers:
+  profiling:
+
+processors:
+  resourcedetection:
+    detectors: [docker]
+
+exporters:
+  otlphttp/pyroscope:
+    endpoint: http://pyroscope:4040
+
+service:
+  pipelines:
+    profiles:
+      receivers: [profiling]
+      processors: [resourcedetection]
+      exporters: [otlphttp/pyroscope]
+

--- a/src/otel-collector/otelcol-ebpf-profiling.yml
+++ b/src/otel-collector/otelcol-ebpf-profiling.yml
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 receivers:
   profiling:
 

--- a/src/pyroscope/config.yaml
+++ b/src/pyroscope/config.yaml
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 storage:
   backend: filesystem
   filesystem:

--- a/src/pyroscope/config.yaml
+++ b/src/pyroscope/config.yaml
@@ -4,6 +4,6 @@ storage:
     dir: /data
 limits:
   ingestion_relabeling_rules:
-      - action: labelmap
-        regex: ^process\.executable\.name$
-        replacement: service_name
+    - action: labelmap
+      regex: ^process\.executable\.name$
+      replacement: service_name

--- a/src/pyroscope/config.yaml
+++ b/src/pyroscope/config.yaml
@@ -1,0 +1,9 @@
+storage:
+  backend: filesystem
+  filesystem:
+    dir: /data
+limits:
+  ingestion_relabeling_rules:
+      - action: labelmap
+        regex: ^process\.executable\.name$
+        replacement: service_name


### PR DESCRIPTION
# Changes

This work add's profiling to the OTel-Demo. 

Closes: #1601 

- OTel collector added for profiling with heightened privileges, this is needed to profiling requiring access to the kernel. 

- Send the profiling data to a pyroscope backend.

- Makefile updated with `start-profiling` target which starts the demo along with the profiling collector.

> [!NOTE]
> This work leveraged the documentation from Pyroscope, [here](https://grafana.com/docs/pyroscope/latest/configure-client/opentelemetry/ebpf-profiler/).
> We can also add this to k8s, this would be done in the helm charts.

## Running

```bash
make start-profiling
```

You can view profiles via 2 paths:

- `http://localhost:4040/`
   - This is the pyroscope UI 
- `http://localhost:8080/grafana`
   - This is via Grafana

## Profiling in Grafana

Here we can see an overview of the profiling in Grafana

<img width="2458" height="1225" alt="image" src="https://github.com/user-attachments/assets/8aefba0e-08ca-41d2-82bf-cd54de9303b7" />


### Ad service High CPU

Here we turn on high CPU for the ad service (feature-flag) and we can use profiling to show us the problem code:

<img width="2430" height="982" alt="image" src="https://github.com/user-attachments/assets/14024723-2a6b-4556-9352-12c58aa11baa" />


## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
