### PR TITLE
feat(make): add optional single-service support to build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,20 @@ install-tools: $(MISSPELL) $(ADDLICENSE)
 	npm install
 	@echo "All tools installed"
 
+# Use to build all services, or a single service component
+# Example: make build service=frontend
 .PHONY: build
 build:
+# work with `service` or `SERVICE` as input
+ifdef SERVICE
+	service := $(SERVICE)
+endif
+
+ifdef service
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build $(service)
+else
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build
+endif
 
 .PHONY: build-and-push
 build-and-push:


### PR DESCRIPTION
Add an ability to use `make build service=<service_name>` to build an individual service. With the move to layered compose files, this will also ensure the full compose set is loaded when doing a build.

The pattern to specify the service is similar to what we do with the `restart` and `redeploy` targets.

Assisted-by: Claude Sonnet 4.6