### PR TITLE
fix: collector otelcol.signal scope attribute conflict in logs pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the release.
 
 ## Unreleased
 
+* [collector] Add `transform/sanitize_logs` processor to work around
+  `otelcol.signal` scope attribute conflict with `otelcol.signal.output`
+  that causes OpenSearch/Elasticsearch mapping failures
+  ([#3321](https://github.com/open-telemetry/opentelemetry-demo/pull/3321))
 * [telemetry-docs] Add a new service to provide telemetry documentation based
   on Weaver
   ([#2794](https://github.com/open-telemetry/opentelemetry-demo/pull/2794))

--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -160,6 +160,16 @@ processors:
     spike_limit_percentage: 25
   resourcedetection:
     detectors: [env, docker, system]
+  transform/sanitize_logs:
+    error_mode: ignore
+    log_statements:
+      - context: scope
+        statements:
+          # Rename flat "otelcol.signal" scope attribute to prevent mapping
+          # conflict with the dotted "otelcol.signal.output" attribute.
+          # Upstream Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/15221
+          - set(attributes["otelcol_signal"], attributes["otelcol.signal"]) where attributes["otelcol.signal"] != nil and not IsMap(attributes["otelcol.signal"])
+          - delete_key(attributes, "otelcol.signal") where attributes["otelcol_signal"] != nil
   transform/sanitize_spans:
     error_mode: ignore
     trace_statements:
@@ -221,7 +231,7 @@ service:
       exporters: [otlp_http/prometheus, debug]
     logs:
       receivers: [otlp]
-      processors: [resourcedetection, memory_limiter]
+      processors: [resourcedetection, memory_limiter, transform/sanitize_logs]
       exporters: [opensearch, debug]
   telemetry:
     metrics:


### PR DESCRIPTION
# Changes

- Add transform/sanitize_logs processor to rename the flat otelcol.signal scope attribute to otelcol_signal, preventing a mapping conflict with the dotted otelcol.signal.output attribute emitted by connectors
- The collector uses otelcol.signal as both a leaf value (on receivers/processors/exporters) and a namespace parent via otelcol.signal.output (on connectors), which breaks any backend with typed field mappings (OpenSearch, Elasticsearch, ClickHouse)
- Upstream issue filed: https://github.com/open-telemetry/opentelemetry-collector/issues/15221

Fixes: https://github.com/open-telemetry/opentelemetry-demo/issues/3297

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
