### PR TITLE
fix: rename Payment category to `demo.payment*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ the release.
   `app.cart.items.count` to `demo.cart.items.count` across cart, checkout,
   email, telemetry schema, and trace tests.
   ([#3389](https://github.com/open-telemetry/opentelemetry-demo/pull/3389))
+* [telemetry] Rename payment telemetry attributes:
+  `app.payment.amount` to `demo.payment.amount`,
+  `app.payment.card_type` to `demo.payment.card_type`,
+  `app.payment.card_valid` to `demo.payment.card_valid`,
+  `app.payment.charged` to `demo.payment.charged`,
+  `app.payment.transaction.id` to `demo.payment.transaction.id`, and
+  `app.payment.currency` to `demo.payment.currency` across checkout, payment,
+  and telemetry schema.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ the release.
   `app.payment.transaction.id` to `demo.payment.transaction.id`, and
   `app.payment.currency` to `demo.payment.currency` across checkout, payment,
   and telemetry schema.
+  ([#3390](https://github.com/open-telemetry/opentelemetry-demo/pull/3390))
 
 ## 2.2.0
 

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -336,7 +336,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	}
 
 	span.AddEvent("charged",
-		trace.WithAttributes(attribute.String("app.payment.transaction.id", txID)))
+		trace.WithAttributes(attribute.String("demo.payment.transaction.id", txID)))
 	logger.LogAttrs(
 		ctx,
 		slog.LevelInfo, "payment went through",

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -54,7 +54,7 @@ module.exports.charge = async request => {
     const loyalty_level = random(LOYALTY_LEVEL);
 
     span.setAttributes({
-      'app.payment.card_type': cardType,
+      'demo.payment.card_type': cardType,
       'app.payment.card_valid': valid,
       'app.loyalty.level': loyalty_level
     });

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -55,7 +55,7 @@ module.exports.charge = async request => {
 
     span.setAttributes({
       'demo.payment.card_type': cardType,
-      'app.payment.card_valid': valid,
+      'demo.payment.card_valid': valid,
       'app.loyalty.level': loyalty_level
     });
 

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -74,9 +74,9 @@ module.exports.charge = async request => {
     // Check baggage for synthetic_request=true, and add charged attribute accordingly
     const baggage = propagation.getBaggage(context.active());
     if (baggage && baggage.getEntry('synthetic_request') && baggage.getEntry('synthetic_request').value === 'true') {
-      span.setAttribute('app.payment.charged', false);
+      span.setAttribute('demo.payment.charged', false);
     } else {
-      span.setAttribute('app.payment.charged', true);
+      span.setAttribute('demo.payment.charged', true);
     }
 
     const { units, nanos, currencyCode } = request.amount;

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -81,7 +81,7 @@ module.exports.charge = async request => {
 
     const { units, nanos, currencyCode } = request.amount;
     logger.info({ transactionId, cardType, lastFourDigits, amount: { units, nanos, currencyCode }, loyalty_level }, 'Transaction complete.');
-    transactionsCounter.add(1, { 'app.payment.currency': currencyCode });
+    transactionsCounter.add(1, { 'demo.payment.currency': currencyCode });
 
     return { transactionId };
   } catch (err) {

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -14,7 +14,7 @@ async function chargeServiceHandler(call, callback) {
   try {
     const amount = call.request.amount
     span?.setAttributes({
-      'app.payment.amount': parseFloat(`${amount.units}.${amount.nanos}`).toFixed(2)
+      'demo.payment.amount': parseFloat(`${amount.units}.${amount.nanos}`).toFixed(2)
     })
     logger.info("Charge request received.")
 

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -39,7 +39,7 @@ attributes:
     stability: stable
     note: The type of credit card being used for payment
     examples: ["visa", "mastercard", "amex"]
-  - key: app.payment.card_valid
+  - key: demo.payment.card_valid
     type: boolean
     brief: Card validation status
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -27,7 +27,7 @@ attributes:
     stability: stable
     note: The count of items currently in the shopping cart
     examples: [0, 3, 7]
-  - key: app.payment.amount
+  - key: demo.payment.amount
     type: string
     brief: Payment amount
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -33,7 +33,7 @@ attributes:
     stability: stable
     note: The monetary amount being charged
     examples: ["29.99", "99.95", "150.00"]
-  - key: app.payment.card_type
+  - key: demo.payment.card_type
     type: string
     brief: Credit card type
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -49,7 +49,7 @@ attributes:
     brief: Whether payment was successfully charged
     stability: stable
     note: Indicates whether the payment transaction was successfully charged to the customer's payment method (true) or not charged (false). For synthetic requests, this is set to false.
-  - key: app.payment.transaction.id
+  - key: demo.payment.transaction.id
     type: string
     brief: Payment transaction identifier
     stability: stable

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -44,7 +44,7 @@ attributes:
     brief: Card validation status
     stability: stable
     note: Whether the card passed validation checks
-  - key: app.payment.charged
+  - key: demo.payment.charged
     type: boolean
     brief: Whether payment was successfully charged
     stability: stable

--- a/telemetry-schema/metrics/payment.yaml
+++ b/telemetry-schema/metrics/payment.yaml
@@ -3,7 +3,7 @@
 
 file_format: definition/2
 attributes:
-  - key: app.payment.currency
+  - key: demo.payment.currency
     type: string
     brief: Currency code for the transaction
     stability: stable
@@ -19,5 +19,5 @@ metrics:
     annotations:
       service: payment
     attributes:
-      - ref: app.payment.currency
+      - ref: demo.payment.currency
         requirement_level: required

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -10,7 +10,7 @@ attribute_groups:
     attributes:
       - ref: app.user.id
       - ref: app.user.currency
-      - ref: app.payment.transaction.id
+      - ref: demo.payment.transaction.id
       - ref: app.shipping.tracking.id
       - ref: demo.order.id
       - ref: app.shipping.amount

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -9,7 +9,7 @@ attribute_groups:
     stability: stable
     attributes:
       - ref: app.loyalty.level
-      - ref: app.payment.card_type
+      - ref: demo.payment.card_type
       - ref: app.payment.card_valid
       - ref: app.payment.charged
       - ref: demo.payment.amount

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -10,6 +10,6 @@ attribute_groups:
     attributes:
       - ref: app.loyalty.level
       - ref: demo.payment.card_type
-      - ref: app.payment.card_valid
+      - ref: demo.payment.card_valid
       - ref: app.payment.charged
       - ref: demo.payment.amount

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -12,4 +12,4 @@ attribute_groups:
       - ref: app.payment.card_type
       - ref: app.payment.card_valid
       - ref: app.payment.charged
-      - ref: app.payment.amount
+      - ref: demo.payment.amount

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -11,5 +11,5 @@ attribute_groups:
       - ref: app.loyalty.level
       - ref: demo.payment.card_type
       - ref: demo.payment.card_valid
-      - ref: app.payment.charged
+      - ref: demo.payment.charged
       - ref: demo.payment.amount


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename:

`app.payment.amount` to `demo.payment.amount`,
  `app.payment.card_type` to `demo.payment.card_type`,
  `app.payment.card_valid` to `demo.payment.card_valid`,
  `app.payment.charged` to `demo.payment.charged`,
  `app.payment.transaction.id` to `demo.payment.transaction.id`, and
  `app.payment.currency` to `demo.payment.currency`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
