### PR TITLE
fix: rename `app.product.question` attribute to `demo.product.review.question`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ the release.
   `app.product.id` to `demo.product.id` across cart, product-catalog,
   product-reviews, telemetry schema, and trace tests.
   ([#3355](https://github.com/open-telemetry/opentelemetry-demo/pull/3355))
+* [telemetry] Rename the product review question telemetry attribute from
+  `app.product.question` to `demo.product.review.question` across
+  product-reviews and telemetry schema.
 
 ## 2.2.0
 

--- a/src/product-reviews/product_reviews_server.py
+++ b/src/product-reviews/product_reviews_server.py
@@ -159,7 +159,7 @@ def get_ai_assistant_response(request_product_id, question):
         ai_assistant_response = demo_pb2.AskProductAIAssistantResponse()
 
         span.set_attribute("demo.product.id", request_product_id)
-        span.set_attribute("app.product.question", question)
+        span.set_attribute("demo.product.review.question", question)
 
         llm_rate_limit_error = check_feature_flag("llmRateLimitError")
         logger.info(f"llmRateLimitError feature flag: {llm_rate_limit_error}")

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -21,7 +21,7 @@ attributes:
     stability: stable
     note: The quantity of a product being added to cart or ordered
     examples: [1, 2, 5]
-  - key: app.product.question
+  - key: demo.product.review.question
     type: string
     brief: Product review question
     stability: stable

--- a/telemetry-schema/services/product_reviews.yaml
+++ b/telemetry-schema/services/product_reviews.yaml
@@ -11,4 +11,4 @@ attribute_groups:
       - ref: demo.product.id
       - ref: app.product_reviews.count
       - ref: app.product_reviews.average_score
-      - ref: app.product.question
+      - ref: demo.product.review.question


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename `app.product.question` attribute to `demo.product.review.question` 

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts


