### PR TITLE
chore(ci): separate image push from force build

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -11,6 +11,11 @@ on:
         default: false
         required: false
         type: boolean
+      force_build:
+        description: Build all images regardless of detected changes
+        default: false
+        required: false
+        type: boolean
       version:
         description: The version used when tagging the image
         default: 'dev'
@@ -185,12 +190,12 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           DOCKER_CONTEXT: ${{ matrix.file_tag.context }}
           DOCKERFILE: ${{ matrix.file_tag.file }}
-          FORCE_PUSH: ${{ inputs.push }}
+          FORCE_BUILD: ${{ inputs.force_build }}
           HEAD_SHA: ${{ github.sha }}
         run: |
           DOCKERFILE_DIR=$(dirname "${DOCKERFILE}")
-          if [ "$FORCE_PUSH" = true ]; then
-            echo "Force push is enabled, proceeding with build."
+          if [ "$FORCE_BUILD" = true ]; then
+            echo "Force build is enabled, proceeding with build."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ -z "$BASE_SHA" ]; then
             echo "No base SHA available, proceeding with build."

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ !github.event.repository.fork }}
     with:
       push: true
+      force_build: true
       version: nightly
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     if: ${{ !github.event.repository.fork }}
     with:
       push: true
+      force_build: true
       version: ${{ github.event.release.tag_name }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
# Changes

## Summary

follow up to #3439

Keep image publishing controlled by the push input while allowing callers to explicitly force all component images to build. This lets Checks pushes rely on change detection, while release and nightly workflows keep full image builds.

Assisted-by: GPT-5


- Separate image publishing from forced image builds in `component-build-images.yml`.
- Add `force_build` input for callers that intentionally need a full image rebuild.
- Keep release and nightly workflows building all images by setting `force_build: true`.
- Restore the pre-zizmor `Checks` behavior where regular pushes rely on change detection instead of forcing every component image build.

## Context

Before the zizmor changes, PR/check builds used change detection to skip unchanged component images. During the security workflow cleanup, `push: true` on `main` pushes also became the signal to force every image build. This change separates those concerns:
- `push` controls whether a built image is published.
- `force_build` controls whether change detection is bypassed.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
