### PR TITLE
chore: group dependabot updates by service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,65 +142,49 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:50"
-  - package-ecosystem: "nuget"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "nuget"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/accounting/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-accounting"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/accounting/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-accounting"
-  - package-ecosystem: "gradle"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "gradle"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/ad/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-ad"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/ad/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-ad"
-  - package-ecosystem: "nuget"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "nuget"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/cart/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-cart"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/cart/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-cart"
-  - package-ecosystem: "gomod"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "gomod"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/checkout/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-checkout"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/checkout/**"
     patterns:
@@ -219,9 +203,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:50"
-  - package-ecosystem: "bundler"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "bundler"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/email/**"
     patterns:
@@ -229,57 +211,43 @@ updates:
     multi-ecosystem-group: "src-email"
     allow:
       - dependency-type: "all"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/email/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-email"
-  - package-ecosystem: "mix"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "mix"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/flagd-ui/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-flagd-ui"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/flagd-ui/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-flagd-ui"
-  - package-ecosystem: "gradle"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "gradle"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/fraud-detection/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-fraud-detection"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/fraud-detection/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-fraud-detection"
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "npm"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/frontend/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-frontend"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/frontend/**"
     patterns:
@@ -324,33 +292,25 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:50"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "pip"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/llm/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-llm"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/llm/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-llm"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "pip"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/load-generator/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-load-generator"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/load-generator/**"
     patterns:
@@ -369,97 +329,73 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:50"
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "npm"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/payment/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-payment"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/payment/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-payment"
-  - package-ecosystem: "gomod"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "gomod"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/product-catalog/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-catalog"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/product-catalog/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-catalog"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "pip"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/product-reviews/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-reviews"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/product-reviews/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-reviews"
-  - package-ecosystem: "composer"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "composer"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/quote/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-quote"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/quote/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-quote"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "pip"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/recommendation/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-recommendation"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/recommendation/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-recommendation"
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "npm"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/react-native-app/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-react-native-app"
-  - package-ecosystem: "bundler"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "bundler"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/react-native-app/**"
     patterns:
@@ -467,17 +403,13 @@ updates:
     multi-ecosystem-group: "src-react-native-app"
     allow:
       - dependency-type: "all"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/react-native-app/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-react-native-app"
-  - package-ecosystem: "cargo"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "cargo"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/shipping/**"
     patterns:
@@ -485,25 +417,19 @@ updates:
     multi-ecosystem-group: "src-shipping"
     allow:
       - dependency-type: "all"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/shipping/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-shipping"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "pip"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/telemetry-docs/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-telemetry-docs"
-  - package-ecosystem: "docker"
-    cooldown:
-      default-days: 3
+  - package-ecosystem: "docker"  # zizmor: ignore[dependabot-cooldown] cooldown prevents multi-ecosystem batching
     directories:
       - "/src/telemetry-docs/**"
     patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -145,28 +145,32 @@ updates:
   - package-ecosystem: "nuget"
     cooldown:
       default-days: 3
-    directory: "/src/accounting"
+    directories:
+      - "/src/accounting/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-accounting"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/accounting"
+    directories:
+      - "/src/accounting/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-accounting"
   - package-ecosystem: "gradle"
     cooldown:
       default-days: 3
-    directory: "/src/ad"
+    directories:
+      - "/src/ad/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-ad"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/ad"
+    directories:
+      - "/src/ad/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-ad"
@@ -174,22 +178,23 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/cart/src"
-      - "/src/cart/tests"
+      - "/src/cart/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-cart"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/cart/src"
+    directories:
+      - "/src/cart/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-cart"
   - package-ecosystem: "gomod"
     cooldown:
       default-days: 3
-    directory: "/src/checkout"
+    directories:
+      - "/src/checkout/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-checkout"
@@ -197,8 +202,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/checkout"
-      - "/src/checkout/genproto"
+      - "/src/checkout/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-checkout"
@@ -206,8 +210,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/currency"
-      - "/src/currency/genproto"
+      - "/src/currency/**"
     groups:
       src-currency:
         patterns:
@@ -219,7 +222,8 @@ updates:
   - package-ecosystem: "bundler"
     cooldown:
       default-days: 3
-    directory: "/src/email"
+    directories:
+      - "/src/email/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-email"
@@ -228,42 +232,48 @@ updates:
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/email"
+    directories:
+      - "/src/email/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-email"
   - package-ecosystem: "mix"
     cooldown:
       default-days: 3
-    directory: "/src/flagd-ui"
+    directories:
+      - "/src/flagd-ui/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-flagd-ui"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/flagd-ui"
+    directories:
+      - "/src/flagd-ui/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-flagd-ui"
   - package-ecosystem: "gradle"
     cooldown:
       default-days: 3
-    directory: "/src/fraud-detection"
+    directories:
+      - "/src/fraud-detection/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-fraud-detection"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/fraud-detection"
+    directories:
+      - "/src/fraud-detection/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-fraud-detection"
   - package-ecosystem: "npm"
     cooldown:
       default-days: 3
-    directory: "/src/frontend"
+    directories:
+      - "/src/frontend/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-frontend"
@@ -271,15 +281,15 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/frontend"
-      - "/src/frontend/genproto"
+      - "/src/frontend/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-frontend"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/frontend-proxy"
+    directories:
+      - "/src/frontend-proxy/**"
     groups:
       src-frontend-proxy:
         patterns:
@@ -291,7 +301,8 @@ updates:
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/image-provider"
+    directories:
+      - "/src/image-provider/**"
     groups:
       src-image-provider:
         patterns:
@@ -303,7 +314,8 @@ updates:
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/kafka"
+    directories:
+      - "/src/kafka/**"
     groups:
       src-kafka:
         patterns:
@@ -315,35 +327,40 @@ updates:
   - package-ecosystem: "pip"
     cooldown:
       default-days: 3
-    directory: "/src/llm"
+    directories:
+      - "/src/llm/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-llm"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/llm"
+    directories:
+      - "/src/llm/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-llm"
   - package-ecosystem: "pip"
     cooldown:
       default-days: 3
-    directory: "/src/load-generator"
+    directories:
+      - "/src/load-generator/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-load-generator"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/load-generator"
+    directories:
+      - "/src/load-generator/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-load-generator"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/opensearch"
+    directories:
+      - "/src/opensearch/**"
     groups:
       src-opensearch:
         patterns:
@@ -355,21 +372,24 @@ updates:
   - package-ecosystem: "npm"
     cooldown:
       default-days: 3
-    directory: "/src/payment"
+    directories:
+      - "/src/payment/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-payment"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/payment"
+    directories:
+      - "/src/payment/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-payment"
   - package-ecosystem: "gomod"
     cooldown:
       default-days: 3
-    directory: "/src/product-catalog"
+    directories:
+      - "/src/product-catalog/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-catalog"
@@ -377,8 +397,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/product-catalog"
-      - "/src/product-catalog/genproto"
+      - "/src/product-catalog/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-catalog"
@@ -386,8 +405,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/product-reviews"
-      - "/src/product-reviews/genproto"
+      - "/src/product-reviews/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-reviews"
@@ -395,22 +413,23 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/product-reviews"
-      - "/src/product-reviews/genproto"
+      - "/src/product-reviews/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-product-reviews"
   - package-ecosystem: "composer"
     cooldown:
       default-days: 3
-    directory: "/src/quote"
+    directories:
+      - "/src/quote/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-quote"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/quote"
+    directories:
+      - "/src/quote/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-quote"
@@ -418,8 +437,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/recommendation"
-      - "/src/recommendation/genproto"
+      - "/src/recommendation/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-recommendation"
@@ -427,22 +445,23 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/recommendation"
-      - "/src/recommendation/genproto"
+      - "/src/recommendation/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-recommendation"
   - package-ecosystem: "npm"
     cooldown:
       default-days: 3
-    directory: "/src/react-native-app"
+    directories:
+      - "/src/react-native-app/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-react-native-app"
   - package-ecosystem: "bundler"
     cooldown:
       default-days: 3
-    directory: "/src/react-native-app"
+    directories:
+      - "/src/react-native-app/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-react-native-app"
@@ -451,14 +470,16 @@ updates:
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/react-native-app"
+    directories:
+      - "/src/react-native-app/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-react-native-app"
   - package-ecosystem: "cargo"
     cooldown:
       default-days: 3
-    directory: "/src/shipping"
+    directories:
+      - "/src/shipping/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-shipping"
@@ -467,21 +488,24 @@ updates:
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/shipping"
+    directories:
+      - "/src/shipping/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-shipping"
   - package-ecosystem: "pip"
     cooldown:
       default-days: 3
-    directory: "/src/telemetry-docs"
+    directories:
+      - "/src/telemetry-docs/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-telemetry-docs"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directory: "/src/telemetry-docs"
+    directories:
+      - "/src/telemetry-docs/**"
     patterns:
       - "*"
     multi-ecosystem-group: "src-telemetry-docs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,97 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 version: 2
+multi-ecosystem-groups:
+  src-accounting:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-ad:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-cart:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-checkout:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-email:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-flagd-ui:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-fraud-detection:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-frontend:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-llm:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-load-generator:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-payment:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-product-catalog:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-product-reviews:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-quote:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-recommendation:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-react-native-app:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-shipping:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  src-telemetry-docs:
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
 updates:
   - package-ecosystem: "github-actions"
     cooldown:
@@ -18,8 +109,7 @@ updates:
     cooldown:
       default-days: 3
     directories:
-      - "/src/**/*"
-      - "/internal/tools/**/*"
+      - "/internal/tools"
     groups:
       go-production-dependencies:
         dependency-type: "production"
