### PR TITLE
fix: rename shipping category to `demo.shipping.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ the release.
   `app.quote.items.count` to `demo.shipping.quote.items_count`, and
   `app.quote.cost.total` to `demo.shipping.quote.cost_total` across checkout,
   quote, shipping, and telemetry schema.
+  ([#3391](https://github.com/open-telemetry/opentelemetry-demo/pull/3391))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ the release.
   `app.shipping.items_count` to `demo.shipping.items_count`,
   `app.shipping.tracking.id` to `demo.shipping.tracking.id`,
   `app.quote.items.count` to `demo.shipping.quote.items_count`, and
-  `app.quote.cost.total` to `demo.shipping.quote.cost_total` across checkout,
+  `app.quote.cost.total` to `demo.shipping.quote.cost.total` across checkout,
   quote, shipping, and telemetry schema.
   ([#3391](https://github.com/open-telemetry/opentelemetry-demo/pull/3391))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,14 @@ the release.
   `app.payment.currency` to `demo.payment.currency` across checkout, payment,
   and telemetry schema.
   ([#3390](https://github.com/open-telemetry/opentelemetry-demo/pull/3390))
+* [telemetry] Rename shipping and quote telemetry attributes:
+  `app.shipping.amount` to `demo.shipping.amount`,
+  `app.shipping.cost.total` to `demo.shipping.cost.total`,
+  `app.shipping.items_count` to `demo.shipping.items_count`,
+  `app.shipping.tracking.id` to `demo.shipping.tracking.id`,
+  `app.quote.items.count` to `demo.shipping.quote.items_count`, and
+  `app.quote.cost.total` to `demo.shipping.quote.cost_total` across checkout,
+  quote, shipping, and telemetry schema.
 
 ## 2.2.0
 

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -347,7 +347,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "shipping error: %+v", err)
 	}
-	shippingTrackingAttribute := attribute.String("app.shipping.tracking.id", shippingTrackingID)
+	shippingTrackingAttribute := attribute.String("demo.shipping.tracking.id", shippingTrackingID)
 	span.AddEvent("shipped", trace.WithAttributes(shippingTrackingAttribute))
 
 	_ = cs.emptyUserCart(ctx, req.UserId)
@@ -377,7 +377,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		slog.Float64("demo.shipping.amount", shippingCostFloat),
 		slog.Float64("demo.order.amount", totalPriceFloat),
 		slog.Int("demo.order.items.count", len(prep.orderItems)),
-		slog.String("app.shipping.tracking.id", shippingTrackingID),
+		slog.String("demo.shipping.tracking.id", shippingTrackingID),
 	)
 
 	if err := cs.sendOrderConfirmation(ctx, req.Email, orderResult); err != nil {

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -365,7 +365,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 
 	span.SetAttributes(
 		attribute.String("demo.order.id", orderID.String()),
-		attribute.Float64("app.shipping.amount", shippingCostFloat),
+		attribute.Float64("demo.shipping.amount", shippingCostFloat),
 		attribute.Float64("demo.order.amount", totalPriceFloat),
 		attribute.Int("demo.order.items.count", len(prep.orderItems)),
 		shippingTrackingAttribute,
@@ -374,7 +374,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		ctx,
 		slog.LevelInfo, "order placed",
 		slog.String("demo.order.id", orderID.String()),
-		slog.Float64("app.shipping.amount", shippingCostFloat),
+		slog.Float64("demo.shipping.amount", shippingCostFloat),
 		slog.Float64("demo.order.amount", totalPriceFloat),
 		slog.Int("demo.order.items.count", len(prep.orderItems)),
 		slog.String("app.shipping.tracking.id", shippingTrackingID),
@@ -436,7 +436,7 @@ func (cs *checkout) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Contex
 	shippingCostFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", shippingPrice.GetUnits(), shippingPrice.GetNanos()/1000000000), 64)
 
 	span.SetAttributes(
-		attribute.Float64("app.shipping.amount", shippingCostFloat),
+		attribute.Float64("demo.shipping.amount", shippingCostFloat),
 		attribute.Int("demo.cart.items.count", int(totalCart)),
 		attribute.Int("demo.order.items.count", len(orderItems)),
 	)

--- a/src/quote/app/routes.php
+++ b/src/quote/app/routes.php
@@ -30,7 +30,7 @@ function calculateQuote($jsonObject): float
         $quote = round($costPerItem * $numberOfItems, 2);
 
         $childSpan->setAttribute('demo.shipping.quote.items_count', $numberOfItems);
-        $childSpan->setAttribute('app.quote.cost.total', $quote);
+        $childSpan->setAttribute('demo.shipping.quote.cost_total', $quote);
 
         $childSpan->addEvent('Quote calculated, returning its value');
 
@@ -61,7 +61,7 @@ return function (App $app) {
         $response->getBody()->write($payload);
 
         $span->addEvent('Quote processed, response sent back', [
-            'app.quote.cost.total' => $data
+            'demo.shipping.quote.cost_total' => $data
         ]);
         //exported as an opentelemetry log (see dependencies.php)
         $logger->info('Calculated quote', [

--- a/src/quote/app/routes.php
+++ b/src/quote/app/routes.php
@@ -29,7 +29,7 @@ function calculateQuote($jsonObject): float
         $costPerItem = 8.99;
         $quote = round($costPerItem * $numberOfItems, 2);
 
-        $childSpan->setAttribute('app.quote.items.count', $numberOfItems);
+        $childSpan->setAttribute('demo.shipping.quote.items_count', $numberOfItems);
         $childSpan->setAttribute('app.quote.cost.total', $quote);
 
         $childSpan->addEvent('Quote calculated, returning its value');

--- a/src/quote/app/routes.php
+++ b/src/quote/app/routes.php
@@ -30,7 +30,7 @@ function calculateQuote($jsonObject): float
         $quote = round($costPerItem * $numberOfItems, 2);
 
         $childSpan->setAttribute('demo.shipping.quote.items_count', $numberOfItems);
-        $childSpan->setAttribute('demo.shipping.quote.cost_total', $quote);
+        $childSpan->setAttribute('demo.shipping.quote.cost.total', $quote);
 
         $childSpan->addEvent('Quote calculated, returning its value');
 
@@ -61,7 +61,7 @@ return function (App $app) {
         $response->getBody()->write($payload);
 
         $span->addEvent('Quote processed, response sent back', [
-            'demo.shipping.quote.cost_total' => $data
+            'demo.shipping.quote.cost.total' => $data
         ]);
         //exported as an opentelemetry log (see dependencies.php)
         $logger->info('Calculated quote', [

--- a/src/shipping/src/shipping_service/quote.rs
+++ b/src/shipping/src/shipping_service/quote.rs
@@ -22,7 +22,7 @@ pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status>
     };
 
     let meter = global::meter("otel_demo.shipping.quote");
-    let counter = meter.u64_counter("app.shipping.items_count").build();
+    let counter = meter.u64_counter("demo.shipping.items_count").build();
     counter.add(count as u64, &[]);
 
     Ok(get_active_span(|span| {

--- a/src/shipping/src/shipping_service/quote.rs
+++ b/src/shipping/src/shipping_service/quote.rs
@@ -29,9 +29,9 @@ pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status>
         let q = create_quote_from_float(f);
         span.add_event(
             "Received Quote".to_string(),
-            vec![KeyValue::new("app.shipping.cost.total", format!("{}", q))],
+            vec![KeyValue::new("demo.shipping.cost.total", format!("{}", q))],
         );
-        span.set_attribute(KeyValue::new("app.shipping.cost.total", format!("{}", q)));
+        span.set_attribute(KeyValue::new("demo.shipping.cost.total", format!("{}", q)));
         q
     }))
 }

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -9,7 +9,7 @@ attributes:
     stability: stable
     note: The monetary amount charged for shipping
     examples: [5.99, 15.00]
-  - key: app.shipping.cost.total
+  - key: demo.shipping.cost.total
     type: string
     brief: Total shipping cost
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -21,7 +21,7 @@ attributes:
     stability: stable
     note: The count of items included in a shipment
     examples: [1, 5, 10]
-  - key: app.shipping.tracking.id
+  - key: demo.shipping.tracking.id
     type: string
     brief: Shipping tracking identifier
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -33,7 +33,7 @@ attributes:
     stability: stable
     note: The count of items included in a pricing quote
     examples: [1, 5, 10]
-  - key: demo.shipping.quote.cost_total
+  - key: demo.shipping.quote.cost.total
     type: double
     brief: Total quote cost
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -33,7 +33,7 @@ attributes:
     stability: stable
     note: The count of items included in a pricing quote
     examples: [1, 5, 10]
-  - key: app.quote.cost.total
+  - key: demo.shipping.quote.cost_total
     type: double
     brief: Total quote cost
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -27,7 +27,7 @@ attributes:
     stability: stable
     note: The tracking number or identifier for a shipment
     examples: ["TRACK-123456", "SHP-789012"]
-  - key: app.quote.items.count
+  - key: demo.shipping.quote.items_count
     type: int
     brief: Number of items in quote
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -15,7 +15,7 @@ attributes:
     stability: stable
     note: The total cost of shipping for an order (string representation)
     examples: ["10.50", "25.00"]
-  - key: app.shipping.items_count
+  - key: demo.shipping.items_count
     type: int
     brief: Number of items being shipped
     stability: stable

--- a/telemetry-schema/attributes/shipping.yaml
+++ b/telemetry-schema/attributes/shipping.yaml
@@ -3,7 +3,7 @@
 
 file_format: definition/2
 attributes:
-  - key: app.shipping.amount
+  - key: demo.shipping.amount
     type: double
     brief: Shipping cost amount
     stability: stable

--- a/telemetry-schema/metrics/shipping.yaml
+++ b/telemetry-schema/metrics/shipping.yaml
@@ -3,7 +3,7 @@
 
 file_format: definition/2
 metrics:
-  - name: app.shipping.items_count
+  - name: demo.shipping.items_count
     brief: Shipping items counter
     instrument: counter
     unit: "{item}"

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -13,7 +13,7 @@ attribute_groups:
       - ref: demo.payment.transaction.id
       - ref: app.shipping.tracking.id
       - ref: demo.order.id
-      - ref: app.shipping.amount
+      - ref: demo.shipping.amount
       - ref: demo.order.amount
       - ref: demo.order.items.count
       - ref: demo.cart.items.count

--- a/telemetry-schema/services/checkout.yaml
+++ b/telemetry-schema/services/checkout.yaml
@@ -11,7 +11,7 @@ attribute_groups:
       - ref: app.user.id
       - ref: app.user.currency
       - ref: demo.payment.transaction.id
-      - ref: app.shipping.tracking.id
+      - ref: demo.shipping.tracking.id
       - ref: demo.order.id
       - ref: demo.shipping.amount
       - ref: demo.order.amount

--- a/telemetry-schema/services/quote.yaml
+++ b/telemetry-schema/services/quote.yaml
@@ -9,4 +9,4 @@ attribute_groups:
     stability: stable
     attributes:
       - ref: demo.shipping.quote.items_count
-      - ref: demo.shipping.quote.cost_total
+      - ref: demo.shipping.quote.cost.total

--- a/telemetry-schema/services/quote.yaml
+++ b/telemetry-schema/services/quote.yaml
@@ -9,4 +9,4 @@ attribute_groups:
     stability: stable
     attributes:
       - ref: demo.shipping.quote.items_count
-      - ref: app.quote.cost.total
+      - ref: demo.shipping.quote.cost_total

--- a/telemetry-schema/services/quote.yaml
+++ b/telemetry-schema/services/quote.yaml
@@ -8,5 +8,5 @@ attribute_groups:
     brief: Quote service attributes
     stability: stable
     attributes:
-      - ref: app.quote.items.count
+      - ref: demo.shipping.quote.items_count
       - ref: app.quote.cost.total

--- a/telemetry-schema/services/shipping.yaml
+++ b/telemetry-schema/services/shipping.yaml
@@ -8,4 +8,4 @@ attribute_groups:
     brief: Shipping service attributes
     stability: stable
     attributes:
-      - ref: app.shipping.cost.total
+      - ref: demo.shipping.cost.total


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Rename:

`app.shipping.amount` to `demo.shipping.amount`,
  `app.shipping.cost.total` to `demo.shipping.cost.total`,
  `app.shipping.items_count` to `demo.shipping.items_count`,
  `app.shipping.tracking.id` to `demo.shipping.tracking.id`,
  `app.quote.items.count` to `demo.shipping.quote.items_count`, and
  `app.quote.cost.total` to `demo.shipping.quote.cost_total`

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
