### PR TITLE
fix: Rename `app.filtered_products.count`, `app.filtered_products.list`, `app.products_search.count`, `app.product_reviews.count`, `app.product_reviews.average_score`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ the release.
   `app.products_recommended.count` to `demo.product.recommended.count` across
   recommendation, telemetry schema, and trace tests.
   ([#3374](https://github.com/open-telemetry/opentelemetry-demo/pull/3374))
+* [telemetry] Rename product filtering, search, and review telemetry attributes:
+  `app.filtered_products.count` to `demo.product.filtered.count`,
+  `app.filtered_products.list` to `demo.product.filtered.list`,
+  `app.products_search.count` to `demo.product.search.count`,
+  `app.product_reviews.count` to `demo.product.review.count`, and
+  `app.product_reviews.average_score` to `demo.product.review.average_score`
+  across product-catalog, product-reviews, recommendation, telemetry schema,
+  and trace tests.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ the release.
   `app.product_reviews.average_score` to `demo.product.review.average_score`
   across product-catalog, product-reviews, recommendation, telemetry schema,
   and trace tests.
+  ([#3376](https://github.com/open-telemetry/opentelemetry-demo/pull/3376))
 
 ## 2.2.0
 

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -402,7 +402,7 @@ func (p *productCatalog) SearchProducts(ctx context.Context, req *pb.SearchProdu
 	}
 
 	span.SetAttributes(
-		attribute.Int("app.products_search.count", len(result)),
+		attribute.Int("demo.product.search.count", len(result)),
 	)
 	return &pb.SearchProductsResponse{Results: result}, nil
 }

--- a/src/product-reviews/product_reviews_server.py
+++ b/src/product-reviews/product_reviews_server.py
@@ -131,7 +131,7 @@ def get_product_reviews(request_product_id):
                     score=str(row[2])
             )
 
-        span.set_attribute("app.product_reviews.count", len(product_reviews.product_reviews))
+        span.set_attribute("demo.product.review.count", len(product_reviews.product_reviews))
 
         # Collect metrics for this service
         product_review_svc_metrics["app_product_review_counter"].add(len(product_reviews.product_reviews), {'product.id': request_product_id})

--- a/src/product-reviews/product_reviews_server.py
+++ b/src/product-reviews/product_reviews_server.py
@@ -148,7 +148,7 @@ def get_average_product_review_score(request_product_id):
         avg_score = fetch_avg_product_review_score_from_db(request_product_id)
         product_review_score.average_score = avg_score
 
-        span.set_attribute("app.product_reviews.average_score", avg_score)
+        span.set_attribute("demo.product.review.average_score", avg_score)
 
         return product_review_score
 

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -108,7 +108,7 @@ def get_product_list(request_product_ids):
         # Fetch product ids from indices
         prod_list = [filtered_products[i] for i in indices]
 
-        span.set_attribute("app.filtered_products.list", prod_list)
+        span.set_attribute("demo.product.filtered.list", prod_list)
 
         return prod_list
 

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -100,7 +100,7 @@ def get_product_list(request_product_ids):
         # Create a filtered list of products excluding the products received as input
         filtered_products = list(set(product_ids) - set(request_product_ids))
         num_products = len(filtered_products)
-        span.set_attribute("app.filtered_products.count", num_products)
+        span.set_attribute("demo.product.filtered.count", num_products)
         num_return = min(max_responses, num_products)
 
         # Sample list of indicies to return

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -63,7 +63,7 @@ attributes:
     stability: stable
     note: The count of reviews returned or processed for a specific product
     examples: [5, 10, 25]
-  - key: app.product_reviews.average_score
+  - key: demo.product.review.average_score
     type: double
     brief: Average review score
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -51,7 +51,7 @@ attributes:
     stability: stable
     note: A list of product IDs that were included in the filtered product set
     examples: ["OLJCESPC7Z,9SOIN3QJO0,6E92ZMJLZN"]
-  - key: app.products_search.count
+  - key: demo.product.search.count
     type: int
     brief: Number of search results
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -57,7 +57,7 @@ attributes:
     stability: stable
     note: The count of products matching a search query
     examples: [0, 10, 50]
-  - key: app.product_reviews.count
+  - key: demo.product.review.count
     type: int
     brief: Number of product reviews
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -39,7 +39,7 @@ attributes:
     stability: stable
     note: The count of products recommended to the user
     examples: [5, 10, 15]
-  - key: app.filtered_products.count
+  - key: demo.product.filtered.count
     type: int
     brief: Number of products after filtering
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -45,7 +45,7 @@ attributes:
     stability: stable
     note: The number of products remaining after applying filters (e.g., availability, category, price range)
     examples: [5, 20, 50]
-  - key: app.filtered_products.list
+  - key: demo.product.filtered.list
     type: string[]
     brief: List of filtered product IDs
     stability: stable

--- a/telemetry-schema/services/product_catalog.yaml
+++ b/telemetry-schema/services/product_catalog.yaml
@@ -11,4 +11,4 @@ attribute_groups:
       - ref: demo.product.count
       - ref: demo.product.id
       - ref: demo.product.name
-      - ref: app.products_search.count
+      - ref: demo.product.search.count

--- a/telemetry-schema/services/product_reviews.yaml
+++ b/telemetry-schema/services/product_reviews.yaml
@@ -10,5 +10,5 @@ attribute_groups:
     attributes:
       - ref: demo.product.id
       - ref: demo.product.review.count
-      - ref: app.product_reviews.average_score
+      - ref: demo.product.review.average_score
       - ref: demo.product.review.question

--- a/telemetry-schema/services/product_reviews.yaml
+++ b/telemetry-schema/services/product_reviews.yaml
@@ -9,6 +9,6 @@ attribute_groups:
     stability: stable
     attributes:
       - ref: demo.product.id
-      - ref: app.product_reviews.count
+      - ref: demo.product.review.count
       - ref: app.product_reviews.average_score
       - ref: demo.product.review.question

--- a/telemetry-schema/services/recommendation.yaml
+++ b/telemetry-schema/services/recommendation.yaml
@@ -12,5 +12,5 @@ attribute_groups:
       - ref: app.recommendation.cache_enabled
       - ref: app.cache_hit
       - ref: demo.product.count
-      - ref: app.filtered_products.count
+      - ref: demo.product.filtered.count
       - ref: app.filtered_products.list

--- a/telemetry-schema/services/recommendation.yaml
+++ b/telemetry-schema/services/recommendation.yaml
@@ -13,4 +13,4 @@ attribute_groups:
       - ref: app.cache_hit
       - ref: demo.product.count
       - ref: demo.product.filtered.count
-      - ref: app.filtered_products.list
+      - ref: demo.product.filtered.list

--- a/test/tracetesting/product-catalog/search.yaml
+++ b/test/tracetesting/product-catalog/search.yaml
@@ -20,7 +20,7 @@ spec:
   - name: It called SearchProducts correctly and it returned 1 item
     selector: span[tracetest.span.type="rpc" name="oteldemo.ProductCatalogService/SearchProducts" rpc.system="grpc" rpc.method="SearchProducts" rpc.service="oteldemo.ProductCatalogService"]
     assertions:
-    - attr:app.products_search.count = 1
+    - attr:demo.product.search.count = 1
     - attr:rpc.grpc.status_code = 0
   - name: It returned the desired product
     selector: span[tracetest.span.type="general" name="Tracetest trigger"]

--- a/test/tracetesting/product-reviews/reviews.yaml
+++ b/test/tracetesting/product-reviews/reviews.yaml
@@ -21,4 +21,4 @@ spec:
       selector: span[name="get_product_reviews"]
       assertions:
         - attr:demo.product.id  =  "L9ECAV7KIM"
-        - attr:app.product_reviews.count = 5
+        - attr:demo.product.review.count = 5

--- a/test/tracetesting/product-reviews/summary.yaml
+++ b/test/tracetesting/product-reviews/summary.yaml
@@ -21,4 +21,4 @@ spec:
       selector: span[name="get_average_product_review_score"]
       assertions:
         - attr:demo.product.id  =  "66VCHSJNUP"
-        - attr:app.product_reviews.average_score = 4.6
+        - attr:demo.product.review.average_score = 4.6


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename:

- `app.filtered_products.count` to `demo.product.filtered.count`
- `app.filtered_products.list` to `demo.product.filtered.list`
- `app.products_search.count` to `demo.product.search.count`
- `app.product_reviews.count` to `demo.product.review.count`
- `app.product_reviews.average_score` to `demo.product.review.average_score`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts


