### PR TITLE
fix(frontend): handle corrupted session data in localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [frontend] fix: handle corrupted session data in localStorage
+  ([#3313](https://github.com/open-telemetry/opentelemetry-demo/pull/3313))
 * [docker] Podman doesn't support the tag feature of docker logs,
   for the otel-demo to support podman we need to remove the tag from docker logs.
   [#3304](https://github.com/open-telemetry/opentelemetry-demo/pull/3304)

--- a/src/frontend/cypress/e2e/Home.cy.ts
+++ b/src/frontend/cypress/e2e/Home.cy.ts
@@ -26,4 +26,13 @@ describe('Home Page', () => {
 
     getElementByField(CypressFields.ProductCard).should('contain', getSymbolFromCurrency('EUR'));
   });
+
+  it('should recover corrupted stored session', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('session', 'not}{valid-json');
+      },
+    });
+    getElementByField(CypressFields.SessionId).should('contain', SessionGateway.getSession().userId);
+  });
 });

--- a/src/frontend/cypress/e2e/Home.cy.ts
+++ b/src/frontend/cypress/e2e/Home.cy.ts
@@ -7,11 +7,8 @@ import { getElementByField } from '../../utils/Cypress';
 import { CypressFields } from '../../utils/enums/CypressFields';
 
 describe('Home Page', () => {
-  beforeEach(() => {
-    cy.visit('/');
-  });
-
   it('should validate the home page', () => {
+    cy.visit('/');
     getElementByField(CypressFields.HomePage).should('exist');
     getElementByField(CypressFields.ProductCard, getElementByField(CypressFields.ProductList)).should('have.length', 10);
 
@@ -19,6 +16,7 @@ describe('Home Page', () => {
   });
 
   it('should change currency', () => {
+    cy.visit('/');
     getElementByField(CypressFields.CurrencySwitcher).select('EUR');
     getElementByField(CypressFields.ProductCard, getElementByField(CypressFields.ProductList)).should('have.length', 10);
 

--- a/src/frontend/gateways/Session.gateway.ts
+++ b/src/frontend/gateways/Session.gateway.ts
@@ -19,9 +19,19 @@ const SessionGateway = () => ({
     if (typeof window === 'undefined') return defaultSession;
     const sessionString = localStorage.getItem(sessionKey);
 
-    if (!sessionString) localStorage.setItem(sessionKey, JSON.stringify(defaultSession));
-
-    return JSON.parse(sessionString || JSON.stringify(defaultSession)) as ISession;
+    let session: ISession | null = null;
+    if (sessionString) {
+      try {
+        session = JSON.parse(sessionString);
+      } catch {
+        session = null;
+      }
+    }
+    if (!session || !isValid(session)) {
+      session = { ...defaultSession };
+      localStorage.setItem(sessionKey, JSON.stringify(session));
+    }
+    return session;
   },
   setSessionValue<K extends keyof ISession>(key: K, value: ISession[K]) {
     const session = this.getSession();
@@ -29,5 +39,14 @@ const SessionGateway = () => ({
     localStorage.setItem(sessionKey, JSON.stringify({ ...session, [key]: value }));
   },
 });
+
+const isValid = (session: any): boolean => {
+  return (
+    typeof session === 'object' &&
+    session !== null &&
+    typeof (session as ISession).userId === 'string' &&
+    typeof (session as ISession).currencyCode === 'string'
+  );
+};
 
 export default SessionGateway();

--- a/src/frontend/gateways/Session.gateway.ts
+++ b/src/frontend/gateways/Session.gateway.ts
@@ -9,7 +9,7 @@ interface ISession {
 }
 
 const sessionKey = 'session';
-const defaultSession: ISession = Object.freeze({
+const defaultSession: Readonly<ISession> = Object.freeze({
   userId: v4(),
   currencyCode: 'USD',
 });

--- a/src/frontend/gateways/Session.gateway.ts
+++ b/src/frontend/gateways/Session.gateway.ts
@@ -9,29 +9,28 @@ interface ISession {
 }
 
 const sessionKey = 'session';
-const defaultSession = {
+const defaultSession: ISession = Object.freeze({
   userId: v4(),
   currencyCode: 'USD',
-};
+});
 
 const SessionGateway = () => ({
   getSession(): ISession {
     if (typeof window === 'undefined') return defaultSession;
     const sessionString = localStorage.getItem(sessionKey);
 
-    let session: ISession | null = null;
     if (sessionString) {
       try {
-        session = JSON.parse(sessionString);
-      } catch {
-        session = null;
+        const parsed: unknown = JSON.parse(sessionString);
+        if (isValid(parsed)) {
+          return parsed;
+        }
+      } catch (e) {
+        console.warn('Failed to parse session from localStorage', e);
       }
     }
-    if (!session || !isValid(session)) {
-      session = { ...defaultSession };
-      localStorage.setItem(sessionKey, JSON.stringify(session));
-    }
-    return session;
+    localStorage.setItem(sessionKey, JSON.stringify(defaultSession));
+    return defaultSession;
   },
   setSessionValue<K extends keyof ISession>(key: K, value: ISession[K]) {
     const session = this.getSession();
@@ -40,7 +39,7 @@ const SessionGateway = () => ({
   },
 });
 
-const isValid = (session: any): boolean => {
+const isValid = (session: unknown): session is ISession => {
   return (
     typeof session === 'object' &&
     session !== null &&


### PR DESCRIPTION
# Changes

Add try-catch around JSON.parse to prevent from corrupted
localStorage data before returning session.
