### PR TITLE
fix(ci): handle stale image diff base

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/component-build-images.yml
     with:
       push: ${{ github.event_name == 'push' }}
+      force_build: ${{ github.event_name == 'push' }}
       # Use a non-release tag for PR builds; tags are not pushed when push=false.
       version: ${{ github.event_name == 'push' && 'main' || 'dev' }}
     secrets:

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -223,7 +223,6 @@ jobs:
               echo "skip=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            fi
 
             FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")
             if [ -z "$FILES_CHANGED" ]; then

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -187,20 +187,37 @@ jobs:
       - name: Check for changes and set push options
         id: check_changes
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOCKER_CONTEXT: ${{ matrix.file_tag.context }}
           DOCKERFILE: ${{ matrix.file_tag.file }}
           FORCE_BUILD: ${{ inputs.force_build }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           DOCKERFILE_DIR=$(dirname "${DOCKERFILE}")
+          ZERO_SHA=0000000000000000000000000000000000000000
           if [ "$FORCE_BUILD" = true ]; then
             echo "Force build is enabled, proceeding with build."
             echo "skip=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$BASE_SHA" ]; then
-            echo "No base SHA available, proceeding with build."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
           else
+            if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+              echo "Head SHA ${HEAD_SHA} is unavailable, using checked out HEAD."
+              HEAD_SHA=$(git rev-parse HEAD)
+            fi
+
+            if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "$ZERO_SHA" ] ||
+              ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              echo "Base SHA unavailable, using merge base with ${DEFAULT_BRANCH}."
+              git fetch --no-tags origin "${DEFAULT_BRANCH}" || true
+              BASE_SHA=$(git merge-base "$HEAD_SHA" "origin/${DEFAULT_BRANCH}" || true)
+            fi
+
+            if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              echo "No usable base SHA available, proceeding with build."
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")
             if [ -z "$FILES_CHANGED" ]; then
               echo "No changes in ${DOCKER_CONTEXT}, skipping build."

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -207,15 +207,22 @@ jobs:
 
             if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "$ZERO_SHA" ] ||
               ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              echo "Base SHA unavailable, using merge base with ${DEFAULT_BRANCH}."
-              git fetch --no-tags origin "${DEFAULT_BRANCH}" || true
-              BASE_SHA=$(git merge-base "$HEAD_SHA" "origin/${DEFAULT_BRANCH}" || true)
+              if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] || [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+                echo "Base SHA unavailable, using merge base with ${DEFAULT_BRANCH}."
+                git fetch --no-tags origin "${DEFAULT_BRANCH}" || true
+                BASE_SHA=$(git merge-base "$HEAD_SHA" "origin/${DEFAULT_BRANCH}" || true)
+              else
+                echo "No usable base SHA available for ${GITHUB_EVENT_NAME}, proceeding with build."
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
             fi
 
             if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
               echo "No usable base SHA available, proceeding with build."
               echo "skip=false" >> "$GITHUB_OUTPUT"
               exit 0
+            fi
             fi
 
             FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")


### PR DESCRIPTION
# Changes

Validate the image build diff SHAs before running git diff. If a PR rebase leaves the event base SHA unavailable in the checkout, fall back to the merge base with the default branch so unchanged component images can still be skipped.

Assisted-by: GPT-5

## Summary

Fix component image change detection when a PR branch is rebased.

A recent failure in PR #3443 showed most component image jobs failing before Docker build/cache logic with:

```text
fatal: bad object f7ffab4cac440376842bd9d63769f83c1504b6f8
```

Example failing job:

https://github.com/open-telemetry/opentelemetry-demo/actions/runs/26864692249/job/79225909545?pr=3443

## Background

Before the zizmor workflow refactor, component image change detection compared the PR base directly with the checked-out head:

https://github.com/open-telemetry/opentelemetry-demo/blob/025ebf3846c80a3b58f38fce270885151ea6fcf7/.github/workflows/component-build-images.yml#L169-L180

After the refactor, the reusable workflow started storing the comparison base in `BASE_SHA` using:

```yaml
github.event.pull_request.base.sha || github.event.before
```

Current main before this fix:

https://github.com/open-telemetry/opentelemetry-demo/blob/f139d2d642378d5d3018f686a8a12d8f618ad81d/.github/workflows/component-build-images.yml#L187-L205

That works only when the selected SHA is present in the checkout. After a PR rebase, `github.event.before` can point to the previous PR head. In the failing run, that was `f7ffab4...`, while the rebased head was `0a53ab9...`. The old head was no longer available locally, so `git diff "$BASE_SHA" "$HEAD_SHA"` failed with `fatal: bad object`.

## Why this restores previous behavior

The pre-zizmor behavior for PR image checks was to decide component builds from the PR diff against the target branch, not from the previous PR head to the new PR head.

This change brings that behavior back by:

- validating that both SHAs exist before running `git diff`
- treating empty, all-zero, or stale base SHAs as unusable
- falling back to the merge base with the default branch
- preserving per-component skip behavior, so unrelated images are still skipped
- only building everything when no usable base can be found at all

That means a rebased Dependabot PR changing only `src/flagd-ui/**` should build the `flagd-ui` image and skip unrelated component images, instead of failing on a stale SHA or rebuilding everything.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
