### PR TITLE
fix(telemetry-docs): update service template attr_category for demo.* prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,9 @@ the release.
   ([#3422](https://github.com/open-telemetry/opentelemetry-demo/pull/3422))
 * [grafana] Update the cart exemplars dashboard to use the renamed
   `demo_cart_*` Prometheus metrics.
+* [telemetry-docs] Fix the `attr_category` macro in the service template
+  (`service.md.j2`) to bucket attributes by their current `demo.*` prefixes
+  instead of the old `app.*` ones.
 
 ## 2.2.0
 

--- a/src/telemetry-docs/templates/markdown/service.md.j2
+++ b/src/telemetry-docs/templates/markdown/service.md.j2
@@ -10,13 +10,13 @@
 
 {#- Helper macro to determine the registry category for an attribute -#}
 {%- macro attr_category(attr_name) -%}
-{%- if attr_name.startswith("app.product") or attr_name.startswith("app.products") or attr_name.startswith("app.filtered_products") or attr_name.startswith("app.ads") or attr_name.startswith("app.product_reviews") -%}
+{%- if attr_name.startswith("demo.product") or attr_name.startswith("demo.ad") -%}
 product
-{%- elif attr_name.startswith("app.user") or attr_name.startswith("session") or attr_name.startswith("app.loyalty") -%}
+{%- elif attr_name.startswith("user.") or attr_name.startswith("demo.user_context") or attr_name.startswith("session") -%}
 user
-{%- elif attr_name.startswith("app.order") or attr_name.startswith("app.cart") or attr_name.startswith("app.payment") -%}
+{%- elif attr_name.startswith("demo.order") or attr_name.startswith("demo.cart") or attr_name.startswith("demo.payment") -%}
 order
-{%- elif attr_name.startswith("app.shipping") or attr_name.startswith("app.quote") -%}
+{%- elif attr_name.startswith("demo.shipping") -%}
 shipping
 {%- else -%}
 misc


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Fix the `attr_category` macro in the service template
  (`service.md.j2`) to bucket attributes by their current `demo.*` prefixes
  instead of the old `app.*` ones.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