@@ -27,63 +117,10 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:05"
-  - package-ecosystem: "gradle"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/**/*"
-    exclude-paths:
-      - "src/react-native-app/**"
-    groups:
-      gradle-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:10"
-  - package-ecosystem: "pip"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/**/*"
-    groups:
-      pip-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:15"
-  - package-ecosystem: "nuget"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/**/*"
-    groups:
-      nuget-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:20"
-  - package-ecosystem: "composer"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/**/*"
-    groups:
-      composer-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:25"
   - package-ecosystem: "npm"
     cooldown:
       default-days: 3
-    directories:
-      - "/"
-      - "/src/frontend/*"
-      - "/src/payment/*"
+    directory: "/"
     groups:
       npm-production-dependencies:
         dependency-type: "production"
@@ -93,60 +130,358 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "03:30"
-  - package-ecosystem: "cargo"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/shipping/*"
-    groups:
-      cargo-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:35"
-    allow:
-      - dependency-type: "all"
-  - package-ecosystem: "bundler"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/email/*"
-    groups:
-      bundler-production-dependencies:
-        dependency-type: "production"
-      bundler-development-dependencies:
-        dependency-type: "development"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:40"
-    allow:
-      - dependency-type: "all"
-  - package-ecosystem: "mix"
-    cooldown:
-      default-days: 3
-    directories:
-      - "/src/flagd-ui/*"
-    groups:
-      mix-production-dependencies:
-        dependency-type: "production"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:45"
   - package-ecosystem: "docker"
     cooldown:
       default-days: 3
-    directories:
-      - "/"
-      - "/src/**/*"
-      - "/test/**/*"
+    directory: "/test/tracetesting"
     groups:
