### PR TITLE
fix: rename Order and Cart categories to `demo.order.*` and `demo.cart.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ the release.
   `app.order.items.count` to `demo.order.items.count`, and
   `app.cart.items.count` to `demo.cart.items.count` across cart, checkout,
   email, telemetry schema, and trace tests.
+  ([#3389](https://github.com/open-telemetry/opentelemetry-demo/pull/3389))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ the release.
   `app.ads.ad_response_type` to `demo.ad.response_type` across ad,
   product-catalog, product-reviews, recommendation, telemetry schema, and trace
   tests.
-  ([#3377](https://github.com/open-telemetry/opentelemetry-demo/pull/3387))
+  ([#3387](https://github.com/open-telemetry/opentelemetry-demo/pull/3387))
 * [telemetry] Rename order and cart telemetry attributes:
   `app.order.id` to `demo.order.id`,
   `app.order.amount` to `demo.order.amount`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ the release.
   product-catalog, product-reviews, recommendation, telemetry schema, and trace
   tests.
   ([#3377](https://github.com/open-telemetry/opentelemetry-demo/pull/3387))
+* [telemetry] Rename order and cart telemetry attributes:
+  `app.order.id` to `demo.order.id`,
+  `app.order.amount` to `demo.order.amount`,
+  `app.order.items.count` to `demo.order.items.count`, and
+  `app.cart.items.count` to `demo.cart.items.count` across cart, checkout,
+  email, telemetry schema, and trace tests.
 
 ## 2.2.0
 

--- a/src/cart/src/services/CartService.cs
+++ b/src/cart/src/services/CartService.cs
@@ -60,7 +60,7 @@ public class CartService : Oteldemo.CartService.CartServiceBase
             {
                 totalCart += item.Quantity;
             }
-            activity?.SetTag("app.cart.items.count", totalCart);
+            activity?.SetTag("demo.cart.items.count", totalCart);
 
             return cart;
         }

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -364,7 +364,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	totalPriceFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", total.GetUnits(), total.GetNanos()/1000000000), 64)
 
 	span.SetAttributes(
-		attribute.String("app.order.id", orderID.String()),
+		attribute.String("demo.order.id", orderID.String()),
 		attribute.Float64("app.shipping.amount", shippingCostFloat),
 		attribute.Float64("app.order.amount", totalPriceFloat),
 		attribute.Int("app.order.items.count", len(prep.orderItems)),
@@ -373,7 +373,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	logger.LogAttrs(
 		ctx,
 		slog.LevelInfo, "order placed",
-		slog.String("app.order.id", orderID.String()),
+		slog.String("demo.order.id", orderID.String()),
 		slog.Float64("app.shipping.amount", shippingCostFloat),
 		slog.Float64("app.order.amount", totalPriceFloat),
 		slog.Int("app.order.items.count", len(prep.orderItems)),

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -437,7 +437,7 @@ func (cs *checkout) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Contex
 
 	span.SetAttributes(
 		attribute.Float64("app.shipping.amount", shippingCostFloat),
-		attribute.Int("app.cart.items.count", int(totalCart)),
+		attribute.Int("demo.cart.items.count", int(totalCart)),
 		attribute.Int("demo.order.items.count", len(orderItems)),
 	)
 	return out, nil

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -367,7 +367,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		attribute.String("demo.order.id", orderID.String()),
 		attribute.Float64("app.shipping.amount", shippingCostFloat),
 		attribute.Float64("demo.order.amount", totalPriceFloat),
-		attribute.Int("app.order.items.count", len(prep.orderItems)),
+		attribute.Int("demo.order.items.count", len(prep.orderItems)),
 		shippingTrackingAttribute,
 	)
 	logger.LogAttrs(
@@ -376,7 +376,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		slog.String("demo.order.id", orderID.String()),
 		slog.Float64("app.shipping.amount", shippingCostFloat),
 		slog.Float64("demo.order.amount", totalPriceFloat),
-		slog.Int("app.order.items.count", len(prep.orderItems)),
+		slog.Int("demo.order.items.count", len(prep.orderItems)),
 		slog.String("app.shipping.tracking.id", shippingTrackingID),
 	)
 
@@ -438,7 +438,7 @@ func (cs *checkout) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Contex
 	span.SetAttributes(
 		attribute.Float64("app.shipping.amount", shippingCostFloat),
 		attribute.Int("app.cart.items.count", int(totalCart)),
-		attribute.Int("app.order.items.count", len(orderItems)),
+		attribute.Int("demo.order.items.count", len(orderItems)),
 	)
 	return out, nil
 }

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -366,7 +366,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	span.SetAttributes(
 		attribute.String("demo.order.id", orderID.String()),
 		attribute.Float64("app.shipping.amount", shippingCostFloat),
-		attribute.Float64("app.order.amount", totalPriceFloat),
+		attribute.Float64("demo.order.amount", totalPriceFloat),
 		attribute.Int("app.order.items.count", len(prep.orderItems)),
 		shippingTrackingAttribute,
 	)
@@ -375,7 +375,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		slog.LevelInfo, "order placed",
 		slog.String("demo.order.id", orderID.String()),
 		slog.Float64("app.shipping.amount", shippingCostFloat),
-		slog.Float64("app.order.amount", totalPriceFloat),
+		slog.Float64("demo.order.amount", totalPriceFloat),
 		slog.Int("app.order.items.count", len(prep.orderItems)),
 		slog.String("app.shipping.tracking.id", shippingTrackingID),
 	)

--- a/src/email/email_server.rb
+++ b/src/email/email_server.rb
@@ -46,7 +46,7 @@ post "/send_order_confirmation" do
   # get the current auto-instrumented span
   current_span = OpenTelemetry::Trace.current_span
   current_span.add_attributes({
-    "app.order.id" => data.order.order_id,
+    "demo.order.id" => data.order.order_id,
   })
 
   $confirmation_counter.add(1)
@@ -84,12 +84,12 @@ def send_email(data)
       Mail::TestMailer.deliveries.clear
     end
 
-    span.set_attribute("app.order.id", data.order.order_id)
+    span.set_attribute("demo.order.id", data.order.order_id)
     $logger.on_emit(
       timestamp: Time.now,
       severity_text: 'INFO',
       body: 'Order confirmation email sent',
-      attributes: { 'app.order.id' => data.order.order_id },
+      attributes: { 'demo.order.id' => data.order.order_id },
     )
 
     puts "Order confirmation email sent for order #{data.order.order_id}"

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -15,7 +15,7 @@ attributes:
     stability: stable
     note: The total monetary amount of the order
     examples: [99.99, 150.50]
-  - key: app.order.items.count
+  - key: demo.order.items.count
     type: int
     brief: Number of items in order
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -3,7 +3,7 @@
 
 file_format: definition/2
 attributes:
-  - key: app.order.id
+  - key: demo.order.id
     type: string
     brief: Order identifier
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -9,7 +9,7 @@ attributes:
     stability: stable
     note: The unique identifier for an order
     examples: ["order-123", "ORD-456789"]
-  - key: app.order.amount
+  - key: demo.order.amount
     type: double
     brief: Total order amount
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -21,7 +21,7 @@ attributes:
     stability: stable
     note: The count of distinct items in the order
     examples: [1, 5, 10]
-  - key: app.cart.items.count
+  - key: demo.cart.items.count
     type: int
     brief: Number of items in cart
     stability: stable

--- a/telemetry-schema/services/cart.yaml
+++ b/telemetry-schema/services/cart.yaml
@@ -11,4 +11,4 @@ attribute_groups:
       - ref: app.user.id
       - ref: demo.product.id
       - ref: demo.product.quantity
-      - ref: app.cart.items.count
+      - ref: demo.cart.items.count

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -15,5 +15,5 @@ attribute_groups:
       - ref: demo.order.id
       - ref: app.shipping.amount
       - ref: demo.order.amount
-      - ref: app.order.items.count
+      - ref: demo.order.items.count
       - ref: app.cart.items.count

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -12,7 +12,7 @@ attribute_groups:
       - ref: app.user.currency
       - ref: app.payment.transaction.id
       - ref: app.shipping.tracking.id
-      - ref: app.order.id
+      - ref: demo.order.id
       - ref: app.shipping.amount
       - ref: app.order.amount
       - ref: app.order.items.count

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -14,6 +14,6 @@ attribute_groups:
       - ref: app.shipping.tracking.id
       - ref: demo.order.id
       - ref: app.shipping.amount
-      - ref: app.order.amount
+      - ref: demo.order.amount
       - ref: app.order.items.count
       - ref: app.cart.items.count

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -16,4 +16,4 @@ attribute_groups:
       - ref: app.shipping.amount
       - ref: demo.order.amount
       - ref: demo.order.items.count
-      - ref: app.cart.items.count
+      - ref: demo.cart.items.count

--- a/telemetry-schema/services/email.yaml
+++ b/telemetry-schema/services/email.yaml
@@ -8,5 +8,5 @@ attribute_groups:
     brief: Email service attributes
     stability: stable
     attributes:
-      - ref: app.order.id
+      - ref: demo.order.id
       - ref: app.email.recipient

--- a/test/tracetesting/frontend/06-checking-out-cart.yaml
+++ b/test/tracetesting/frontend/06-checking-out-cart.yaml
@@ -42,7 +42,7 @@ spec:
     selector: span[tracetest.span.type="rpc" name="oteldemo.CheckoutService/PlaceOrder" rpc.system="grpc" rpc.method="PlaceOrder" rpc.service="oteldemo.CheckoutService"]
     assertions:
     - attr:app.user.id = "2491f868-88f1-4345-8836-d5d8511a9f83"
-    - attr:app.order.items.count = 1
+    - attr:demo.order.items.count = 1
   - name: "The user was charged"
     selector: span[tracetest.span.type="rpc" name="oteldemo.PaymentService/Charge" rpc.system="grpc" rpc.method="Charge" rpc.service="oteldemo.PaymentService"]
     assertions:


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename the Order and Cart categories

`app.order.id` to `demo.order.id`, `app.order.amount` to `demo.order.amount`,
  `app.order.items.count` to `demo.order.items.count`, and
  `app.cart.items.count` to `demo.cart.items.count`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
