### PR TITLE
ci: cache lychee link-check results and use during checking

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,11 +62,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Restore lychee cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        id: cache-restore
+        with:
+          path: .lycheecache
+          key: ${{ runner.os }}-lychee-${{ hashFiles('.lychee.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-lychee-
       - name: Run lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
-          args: --config .lychee.toml .
+          args: --config .lychee.toml --cache --max-cache-age 3d --cache-exclude-status 300..=599 .
           fail: true
+      - name: Save lychee cache
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: .lycheecache
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
   sanity:
     runs-on: ubuntu-latest

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,5 +19,3 @@ exclude = [
 exclude_path = [
   "CHANGELOG\\.md",
 ]
-
-accept = ["200", "429"]


### PR DESCRIPTION
In `.github/workflows/checks.yml`:

- Restores the lychee cache before link checks to reuse recent results across CI runs.
- Saves the cache after each run so future checks avoid revalidating unchanged links.
- Moves accepted status handling into cached lychee args and removes the static TOML override.

This is based on the go repo setups (they also use Lychee caching).

/cc @puckpuck @julianocosta89 