-      docker-base-images:
+      test-docker-base-images:
         patterns:
           - "*"
     schedule:
       interval: "weekly"
       day: "tuesday"
       time: "03:50"
+  - package-ecosystem: "nuget"
+    cooldown:
+      default-days: 3
+    directory: "/src/accounting"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-accounting"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/accounting"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-accounting"
+  - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 3
+    directory: "/src/ad"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-ad"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/ad"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-ad"
+  - package-ecosystem: "nuget"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/cart/src"
+      - "/src/cart/tests"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-cart"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/cart/src"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-cart"
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 3
+    directory: "/src/checkout"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-checkout"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/checkout"
+      - "/src/checkout/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-checkout"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/currency"
+      - "/src/currency/genproto"
+    groups:
+      src-currency:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  - package-ecosystem: "bundler"
+    cooldown:
+      default-days: 3
+    directory: "/src/email"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-email"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/email"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-email"
+  - package-ecosystem: "mix"
+    cooldown:
+      default-days: 3
+    directory: "/src/flagd-ui"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-flagd-ui"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/flagd-ui"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-flagd-ui"
+  - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 3
+    directory: "/src/fraud-detection"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-fraud-detection"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/fraud-detection"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-fraud-detection"
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 3
+    directory: "/src/frontend"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-frontend"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/frontend"
+      - "/src/frontend/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-frontend"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/frontend-proxy"
+    groups:
+      src-frontend-proxy:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/image-provider"
+    groups:
+      src-image-provider:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/kafka"
+    groups:
+      src-kafka:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 3
+    directory: "/src/llm"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-llm"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/llm"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-llm"
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 3
+    directory: "/src/load-generator"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-load-generator"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/load-generator"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-load-generator"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/opensearch"
+    groups:
+      src-opensearch:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:50"
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 3
+    directory: "/src/payment"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-payment"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/payment"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-payment"
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 3
+    directory: "/src/product-catalog"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-product-catalog"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/product-catalog"
+      - "/src/product-catalog/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-product-catalog"
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/product-reviews"
+      - "/src/product-reviews/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-product-reviews"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/product-reviews"
+      - "/src/product-reviews/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-product-reviews"
+  - package-ecosystem: "composer"
+    cooldown:
+      default-days: 3
+    directory: "/src/quote"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-quote"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/quote"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-quote"
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/recommendation"
+      - "/src/recommendation/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-recommendation"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/src/recommendation"
+      - "/src/recommendation/genproto"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-recommendation"
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 3
+    directory: "/src/react-native-app"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-react-native-app"
+  - package-ecosystem: "bundler"
+    cooldown:
+      default-days: 3
+    directory: "/src/react-native-app"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-react-native-app"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/react-native-app"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-react-native-app"
+  - package-ecosystem: "cargo"
+    cooldown:
+      default-days: 3
+    directory: "/src/shipping"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-shipping"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/shipping"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-shipping"
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 3
+    directory: "/src/telemetry-docs"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-telemetry-docs"
+  - package-ecosystem: "docker"
+    cooldown:
+      default-days: 3
+    directory: "/src/telemetry-docs"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "src-telemetry-docs"


