### PR TITLE
fix(cart): anchor fallback ProtosDir to $(ProjectDir) for IDE compati…

### DIFF
--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!Exists('$(ProtosDir)')">
-    <ProtosDir>..\..\..\pb</ProtosDir>
+    <ProtosDir>$(ProjectDir)..\..\..\pb</ProtosDir>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
VSCode throws an error on startup because it can't find the proto file.

The bare relative fallback path `..\..\..\pb` was resolved relative to the language server's working directory rather than the project file, causing the C# extension in VSCode to report a missing proto file on startup. Adding $(ProjectDir) will resolve in builds and by the C# extension properly.

Assisted-by: Claude Sonnet 4.6