### PR TITLE
fix: rename `app.product.quantity` attribute to `demo.product.quantity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,14 +87,14 @@ the release.
   `app.product.id` to `demo.product.id` across cart, product-catalog,
   product-reviews, telemetry schema, and trace tests.
   ([#3355](https://github.com/open-telemetry/opentelemetry-demo/pull/3355))
-* [telemetry] Rename the product review question telemetry attribute from
-  `app.product.question` to `demo.product.review.question` across
-  product-reviews and telemetry schema.
-  ([#3372](https://github.com/open-telemetry/opentelemetry-demo/pull/3372))
 * [telemetry] Rename the product quantity telemetry attribute from
   `app.product.quantity` to `demo.product.quantity` across cart and
   telemetry schema.
   ([#3371](https://github.com/open-telemetry/opentelemetry-demo/pull/3371))
+* [telemetry] Rename the product review question telemetry attribute from
+  `app.product.question` to `demo.product.review.question` across
+  product-reviews and telemetry schema.
+  ([#3372](https://github.com/open-telemetry/opentelemetry-demo/pull/3372))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ the release.
 * [telemetry] Rename the product review question telemetry attribute from
   `app.product.question` to `demo.product.review.question` across
   product-reviews and telemetry schema.
+  ([#3372](https://github.com/open-telemetry/opentelemetry-demo/pull/3372))
+* [telemetry] Rename the product quantity telemetry attribute from
+  `app.product.quantity` to `demo.product.quantity` across cart and
+  telemetry schema.
+  ([#3371](https://github.com/open-telemetry/opentelemetry-demo/pull/3371))
 
 ## 2.2.0
 

--- a/src/cart/src/services/CartService.cs
+++ b/src/cart/src/services/CartService.cs
@@ -30,7 +30,7 @@ public class CartService : Oteldemo.CartService.CartServiceBase
         var activity = Activity.Current;
         activity?.SetTag("app.user.id", request.UserId);
         activity?.SetTag("demo.product.id", request.Item.ProductId);
-        activity?.SetTag("app.product.quantity", request.Item.Quantity);
+        activity?.SetTag("demo.product.quantity", request.Item.Quantity);
 
         try
         {

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -15,7 +15,7 @@ attributes:
     stability: stable
     note: The name or title of the product
     examples: ["Wireless Headphones", "Coffee Maker", "Running Shoes"]
-  - key: app.product.quantity
+  - key: demo.product.quantity
     type: int
     brief: Product quantity
     stability: stable

--- a/telemetry-schema/services/cart.yaml
+++ b/telemetry-schema/services/cart.yaml
@@ -10,5 +10,5 @@ attribute_groups:
     attributes:
       - ref: app.user.id
       - ref: demo.product.id
-      - ref: app.product.quantity
+      - ref: demo.product.quantity
       - ref: app.cart.items.count


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename `app.product.quantity` attribute to `demo.product.quantity` 

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts


