### PR TITLE
fix: rename Advertising category to `demo.ad.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ the release.
   `app.ads.ad_response_type` to `demo.ad.response_type` across ad,
   product-catalog, product-reviews, recommendation, telemetry schema, and trace
   tests.
+  ([#3377](https://github.com/open-telemetry/opentelemetry-demo/pull/3387))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ the release.
   across product-catalog, product-reviews, recommendation, telemetry schema,
   and trace tests.
   ([#3376](https://github.com/open-telemetry/opentelemetry-demo/pull/3376))
+* [telemetry] Rename advertising telemetry attributes:
+  `app.ads.category` to `demo.ad.category`,
+  `app.ads.count` to `demo.ad.count`,
+  `app.ads.contextKeys` to `demo.ad.context_keys`,
+  `app.ads.contextKeys.count` to `demo.ad.context_keys.count`,
+  `app.ads.ad_request_type` to `demo.ad.request_type`, and
+  `app.ads.ad_response_type` to `demo.ad.response_type` across ad,
+  product-catalog, product-reviews, recommendation, telemetry schema, and trace
+  tests.
 
 ## 2.2.0
 

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -71,7 +71,7 @@ public final class AdService {
   private static final AttributeKey<String> adRequestTypeKey =
       AttributeKey.stringKey("demo.ad.request_type");
   private static final AttributeKey<String> adResponseTypeKey =
-      AttributeKey.stringKey("app.ads.ad_response_type");
+      AttributeKey.stringKey("demo.ad.response_type");
 
   private void start() throws IOException {
     int port =
@@ -194,7 +194,7 @@ public final class AdService {
         }
         span.setAttribute("demo.ad.count", allAds.size());
         span.setAttribute("demo.ad.request_type", adRequestType.name());
-        span.setAttribute("app.ads.ad_response_type", adResponseType.name());
+        span.setAttribute("demo.ad.response_type", adResponseType.name());
 
         adRequestsCounter.add(
             1,

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -171,8 +171,8 @@ public final class AdService {
         CPULoad cpuload = CPULoad.getInstance();
         cpuload.execute(ffClient.getBooleanValue(AD_HIGH_CPU_FEATURE_FLAG, false, evaluationContext));
 
-        span.setAttribute("app.ads.contextKeys", req.getContextKeysList().toString());
-        span.setAttribute("app.ads.contextKeys.count", req.getContextKeysCount());
+        span.setAttribute("demo.ad.context_keys", req.getContextKeysList().toString());
+        span.setAttribute("demo.ad.context_keys.count", req.getContextKeysCount());
         if (req.getContextKeysCount() > 0) {
           logger.info("Targeted ad request received for " + req.getContextKeysList());
           for (int i = 0; i < req.getContextKeysCount(); i++) {

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -192,7 +192,7 @@ public final class AdService {
           allAds = service.getRandomAds();
           adResponseType = AdResponseType.RANDOM;
         }
-        span.setAttribute("app.ads.count", allAds.size());
+        span.setAttribute("demo.ad.count", allAds.size());
         span.setAttribute("app.ads.ad_request_type", adRequestType.name());
         span.setAttribute("app.ads.ad_response_type", adResponseType.name());
 
@@ -230,7 +230,7 @@ public final class AdService {
   @WithSpan("getAdsByCategory")
   private Collection<Ad> getAdsByCategory(@SpanAttribute("demo.ad.category") String category) {
     Collection<Ad> ads = adsMap.get(category);
-    Span.current().setAttribute("app.ads.count", ads.size());
+    Span.current().setAttribute("demo.ad.count", ads.size());
     return ads;
   }
 
@@ -250,7 +250,7 @@ public final class AdService {
       for (int i = 0; i < MAX_ADS_TO_SERVE; i++) {
         ads.add(Iterables.get(allAds, random.nextInt(allAds.size())));
       }
-      span.setAttribute("app.ads.count", ads.size());
+      span.setAttribute("demo.ad.count", ads.size());
 
     } finally {
       span.end();

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -69,7 +69,7 @@ public final class AdService {
           .build();
 
   private static final AttributeKey<String> adRequestTypeKey =
-      AttributeKey.stringKey("app.ads.ad_request_type");
+      AttributeKey.stringKey("demo.ad.request_type");
   private static final AttributeKey<String> adResponseTypeKey =
       AttributeKey.stringKey("app.ads.ad_response_type");
 
@@ -193,7 +193,7 @@ public final class AdService {
           adResponseType = AdResponseType.RANDOM;
         }
         span.setAttribute("demo.ad.count", allAds.size());
-        span.setAttribute("app.ads.ad_request_type", adRequestType.name());
+        span.setAttribute("demo.ad.request_type", adRequestType.name());
         span.setAttribute("app.ads.ad_response_type", adResponseType.name());
 
         adRequestsCounter.add(

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -228,7 +228,7 @@ public final class AdService {
   private static final ImmutableListMultimap<String, Ad> adsMap = createAdsMap();
 
   @WithSpan("getAdsByCategory")
-  private Collection<Ad> getAdsByCategory(@SpanAttribute("app.ads.category") String category) {
+  private Collection<Ad> getAdsByCategory(@SpanAttribute("demo.ad.category") String category) {
     Collection<Ad> ads = adsMap.get(category);
     Span.current().setAttribute("app.ads.count", ads.size());
     return ads;

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -99,7 +99,7 @@ attributes:
     stability: stable
     note: Indicates whether the ad request was targeted or not
     examples: ["TARGETED", "NOT_TARGETED"]
-  - key: app.ads.ad_response_type
+  - key: demo.ad.response_type
     type: string
     brief: Type of ad response
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -75,7 +75,7 @@ attributes:
     stability: stable
     note: The category of advertisements being served
     examples: ["electronics", "clothing", "home"]
-  - key: app.ads.count
+  - key: demo.ad.count
     type: int
     brief: Number of advertisements served
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -93,7 +93,7 @@ attributes:
     stability: stable
     note: The count of context keys provided for ad targeting
     examples: [0, 2, 5]
-  - key: app.ads.ad_request_type
+  - key: demo.ad.request_type
     type: string
     brief: Type of ad request
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -81,13 +81,13 @@ attributes:
     stability: stable
     note: The count of advertisements returned or served in a request
     examples: [1, 2, 5]
-  - key: app.ads.contextKeys
+  - key: demo.ad.context_keys
     type: string
     brief: Context keys for ad targeting
     stability: stable
     note: Comma-separated list of context keys used for ad targeting
     examples: ["electronics,gadgets", "home,kitchen"]
-  - key: app.ads.contextKeys.count
+  - key: demo.ad.context_keys.count
     type: int
     brief: Number of context keys
     stability: stable

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -69,7 +69,7 @@ attributes:
     stability: stable
     note: The average rating score across all reviews for a product, typically on a scale of 1-5
     examples: [4.5, 3.2, 4.8]
-  - key: app.ads.category
+  - key: demo.ad.category
     type: string
     brief: Advertisement category
     stability: stable

--- a/telemetry-schema/metrics/ad.yaml
+++ b/telemetry-schema/metrics/ad.yaml
@@ -11,7 +11,7 @@ metrics:
     annotations:
       service: ad
     attributes:
-      - ref: app.ads.ad_request_type
+      - ref: demo.ad.request_type
         requirement_level: required
         note: Indicates whether the ad request was targeted based on context keys
       - ref: app.ads.ad_response_type

--- a/telemetry-schema/metrics/ad.yaml
+++ b/telemetry-schema/metrics/ad.yaml
@@ -14,6 +14,6 @@ metrics:
       - ref: demo.ad.request_type
         requirement_level: required
         note: Indicates whether the ad request was targeted based on context keys
-      - ref: app.ads.ad_response_type
+      - ref: demo.ad.response_type
         requirement_level: required
         note: Indicates whether targeted ads were returned or random ads were used

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -8,8 +8,8 @@ attribute_groups:
     brief: Ad service attributes
     stability: stable
     attributes:
-      - ref: app.ads.contextKeys
-      - ref: app.ads.contextKeys.count
+      - ref: demo.ad.context_keys
+      - ref: demo.ad.context_keys.count
       - ref: demo.ad.count
       - ref: app.ads.ad_request_type
       - ref: app.ads.ad_response_type

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -10,7 +10,7 @@ attribute_groups:
     attributes:
       - ref: app.ads.contextKeys
       - ref: app.ads.contextKeys.count
-      - ref: app.ads.count
+      - ref: demo.ad.count
       - ref: app.ads.ad_request_type
       - ref: app.ads.ad_response_type
       - ref: demo.ad.category

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -12,6 +12,6 @@ attribute_groups:
       - ref: demo.ad.context_keys.count
       - ref: demo.ad.count
       - ref: demo.ad.request_type
-      - ref: app.ads.ad_response_type
+      - ref: demo.ad.response_type
       - ref: demo.ad.category
       - ref: session.id

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -13,5 +13,5 @@ attribute_groups:
       - ref: app.ads.count
       - ref: app.ads.ad_request_type
       - ref: app.ads.ad_response_type
-      - ref: app.ads.category
+      - ref: demo.ad.category
       - ref: session.id

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -11,7 +11,7 @@ attribute_groups:
       - ref: demo.ad.context_keys
       - ref: demo.ad.context_keys.count
       - ref: demo.ad.count
-      - ref: app.ads.ad_request_type
+      - ref: demo.ad.request_type
       - ref: app.ads.ad_response_type
       - ref: demo.ad.category
       - ref: session.id

--- a/test/tracetesting/ad/get.yaml
+++ b/test/tracetesting/ad/get.yaml
@@ -20,7 +20,7 @@ spec:
   - name: It returns two ads
     selector: span[tracetest.span.type="rpc" name="oteldemo.AdService/GetAds" rpc.system="grpc" rpc.method="GetAds" rpc.service="oteldemo.AdService"]
     assertions:
-    - attr:app.ads.count = 2
+    - attr:demo.ad.count = 2
   - name: It returns a valid redirectUrl for each ads
     selector: span[tracetest.span.type="general" name="Tracetest trigger"]
     assertions:

--- a/test/tracetesting/frontend/01-see-ads.yaml
+++ b/test/tracetesting/frontend/01-see-ads.yaml
@@ -32,4 +32,4 @@ spec:
   - name: It returns two ads
     selector: span[tracetest.span.type="rpc" name="oteldemo.AdService/GetAds" rpc.system="grpc" rpc.method="GetAds" rpc.service="oteldemo.AdService"]
     assertions:
-    - attr:app.ads.count = 2
+    - attr:demo.ad.count = 2


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename the Advertising category in https://github.com/open-telemetry/opentelemetry-demo/issues/3267

  `app.ads.category` to `demo.ad.category`,
  `app.ads.count` to `demo.ad.count`,
  `app.ads.contextKeys` to `demo.ad.context_keys`,
  `app.ads.contextKeys.count` to `demo.ad.context_keys.count`,
  `app.ads.ad_request_type` to `demo.ad.request_type`, and
  `app.ads.ad_response_type` to `demo.ad.response_type`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
