### PR TITLE
fix(make): make `SERVICE=` alias actually work for build, restart, redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [make] Fix `SERVICE=` alias for `build`, `restart`, and `redeploy` targets
+  so the documented uppercase form actually dispatches to a single service,
+  and clean up the no-arg error message that was being mangled by backticks.
 * [frontend,ad,payment] Propagate `enduser.id` as a span attribute on all
   browser spans via `SessionIdProcessor`, forward it via W3C Baggage on
   outgoing API requests through the ApiGateway proxy, and extract it in the

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ DOCKER_COMPOSE_FILES_TESTS=-f compose.tests.yaml
 # Default: full demo + observability stack + extras stub
 DOCKER_COMPOSE_FILES=$(DOCKER_COMPOSE_FILES_FULL) $(DOCKER_COMPOSE_FILES_OBSERVABILITY) $(DOCKER_COMPOSE_FILES_EXTRAS)
 
+# Accept either `service=` or `SERVICE=` for single-service targets (build, restart, redeploy).
+# Must be evaluated at file scope; an `ifdef SERVICE` block inside a recipe is a shell command,
+# not a Make conditional, so the alias never takes effect there.
+ifdef SERVICE
+service := $(SERVICE)
+endif
+
 
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
@@ -132,12 +139,7 @@ install-tools: $(MISSPELL) $(ADDLICENSE)
 # Example: make build service=frontend
 .PHONY: build
 build:
-# work with `service` or `SERVICE` as input
-ifdef SERVICE
-	service := $(SERVICE)
-endif
-
-ifdef service
+ifneq ($(strip $(service)),)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build $(service)
 else
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build
@@ -282,37 +284,27 @@ stop:
 # Example: make restart service=frontend
 .PHONY: restart
 restart:
-# work with `service` or `SERVICE` as input
-ifdef SERVICE
-	service := $(SERVICE)
-endif
-
-ifdef service
+ifneq ($(strip $(service)),)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) stop $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) rm --force $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) create $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) start $(service)
 else
-	@echo "Please provide a service name using `service=[service name]` or `SERVICE=[service name]`"
+	@echo "Please provide a service name using 'service=<name>' or 'SERVICE=<name>'"
 endif
 
 # Use to rebuild and restart (redeploy) a single service component
 # Example: make redeploy service=frontend
 .PHONY: redeploy
 redeploy:
-# work with `service` or `SERVICE` as input
-ifdef SERVICE
-	service := $(SERVICE)
-endif
-
-ifdef service
+ifneq ($(strip $(service)),)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) stop $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) rm --force $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) create $(service)
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) start $(service)
 else
-	@echo "Please provide a service name using `service=[service name]` or `SERVICE=[service name]`"
+	@echo "Please provide a service name using 'service=<name>' or 'SERVICE=<name>'"
 endif
 
 .PHONY: build-react-native-android


### PR DESCRIPTION
# Changes

The `ifdef SERVICE / service := $(SERVICE)` blocks in the `build`, `restart`, and `redeploy` targets were placed **inside** the recipe (TAB-indented), so Make passed `service := $(SERVICE)` to the shell instead of evaluating it as a Make assignment. As a result, the documented `SERVICE=` alias never set anything:

- `make restart SERVICE=foo` always fell through to the "please provide a service name" branch.
- On Linux, the shell additionally tried to invoke the `service(8)` LSB helper, e.g. `service: only basic LSB actions supported`.

This PR:

1. Moves the `SERVICE` → `service` alias to **file scope** so it's a real Make conditional, used by all three targets.
2. Replaces the per-target `ifdef service` (which is true for empty values) with `ifneq ($(strip $(service)),)` so an empty `service=` falls through to the full-stack branch instead of dispatching with an empty argument.
3. Replaces the backticked error message — the shell was running ``service=[service name]`` as a command substitution, producing a spurious `/bin/sh: name]: command not found` line before the real text.

## Verification

End-to-end with real `docker compose`:

| Command | Behavior |
|---|---|
| `make build service=image-provider` | builds only image-provider ✅ |
| `make build SERVICE=image-provider` | builds only image-provider ✅ (was broken) |
| `make build service=` (empty) | falls through to full-stack build ✅ |
| `make build SERVICE=cart service=image-provider` | lowercase wins → builds image-provider ✅ |
| `make restart {service,SERVICE}=image-provider` | container `StartedAt` rotates ✅ |
| `make redeploy {service,SERVICE}=image-provider` | container `StartedAt` rotates ✅ |
| `make restart` / `make redeploy` (no arg) | prints clean error message ✅ |

## Merge Requirements

This is a Makefile-only developer-tooling fix. CHANGELOG entry added under Unreleased.

* [x] `CHANGELOG.md` updated to document the fix
* [ ] Appropriate documentation updates in the [docs][] — N/A (Makefile-only)
* [ ] Appropriate Helm chart updates in the [helm-charts][] — N/A (Makefile-only)

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
