### PR TITLE
fix: rename `app.product.name` attribute to `demo.product.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ the release.
   `app.product.id` to `demo.product.id` across cart, product-catalog,
   product-reviews, telemetry schema, and trace tests.
   ([#3355](https://github.com/open-telemetry/opentelemetry-demo/pull/3355))
+* [telemetry] Rename the product name telemetry attribute from
+  `app.product.name` to `demo.product.name` across product-catalog and
+  telemetry schema.
+  ([#3370](https://github.com/open-telemetry/opentelemetry-demo/pull/3370))
 * [telemetry] Rename the product quantity telemetry attribute from
   `app.product.quantity` to `demo.product.quantity` across cart and
   telemetry schema.

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -379,13 +379,13 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 	span.AddEvent("Product Found")
 	span.SetAttributes(
 		attribute.String("demo.product.id", req.Id),
-		attribute.String("app.product.name", found.Name),
+		attribute.String("demo.product.name", found.Name),
 	)
 
 	logger.LogAttrs(
 		ctx,
 		slog.LevelInfo, "Product Found",
-		slog.String("app.product.name", found.Name),
+		slog.String("demo.product.name", found.Name),
 		slog.String("demo.product.id", req.Id),
 	)
 

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -9,7 +9,7 @@ attributes:
     stability: stable
     note: The unique identifier of the product being viewed, reviewed, or added to cart
     examples: ["66VCHSJNUP", "OLJCESPC7Z", "9SOIN3QJO0"]
-  - key: app.product.name
+  - key: demo.product.name
     type: string
     brief: Product name
     stability: stable

--- a/telemetry-schema/services/product_catalog.yaml
+++ b/telemetry-schema/services/product_catalog.yaml
@@ -10,5 +10,5 @@ attribute_groups:
     attributes:
       - ref: app.products.count
       - ref: demo.product.id
-      - ref: app.product.name
+      - ref: demo.product.name
       - ref: app.products_search.count


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename `app.product.name` attribute to `demo.product.name` 

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts


