### PR TITLE
chore - switch npm install to npm ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: install dependencies
-        run: npm install
+        run: npm ci
       - name: run markdownlint
         run: make markdownlint
 
@@ -114,7 +114,7 @@ jobs:
       should_build: ${{ steps.filter.outputs.react_native }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
           filters: |

--- a/src/react-native-app/android.Dockerfile
+++ b/src/react-native-app/android.Dockerfile
@@ -11,9 +11,9 @@ FROM reactnativecommunity/react-native-android:v20.1 AS builder
 WORKDIR /reactnativesrc/
 COPY . .
 
-RUN npm install
+RUN npm ci
 # Regenerate the android/ project from app.json using Expo's continuous native
-# generation. `--no-install` skips a redundant `npm install` since we just ran it.
+# generation. `--no-install` skips a redundant install since dependencies are already present.
 RUN npx expo prebuild --platform android --no-install
 WORKDIR android/
 RUN chmod +x gradlew


### PR DESCRIPTION
# Changes

chore - switch npm install to npm ci
to treat lock files as source of the truth

Towards: https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-demo ---> Pinned-Dependencies


## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