### PR DESCRIPTION
# Changes

Reconfigure Dependabot so dependency update PRs follow the `/src/<subfolder>` service boundary.

Dependabot now uses multi-ecosystem groups for services that have multiple dependency ecosystems, so updates for a single service are consolidated into one PR. For example, `/src/cart` NuGet updates and `/src/cart/src` Dockerfile updates should be grouped into one `src-cart` PR.

Docker-only `/src/<subfolder>` entries remain grouped per service folder. Updates outside `/src`, such as GitHub Actions, root npm tooling, `/internal/tools`, and `/test/tracetesting`, remain separate generic Dependabot PRs.

Expected PR shape:
- One PR per `/src/<subfolder>` service when updates are available.
- A service PR may include Docker base image updates plus language/package updates for that same service.
- Generic non-service PRs remain separate for dependency sources outside `/src`.

References:
- [GitHub Docs: Multi-ecosystem updates](https://docs.github.com/en/code-security/concepts/supply-chain-security/multi-ecosystem-updates)
- [GitHub Docs: Configuring multi-ecosystem updates](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates)
- [GitHub Docs: Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)

## Notes

I have never tested, but the configuration seems to be legit. It can be easily tested.
With this, we could avoid one big RP touching all microservices: https://github.com/open-telemetry/opentelemetry-demo/pull/3456

Assisted by Codex/Chatgpt5.5

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

This is a Dependabot configuration-only change, so no changelog, docs, or Helm chart updates are expected.

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts