### PR TITLE
fix(telemetry-schema): split cart and payment attributes from order schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ the release.
   ([#3482](https://github.com/open-telemetry/opentelemetry-demo/pull/3482))
 * [telemetry] Split cart and payment attributes out of the order telemetry
   schema into their own domain files.
+  ([#3484](https://github.com/open-telemetry/opentelemetry-demo/pull/3484))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,8 @@ the release.
 * [telemetry-schema] Split exchange, feature flag, recommendation, and request
   attributes into dedicated schema domains.
   ([#3482](https://github.com/open-telemetry/opentelemetry-demo/pull/3482))
+* [telemetry] Split cart and payment attributes out of the order telemetry
+  schema into their own domain files.
 
 ## 2.2.0
 

--- a/src/telemetry-docs/templates/markdown/service.md.j2
+++ b/src/telemetry-docs/templates/markdown/service.md.j2
@@ -16,8 +16,12 @@ product
 ad
 {%- elif attr_name.startswith("user.") or attr_name.startswith("demo.user_context") or attr_name.startswith("session") or attr_name.startswith("enduser.") -%}
 user
-{%- elif attr_name.startswith("demo.order") or attr_name.startswith("demo.cart") or attr_name.startswith("demo.payment") -%}
+{%- elif attr_name.startswith("demo.order") -%}
 order
+{%- elif attr_name.startswith("demo.cart") -%}
+cart
+{%- elif attr_name.startswith("demo.payment") -%}
+payment
 {%- elif attr_name.startswith("demo.shipping") -%}
 shipping
 {%- elif attr_name.startswith("demo.exchange") -%}

--- a/telemetry-schema/README.md
+++ b/telemetry-schema/README.md
@@ -9,8 +9,8 @@ across the demo services.
 The schema is organized into three directories:
 
 - **`attributes/`** - Attribute definitions organized by business domain
-  (ad, exchange, feature flag, order, product, recommendation, request,
-  shipping, user)
+  (ad, cart, exchange, feature flag, order, payment, product, recommendation,
+  request, shipping, user)
 - **`services/`** - Service-specific attribute references (one file per service)
 - **`metrics/`** - Metric definitions (one file per service that produces
   metrics)

--- a/telemetry-schema/attributes/cart.yaml
+++ b/telemetry-schema/attributes/cart.yaml
@@ -1,0 +1,11 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+file_format: definition/2
+attributes:
+  - key: demo.cart.items.count
+    type: int
+    brief: Number of items in cart
+    stability: stable
+    note: The count of items currently in the shopping cart
+    examples: [0, 3, 7]

--- a/telemetry-schema/attributes/order.yaml
+++ b/telemetry-schema/attributes/order.yaml
@@ -21,37 +21,3 @@ attributes:
     stability: stable
     note: The count of distinct items in the order
     examples: [1, 5, 10]
-  - key: demo.cart.items.count
-    type: int
-    brief: Number of items in cart
-    stability: stable
-    note: The count of items currently in the shopping cart
-    examples: [0, 3, 7]
-  - key: demo.payment.amount
-    type: string
-    brief: Payment amount
-    stability: stable
-    note: The monetary amount being charged
-    examples: ["29.99", "99.95", "150.00"]
-  - key: demo.payment.card_type
-    type: string
-    brief: Credit card type
-    stability: stable
-    note: The type of credit card being used for payment
-    examples: ["visa", "mastercard", "amex"]
-  - key: demo.payment.card_valid
-    type: boolean
-    brief: Card validation status
-    stability: stable
-    note: Whether the card passed validation checks
-  - key: demo.payment.charged
-    type: boolean
-    brief: Whether payment was successfully charged
-    stability: stable
-    note: Indicates whether the payment transaction was successfully charged to the customer's payment method (true) or not charged (false). For synthetic requests, this is set to false.
-  - key: demo.payment.transaction.id
-    type: string
-    brief: Payment transaction identifier
-    stability: stable
-    note: Unique identifier for the payment transaction
-    examples: ["txn-abc123", "PAY-456789"]

--- a/telemetry-schema/attributes/payment.yaml
+++ b/telemetry-schema/attributes/payment.yaml
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+file_format: definition/2
+attributes:
+  - key: demo.payment.amount
+    type: string
+    brief: Payment amount
+    stability: stable
+    note: The monetary amount being charged
+    examples: ["29.99", "99.95", "150.00"]
+  - key: demo.payment.card_type
+    type: string
+    brief: Credit card type
+    stability: stable
+    note: The type of credit card being used for payment
+    examples: ["visa", "mastercard", "amex"]
+  - key: demo.payment.card_valid
+    type: boolean
+    brief: Card validation status
+    stability: stable
+    note: Whether the card passed validation checks
+  - key: demo.payment.charged
+    type: boolean
+    brief: Whether payment was successfully charged
+    stability: stable
+    note: Indicates whether the payment transaction was successfully charged to the customer's payment method (true) or not charged (false). For synthetic requests, this is set to false.
+  - key: demo.payment.transaction.id
+    type: string
+    brief: Payment transaction identifier
+    stability: stable
+    note: Unique identifier for the payment transaction
+    examples: ["txn-abc123", "PAY-456789"]


### PR DESCRIPTION
Towards #3267

# Changes

Split cart and payment attributes out of the order telemetry schema into their own domain files.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
