### PR TITLE
chore(ci): optimize builds

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -265,19 +265,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-        if: ${{ inputs.push && !github.event.repository.fork }}
+        if: ${{ steps.check_changes.outputs.skip == 'false' && inputs.push && !github.event.repository.fork }}
       - name: Log in to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ inputs.push && !github.event.repository.fork }}
+        if: ${{ steps.check_changes.outputs.skip == 'false' && inputs.push && !github.event.repository.fork }}
       - name: Set up QEMU
-        if: ${{ matrix.file_tag.setup-qemu }}
+        if: ${{ steps.check_changes.outputs.skip == 'false' && matrix.file_tag.setup-qemu }}
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
         with:
           image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
+        if: steps.check_changes.outputs.skip == 'false'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
         with:
           buildkitd-config-inline: |

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -196,42 +196,68 @@ jobs:
         run: |
           DOCKERFILE_DIR=$(dirname "${DOCKERFILE}")
           ZERO_SHA=0000000000000000000000000000000000000000
+
+          commit_exists() {
+            [ -n "$1" ] && [ "$1" != "$ZERO_SHA" ] && git cat-file -e "${1}^{commit}" 2>/dev/null
+          }
+
+          use_default_branch_merge_base() {
+            echo "Using merge base with ${DEFAULT_BRANCH}."
+            git fetch --no-tags origin "${DEFAULT_BRANCH}" || true
+            BASE_SHA=$(git merge-base "$HEAD_SHA" "origin/${DEFAULT_BRANCH}" || true)
+          }
+
           if [ "$FORCE_BUILD" = true ]; then
             echo "Force build is enabled, proceeding with build."
             echo "skip=false" >> "$GITHUB_OUTPUT"
-          else
-            if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-              echo "Head SHA ${HEAD_SHA} is unavailable, using checked out HEAD."
-              HEAD_SHA=$(git rev-parse HEAD)
-            fi
+            exit 0
+          fi
 
-            if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "$ZERO_SHA" ] ||
-              ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] || [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
-                echo "Base SHA unavailable, using merge base with ${DEFAULT_BRANCH}."
-                git fetch --no-tags origin "${DEFAULT_BRANCH}" || true
-                BASE_SHA=$(git merge-base "$HEAD_SHA" "origin/${DEFAULT_BRANCH}" || true)
+          if ! commit_exists "$HEAD_SHA"; then
+            echo "Head SHA ${HEAD_SHA} is unavailable, using checked out HEAD."
+            HEAD_SHA=$(git rev-parse HEAD)
+          fi
+
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request|merge_group)
+              if ! commit_exists "$BASE_SHA"; then
+                echo "Base SHA unavailable for ${GITHUB_EVENT_NAME}."
+                use_default_branch_merge_base
+              fi
+              ;;
+            push)
+              if [ "${GITHUB_REF_NAME}" = "${DEFAULT_BRANCH}" ]; then
+                if ! commit_exists "$BASE_SHA"; then
+                  echo "No usable base SHA available for default branch push, proceeding with build."
+                  echo "skip=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
               else
+                use_default_branch_merge_base
+              fi
+              ;;
+            *)
+              if ! commit_exists "$BASE_SHA"; then
                 echo "No usable base SHA available for ${GITHUB_EVENT_NAME}, proceeding with build."
                 echo "skip=false" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
-            fi
+              ;;
+          esac
 
-            if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              echo "No usable base SHA available, proceeding with build."
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+          if ! commit_exists "$BASE_SHA"; then
+            echo "No usable base SHA available, proceeding with build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")
-            if [ -z "$FILES_CHANGED" ]; then
-              echo "No changes in ${DOCKER_CONTEXT}, skipping build."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Changes detected in ${DOCKER_CONTEXT}, proceeding with build."
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-            fi
+          FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")
+          if [ -z "$FILES_CHANGED" ]; then
+            echo "No changes in ${DOCKER_CONTEXT}, skipping build."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected in ${DOCKER_CONTEXT}, proceeding with build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Log in to container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -253,10 +253,10 @@ jobs:
 
           FILES_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$DOCKERFILE_DIR")
           if [ -z "$FILES_CHANGED" ]; then
-            echo "No changes in ${DOCKER_CONTEXT}, skipping build."
+            echo "No changes in ${DOCKERFILE_DIR}, skipping build for ${DOCKERFILE}."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Changes detected in ${DOCKER_CONTEXT}, proceeding with build."
+            echo "Changes detected in ${DOCKERFILE_DIR}, proceeding with build for ${DOCKERFILE}."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Log in to container registry


### PR DESCRIPTION
## Summary

Improve component image build change detection for branch push workflows and avoid Docker setup for images that are skipped.

## Changes

- Use merge-base with the default branch for non-default branch `push` events.
- Keep default branch pushes conservative: if the `before` SHA is unavailable, build all images.
- Preserve PR and merge queue behavior, including fallback to merge-base when the event base SHA is unavailable.
- Skip registry login, QEMU setup, and Buildx setup when the component image was already marked as skipped.

## Expected Behavior

For a forced Dependabot branch push that changes only `src/quote/**`:

- `quote` image builds.
- unrelated images such as `flagd-ui`, `llm`, etc. are skipped.
- skipped image jobs do not pull Docker setup images or start Buildx/QEMU.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
