### PR TITLE
Enable lychee cache for local checks too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ composer.lock
 .dockerhub.env
 .ghcr.env
 *.apk
+/.lycheecache
 
 # Ignore copied/generated protobuf files
 /src/accounting/src/protos/

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ addlicense:	$(ADDLICENSE)
 .PHONY: checklinks
 checklinks:
 	@echo "Checking links..."
-	lychee --config .lychee.toml .
+	lychee --config .lychee.toml --cache .
 
 # Run all checks in order of speed / likely failure.
 .PHONY: check


### PR DESCRIPTION
- Cache external links when running local checks, it'll speed up subsequent runs
- Related and complimentary to #3314

/cc @puckpuck @julianocosta89 