### PR TITLE
fix: replace `enduser.id` with the semantic convention`user.id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,9 @@ the release.
   so the documented uppercase form actually dispatches to a single service,
   and clean up the no-arg error message that was being mangled by backticks.
   ([#3422](https://github.com/open-telemetry/opentelemetry-demo/pull/3422))
+* [telemetry] Replace `enduser.id` with the semantic convention
+  `user.id` for user identity telemetry and remove the local `user.id`
+  attribute definition from the demo telemetry schema.
 
 ## 2.2.0
 

--- a/src/ad/src/main/java/oteldemo/AdService.java
+++ b/src/ad/src/main/java/oteldemo/AdService.java
@@ -193,9 +193,9 @@ public final class AdService {
           span.setAttribute("session.id", sessionId);
           evaluationContext.setTargetingKey(sessionId);
           evaluationContext.add("session", sessionId);
-          final String enduserId = baggage.getEntryValue("enduser.id");
-          if (enduserId != null) {
-            span.setAttribute("enduser.id", enduserId);
+          final String userId = baggage.getEntryValue("user.id");
+          if (userId != null) {
+            span.setAttribute("user.id", userId);
           }
         } else {
           logger.info("no baggage found in context");

--- a/src/frontend/gateways/Api.gateway.ts
+++ b/src/frontend/gateways/Api.gateway.ts
@@ -126,7 +126,7 @@ const ApiGateway = new Proxy(Apis(), {
       const baggage = propagation.getActiveBaggage() || propagation.createBaggage();
       const newBaggage = baggage
         .setEntry(AttributeNames.SESSION_ID, { value: userId })
-        .setEntry(AttributeNames.ENDUSER_ID, { value: userId });
+        .setEntry(AttributeNames.USER_ID, { value: userId });
       const newContext = propagation.setBaggage(context.active(), newBaggage);
       return context.with(newContext, () => {
         return Reflect.apply(originalFunction, undefined, args);

--- a/src/frontend/utils/enums/AttributeNames.ts
+++ b/src/frontend/utils/enums/AttributeNames.ts
@@ -3,5 +3,5 @@
 
 export enum AttributeNames {
     SESSION_ID = 'session.id',
-    ENDUSER_ID = 'enduser.id',
+    USER_ID = 'user.id',
 }

--- a/src/frontend/utils/telemetry/SessionIdProcessor.ts
+++ b/src/frontend/utils/telemetry/SessionIdProcessor.ts
@@ -16,7 +16,7 @@ export class SessionIdProcessor implements SpanProcessor {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onStart(span: Span, parentContext: Context): void {
         span.setAttribute(AttributeNames.SESSION_ID, userId);
-        span.setAttribute(AttributeNames.ENDUSER_ID, userId);
+        span.setAttribute(AttributeNames.USER_ID, userId);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -79,9 +79,9 @@ module.exports.charge = async request => {
       span.setAttribute('demo.payment.charged', true);
     }
 
-    const enduserId = baggage?.getEntry('enduser.id')?.value;
-    if (enduserId) {
-      span.setAttribute('enduser.id', enduserId);
+    const userId = baggage?.getEntry('user.id')?.value;
+    if (userId) {
+      span.setAttribute('user.id', userId);
     }
 
     const { units, nanos, currencyCode } = request.amount;

--- a/telemetry-schema/attributes/user.yaml
+++ b/telemetry-schema/attributes/user.yaml
@@ -3,12 +3,6 @@
 
 file_format: definition/2
 attributes:
-  - key: user.id
-    type: string
-    brief: User identifier
-    stability: stable
-    note: The unique identifier of the user making the request
-    examples: ["user-123", "customer-456"]
   - key: demo.user_context.selected_currency
     type: string
     brief: User's preferred currency

--- a/telemetry-schema/services/ad.yaml
+++ b/telemetry-schema/services/ad.yaml
@@ -15,4 +15,4 @@ attribute_groups:
       - ref: demo.ad.response_type
       - ref: demo.ad.category
       - ref: session.id
-      - ref: enduser.id
+      - ref: user.id

--- a/telemetry-schema/services/frontend.yaml
+++ b/telemetry-schema/services/frontend.yaml
@@ -10,4 +10,4 @@ attribute_groups:
     attributes:
       - ref: demo.synthetic_request
       - ref: session.id
-      - ref: enduser.id
+      - ref: user.id

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -8,7 +8,7 @@ attribute_groups:
     brief: Payment service attributes
     stability: stable
     attributes:
-      - ref: enduser.id
+      - ref: user.id
       - ref: demo.user_context.loyalty_level
       - ref: demo.payment.card_type
       - ref: demo.payment.card_valid


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Replace `enduser.id` with the semantic convention
  `user.id` for user identity telemetry and remove the local `user.id`
  attribute definition from the demo telemetry schema.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
