### PR TITLE
fix/disable ff by default

### DIFF
--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -37,7 +37,7 @@
               "OLJCESPC7Z"
             ]
           },
-          "on",
+          "off",
           "off"
         ]
       }


### PR DESCRIPTION
# Changes

Fix #3424.

It is confusing yes, but 2 `off`s are required.
The Flagd-UI updates line 40 back to `on` whenever the ff is enabled.