### PR TITLE
fix: rename `app.products.count` attribute to `demo.product.count` and `app.products_recommended.count` attribute to `demo.product.recommended.count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ the release.
   `app.products.count` to `demo.product.count` and from
   `app.products_recommended.count` to `demo.product.recommended.count` across
   recommendation, telemetry schema, and trace tests.
+  ([#3374](https://github.com/open-telemetry/opentelemetry-demo/pull/3374))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@ the release.
   `app.product.question` to `demo.product.review.question` across
   product-reviews and telemetry schema.
   ([#3372](https://github.com/open-telemetry/opentelemetry-demo/pull/3372))
+* [telemetry] Rename product count telemetry attributes from
+  `app.products.count` to `demo.product.count` and from
+  `app.products_recommended.count` to `demo.product.recommended.count` across
+  recommendation, telemetry schema, and trace tests.
 
 ## 2.2.0
 

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -349,7 +349,7 @@ func (p *productCatalog) ListProducts(ctx context.Context, req *pb.Empty) (*pb.L
 	}
 
 	span.SetAttributes(
-		attribute.Int("app.products.count", len(products)),
+		attribute.Int("demo.product.count", len(products)),
 	)
 	return &pb.ListProductsResponse{Products: products}, nil
 }

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -43,7 +43,7 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
         prod_list = get_product_list(request.product_ids)
         span = trace.get_current_span()
-        span.set_attribute("app.products_recommended.count", len(prod_list))
+        span.set_attribute("demo.product.recommended.count", len(prod_list))
         logger.info(f"Receive ListRecommendations for product ids:{prod_list}")
 
         # build and return response

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -95,7 +95,7 @@ def get_product_list(request_product_ids):
             cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
             product_ids = [x.id for x in cat_response.products]
 
-        span.set_attribute("app.products.count", len(product_ids))
+        span.set_attribute("demo.product.count", len(product_ids))
 
         # Create a filtered list of products excluding the products received as input
         filtered_products = list(set(product_ids) - set(request_product_ids))

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -33,7 +33,7 @@ attributes:
     stability: stable
     note: The total number of products available in the product catalog
     examples: [100, 500, 1000]
-  - key: app.products_recommended.count
+  - key: demo.product.recommended.count
     type: int
     brief: Number of products recommended
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -27,7 +27,7 @@ attributes:
     stability: stable
     note: A question or query related to product reviews, such as a customer inquiry about product features or quality
     examples: ["Is this product durable?", "What is the warranty?"]
-  - key: app.products.count
+  - key: demo.product.count
     type: int
     brief: Total number of products available
     stability: stable

--- a/telemetry-schema/services/product_catalog.yaml
+++ b/telemetry-schema/services/product_catalog.yaml
@@ -8,7 +8,7 @@ attribute_groups:
     brief: Product Catalog service attributes
     stability: stable
     attributes:
-      - ref: app.products.count
+      - ref: demo.product.count
       - ref: demo.product.id
       - ref: demo.product.name
       - ref: app.products_search.count

--- a/telemetry-schema/services/recommendation.yaml
+++ b/telemetry-schema/services/recommendation.yaml
@@ -8,7 +8,7 @@ attribute_groups:
     brief: Recommendation service attributes
     stability: stable
     attributes:
-      - ref: app.products_recommended.count
+      - ref: demo.product.recommended.count
       - ref: app.recommendation.cache_enabled
       - ref: app.cache_hit
       - ref: demo.product.count

--- a/telemetry-schema/services/recommendation.yaml
+++ b/telemetry-schema/services/recommendation.yaml
@@ -11,6 +11,6 @@ attribute_groups:
       - ref: app.products_recommended.count
       - ref: app.recommendation.cache_enabled
       - ref: app.cache_hit
-      - ref: app.products.count
+      - ref: demo.product.count
       - ref: app.filtered_products.count
       - ref: app.filtered_products.list

--- a/test/tracetesting/frontend/02-get-product-recommendation.yaml
+++ b/test/tracetesting/frontend/02-get-product-recommendation.yaml
@@ -33,4 +33,4 @@ spec:
     selector: span[tracetest.span.type="rpc" name="/oteldemo.RecommendationService/ListRecommendations" rpc.system="grpc" rpc.method="ListRecommendations" rpc.service="oteldemo.RecommendationService"]
     assertions:
     - attr:rpc.grpc.status_code = 0
-    - attr:app.products_recommended.count = 5
+    - attr:demo.product.recommended.count = 5

--- a/test/tracetesting/product-catalog/list.yaml
+++ b/test/tracetesting/product-catalog/list.yaml
@@ -19,7 +19,7 @@ spec:
       rpc.system="grpc" rpc.method="ListProducts" rpc.service="oteldemo.ProductCatalogService"]
     assertions:
     - attr:rpc.grpc.status_code  =  0
-    - attr:app.products.count  =  10
+    - attr:demo.product.count  =  10
   - name: It returned products with IDs
     selector: span[tracetest.span.type="general" name="Tracetest trigger"]
     assertions:

--- a/test/tracetesting/recommendation/list.yaml
+++ b/test/tracetesting/recommendation/list.yaml
@@ -22,4 +22,4 @@ spec:
     selector: span[tracetest.span.type="rpc" name="/oteldemo.RecommendationService/ListRecommendations" rpc.system="grpc" rpc.method="ListRecommendations" rpc.service="oteldemo.RecommendationService"]
     assertions:
     - attr:rpc.grpc.status_code  =  0
-    - attr:app.products_recommended.count = 5
+    - attr:demo.product.recommended.count = 5


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename `app.products.count` attribute to `demo.product.count` and `app.products_recommended.count` attribute to `demo.product.recommended.count`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts


