### PR TITLE
fix(telemetry-schema): split ad attributes from product telemetry schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ the release.
   instead of the old `app.*` ones.
   ([#3440](https://github.com/open-telemetry/opentelemetry-demo/pull/3440))
 * [telemetry-schema] Move ad attributes into a dedicated schema domain.
+  ([#3454](https://github.com/open-telemetry/opentelemetry-demo/pull/3454))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ the release.
   (`service.md.j2`) to bucket attributes by their current `demo.*` prefixes
   instead of the old `app.*` ones.
   ([#3440](https://github.com/open-telemetry/opentelemetry-demo/pull/3440))
+* [telemetry-schema] Move ad attributes into a dedicated schema domain.
 
 ## 2.2.0
 

--- a/src/telemetry-docs/templates/markdown/readme.md.j2
+++ b/src/telemetry-docs/templates/markdown/readme.md.j2
@@ -22,7 +22,7 @@ The demo application consists of multiple microservices, each with its own telem
 
 The telemetry schema is organized by:
 
-1. **Logical Attribute Groups** - Semantic domain-focused attribute definitions (product, user, order, shipping, misc)
+1. **Logical Attribute Groups** - Semantic domain-focused attribute definitions (ad, misc, order, product, shipping, user)
 2. **Service Definitions** - Service-specific attribute references and metric definitions
 
 Each service references logical attribute groups using the `ref` syntax, creating a separation between logical groupings and service-specific usage patterns.

--- a/src/telemetry-docs/templates/markdown/readme.md.j2
+++ b/src/telemetry-docs/templates/markdown/readme.md.j2
@@ -46,4 +46,3 @@ For more information about OpenTelemetry semantic conventions, visit:
 
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
 - [OpenTelemetry Demo Repository](https://github.com/open-telemetry/opentelemetry-demo)
-

--- a/src/telemetry-docs/templates/markdown/service.md.j2
+++ b/src/telemetry-docs/templates/markdown/service.md.j2
@@ -71,4 +71,3 @@ This page documents the telemetry schema for the **{{ ctx.id | replace("_", " ")
 {% endif %}
 {%- endfor %}
 {%- endif %}
-

--- a/src/telemetry-docs/templates/markdown/service.md.j2
+++ b/src/telemetry-docs/templates/markdown/service.md.j2
@@ -10,8 +10,10 @@
 
 {#- Helper macro to determine the registry category for an attribute -#}
 {%- macro attr_category(attr_name) -%}
-{%- if attr_name.startswith("demo.product") or attr_name.startswith("demo.ad") -%}
+{%- if attr_name.startswith("demo.product") -%}
 product
+{%- elif attr_name.startswith("demo.ad") -%}
+ad
 {%- elif attr_name.startswith("user.") or attr_name.startswith("demo.user_context") or attr_name.startswith("session") -%}
 user
 {%- elif attr_name.startswith("demo.order") or attr_name.startswith("demo.cart") or attr_name.startswith("demo.payment") -%}

--- a/src/telemetry-docs/templates/markdown/weaver.yaml
+++ b/src/telemetry-docs/templates/markdown/weaver.yaml
@@ -56,7 +56,7 @@ templates:
     file_name: services/{{ ctx.id | snake_case }}.md
 
   # Generate per-registry attribute documentation pages
-  # Each registry (product, user, order, shipping, misc) gets its own page
+  # Each registry (ad, misc, order, product, shipping, user) gets its own page
   - pattern: registry.md.j2
     filter: >
       .groups

--- a/telemetry-schema/README.md
+++ b/telemetry-schema/README.md
@@ -9,7 +9,7 @@ across the demo services.
 The schema is organized into three directories:
 
 - **`attributes/`** - Attribute definitions organized by business domain
-  (product, user, order, shipping, misc)
+  (ad, misc, order, product, shipping, user)
 - **`services/`** - Service-specific attribute references (one file per service)
 - **`metrics/`** - Metric definitions (one file per service that produces
   metrics)

--- a/telemetry-schema/attributes/ad.yaml
+++ b/telemetry-schema/attributes/ad.yaml
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+file_format: definition/2
+attributes:
+  - key: demo.ad.category
+    type: string
+    brief: Advertisement category
+    stability: stable
+    note: The category of advertisements being served
+    examples: ["electronics", "clothing", "home"]
+  - key: demo.ad.count
+    type: int
+    brief: Number of advertisements served
+    stability: stable
+    note: The count of advertisements returned or served in a request
+    examples: [1, 2, 5]
+  - key: demo.ad.context_keys
+    type: string
+    brief: Context keys for ad targeting
+    stability: stable
+    note: Comma-separated list of context keys used for ad targeting
+    examples: ["electronics,gadgets", "home,kitchen"]
+  - key: demo.ad.context_keys.count
+    type: int
+    brief: Number of context keys
+    stability: stable
+    note: The count of context keys provided for ad targeting
+    examples: [0, 2, 5]
+  - key: demo.ad.request_type
+    type: string
+    brief: Type of ad request
+    stability: stable
+    note: Indicates whether the ad request was targeted or not
+    examples: ["TARGETED", "NOT_TARGETED"]
+  - key: demo.ad.response_type
+    type: string
+    brief: Type of ad response
+    stability: stable
+    note: Indicates whether the ad response was targeted or random
+    examples: ["TARGETED", "RANDOM"]

--- a/telemetry-schema/attributes/product.yaml
+++ b/telemetry-schema/attributes/product.yaml
@@ -69,39 +69,3 @@ attributes:
     stability: stable
     note: The average rating score across all reviews for a product, typically on a scale of 1-5
     examples: [4.5, 3.2, 4.8]
-  - key: demo.ad.category
-    type: string
-    brief: Advertisement category
-    stability: stable
-    note: The category of advertisements being served
-    examples: ["electronics", "clothing", "home"]
-  - key: demo.ad.count
-    type: int
-    brief: Number of advertisements served
-    stability: stable
-    note: The count of advertisements returned or served in a request
-    examples: [1, 2, 5]
-  - key: demo.ad.context_keys
-    type: string
-    brief: Context keys for ad targeting
-    stability: stable
-    note: Comma-separated list of context keys used for ad targeting
-    examples: ["electronics,gadgets", "home,kitchen"]
-  - key: demo.ad.context_keys.count
-    type: int
-    brief: Number of context keys
-    stability: stable
-    note: The count of context keys provided for ad targeting
-    examples: [0, 2, 5]
-  - key: demo.ad.request_type
-    type: string
-    brief: Type of ad request
-    stability: stable
-    note: Indicates whether the ad request was targeted or not
-    examples: ["TARGETED", "NOT_TARGETED"]
-  - key: demo.ad.response_type
-    type: string
-    brief: Type of ad response
-    stability: stable
-    note: Indicates whether the ad response was targeted or random
-    examples: ["TARGETED", "RANDOM"]


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-demo/issues/3267

# Changes

Move ad attributes into a dedicated schema domain.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
