### PR TITLE
test(telemetry): build PR images, harden warmup, cap test step at 15m

### DIFF
--- a/.github/workflows/run-telemetry-tests.yml
+++ b/.github/workflows/run-telemetry-tests.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 # Coalesce concurrent runs on the same PR or branch so an approval right
-# after a push doesn't fire two 45-minute builds in parallel.
+# after a push doesn't fire two builds in parallel.
 concurrency:
   group: telemetry-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -71,22 +71,24 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-  telemetry-tests-full:
+  # Build the demo images from the PR's source ONCE, then hand them to the test
+  # jobs as an artifact. Without this the test jobs ran `docker compose up`,
+  # which pulls the released `ghcr.io/open-telemetry/demo:latest-*` images from
+  # the registry — so a PR's own changes were never actually exercised.
+  build-images:
+    name: "Build demo images"
     needs: gate
     if: ${{ needs.gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    name: "Telemetry Tests (full)"
+    timeout-minutes: 30
     steps:
       - name: check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           # On pull_request_review the default ref is the base branch; check out
-          # the PR head so we test the proposed changes. Falls back to the
+          # the PR head so we build the proposed changes. Falls back to the
           # default ref for push and workflow_dispatch events.
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          # Don't leave the GITHUB_TOKEN credential helper on disk; the test
-          # jobs only read the repo, they never push back.
           persist-credentials: false
 
       - name: Free disk space
@@ -100,7 +102,63 @@ jobs:
       - name: Create .env.override if missing
         run: touch .env.override
 
+      - name: Build demo images
+        run: make build
+
+      - name: Save demo images to an artifact tarball
+        run: |
+          # Only the images we build (demo:latest-*) need shipping; third-party
+          # images (jaeger, prometheus, grafana, ...) are pulled from their own
+          # registries by each test job, so leave them out to keep the tarball small.
+          IMAGES=$(docker images 'ghcr.io/open-telemetry/demo:latest-*' --format '{{.Repository}}:{{.Tag}}')
+          echo "Saving images:"; echo "$IMAGES"
+          docker save $IMAGES | zstd -3 -T0 -o demo-images.tar.zst
+          ls -lh demo-images.tar.zst
+
+      - name: Upload demo images artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: demo-images-${{ github.run_id }}
+          path: demo-images.tar.zst
+          retention-days: 1
+          compression-level: 0  # already zstd-compressed
+
+  telemetry-tests-full:
+    needs: [gate, build-images]
+    if: ${{ needs.gate.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: "Telemetry Tests (full)"
+    steps:
+      - name: check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          docker system prune -af
+
+      - name: Download demo images artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: demo-images-${{ github.run_id }}
+
+      - name: Load demo images
+        run: zstd -d -c demo-images.tar.zst | docker load
+
+      - name: Create .env.override if missing
+        run: touch .env.override
+
       - name: Run telemetry tests
+        timeout-minutes: 15
+        env:
+          # Give backends more headroom on slow shared runners before the
+          # per-test polls begin; the warmup gate waits for all three backends.
+          WARMUP_SECONDS: "300"
+          POLL_TIMEOUT: "240"
         run: make run-telemetry-tests
 
       - name: Print service logs on failure
@@ -112,10 +170,10 @@ jobs:
         run: make stop
 
   telemetry-tests-minimal:
-    needs: gate
+    needs: [gate, build-images]
     if: ${{ needs.gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     name: "Telemetry Tests (minimal)"
     steps:
       - name: check out code
@@ -129,13 +187,22 @@ jobs:
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
           docker system prune -af
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+      - name: Download demo images artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: demo-images-${{ github.run_id }}
+
+      - name: Load demo images
+        run: zstd -d -c demo-images.tar.zst | docker load
 
       - name: Create .env.override if missing
         run: touch .env.override
 
       - name: Run telemetry tests (minimal)
+        timeout-minutes: 15
+        env:
+          WARMUP_SECONDS: "300"
+          POLL_TIMEOUT: "240"
         run: make run-telemetry-tests-minimal
 
       - name: Print service logs on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ the release.
 * [testing] Add telemetry sanity tests to validate end-to-end observability
   pipeline, including service-to-service edge verification via Jaeger trace walks
   ([#3356](https://github.com/open-telemetry/opentelemetry-demo/pull/3356))
+* [testing] Telemetry tests now build the PR's images and share them across the
+  full/minimal jobs via an artifact (instead of pulling released images), wait
+  for the traces, metrics, and logs backends during warmup to avoid per-test
+  timeouts, and cap the test step at 15 minutes
+  ([#3498](https://github.com/open-telemetry/opentelemetry-demo/pull/3498))
 * [telemetry-docs] Add a new service to provide telemetry documentation based
   on Weaver
   ([#2794](https://github.com/open-telemetry/opentelemetry-demo/pull/2794))

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ run-telemetry-tests: start
 		--env-file .env --env-file .env.override \
 		-e TEST_SCOPE=full \
 		-e WARMUP_SECONDS=$${WARMUP_SECONDS:-240} \
+		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
 		opentelemetry-demo-telemetry-tests; \
 	rc=$$?; \
 	$(MAKE) stop; \
@@ -216,6 +217,7 @@ run-telemetry-tests-minimal: start-minimal
 		--env-file .env --env-file .env.override \
 		-e TEST_SCOPE=minimal \
 		-e WARMUP_SECONDS=$${WARMUP_SECONDS:-240} \
+		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
 		opentelemetry-demo-telemetry-tests; \
 	rc=$$?; \
 	$(MAKE) stop; \

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -29,29 +29,83 @@ TEST_SCOPE = os.environ.get("TEST_SCOPE", "minimal")
 WARMUP_SECONDS = int(os.environ.get("WARMUP_SECONDS", "240"))
 
 POLL_INTERVAL = 5
-POLL_TIMEOUT = 180
+POLL_TIMEOUT = int(os.environ.get("POLL_TIMEOUT", "180"))
+
+
+def _jaeger_service_count():
+    """Number of services Jaeger has seen at least one span from."""
+    resp = requests.get(f"{JAEGER_URL}/jaeger/ui/api/services", timeout=5)
+    if resp.status_code != 200:
+        return 0
+    # Jaeger returns {"data": null, ...} until the first span arrives, so coerce
+    # None -> [] before len().
+    return len(resp.json().get("data") or [])
+
+
+def _prometheus_service_count():
+    """Number of distinct service.name labels Prometheus has received via OTLP push."""
+    resp = requests.get(
+        f"{PROMETHEUS_URL}/api/v1/query",
+        params={"query": "count(group(target_info) by (service_name))"},
+        timeout=5,
+    )
+    if resp.status_code != 200:
+        return 0
+    result = resp.json().get("data", {}).get("result") or []
+    if not result:
+        return 0
+    return int(float(result[0]["value"][1]))
+
+
+def _opensearch_log_count():
+    """Number of log records OpenSearch has indexed in the otel-logs index."""
+    resp = requests.get(f"{OPENSEARCH_URL}/otel-logs*/_count", timeout=5)
+    if resp.status_code != 200:
+        return 0
+    return int(resp.json().get("count", 0))
+
+
+# Minimum distinct services / records each backend must report before we treat
+# warmup as complete. A small floor (rather than the full service count) keeps
+# this robust across the full and minimal scopes while still proving each
+# signal pipeline is actually flowing end to end.
+WARMUP_MIN_SERVICES = 3
+WARMUP_MIN_LOGS = 1
 
 
 @pytest.fixture(scope="session", autouse=True)
 def wait_for_warmup():
-    """Wait for backends to be reachable, then allow time for telemetry to flow."""
+    """Wait for Jaeger, Prometheus, and OpenSearch to all ingest telemetry
+    before starting the individual signal checks.
+
+    Traces (Jaeger), metrics (Prometheus), and logs (OpenSearch) reach their
+    backends on independent paths through the collector, each with its own
+    batching / sending-queue interval, so they do not become queryable at the
+    same moment. Observed on a cold start: Jaeger had 12 services at ~11s while
+    Prometheus still had only 3 (it caught up to 20 by ~39s). If warmup gates on
+    traces alone, the metrics tests start against a near-empty Prometheus and
+    time out at the per-test deadline (one timeout per service, which is how a
+    run ballooned to ~45min). Gating on all three keeps the per-test polls fast
+    because the data is already there when they run.
+    """
     print(f"\nWaiting for backends to be ready (up to {WARMUP_SECONDS}s)...")
     deadline = time.time() + WARMUP_SECONDS
     backends_ready = False
     while time.time() < deadline:
         try:
-            resp = requests.get(f"{JAEGER_URL}/jaeger/ui/api/services", timeout=5)
-            # Jaeger returns {"data": null, ...} until the first span arrives, so
-            # coerce None -> [] before len(). ValueError catches non-JSON bodies
-            # (e.g. an HTML error page from a still-warming proxy).
-            if resp.status_code == 200:
-                services = resp.json().get("data") or []
-                if len(services) > 3:
-                    backends_ready = True
-                    break
+            jaeger = _jaeger_service_count()
+            prom = _prometheus_service_count()
+            logs = _opensearch_log_count()
+            if (
+                jaeger > WARMUP_MIN_SERVICES
+                and prom > WARMUP_MIN_SERVICES
+                and logs >= WARMUP_MIN_LOGS
+            ):
+                backends_ready = True
+                break
         except (requests.RequestException, ValueError):
             pass
-        time.sleep(5)
+        time.sleep(POLL_INTERVAL)
     if not backends_ready:
         remaining = max(0, int(deadline - time.time()))
         print(f"Backends not fully ready after {WARMUP_SECONDS - remaining}s, proceeding with poll-based checks...")


### PR DESCRIPTION
# Changes

Hardens the Telemetry Tests CI workflow to fix three issues seen since #3356 merged:

## 1. Tests now exercise the PR's own images

Previously the workflow ran `make run-telemetry-tests` → `docker compose up`, which pulls the released `ghcr.io/open-telemetry/demo:latest-*` images from the registry. A PR's own service changes were never actually built or tested (raised by @julianocosta89 on #3487).

Now a dedicated `build-images` job runs `make build` on the PR head, `docker save | zstd`s the demo images, and uploads them as a run-scoped artifact. Both `telemetry-tests-full` and `telemetry-tests-minimal` `needs: build-images`, download the artifact, and `docker load` before running — so they test the PR's code. Third-party images (Jaeger, Prometheus, Grafana, ...) are still pulled from their own registries, so the artifact stays limited to the images we build (~3 GB zstd).

## 2. Per-test timeouts from a backend warm-up race

On a cold start the three backends become queryable at different times. Observed locally: Jaeger had 12 services at ~11s while Prometheus still had only 3 (it caught up to ~20 by ~39s). The warm-up gate only checked Jaeger, so the metrics tests started against a near-empty Prometheus and burned one 180s per-test timeout per service — that's how a run ballooned to ~45 minutes.

The warm-up fixture now waits for Jaeger, Prometheus, **and** OpenSearch to all report telemetry before the per-test polls begin, so the data is already there when tests run.

## 3. Runaway runs

The test step is now capped at `timeout-minutes: 15` (job timeout lowered to 30m), so a hung run can no longer consume 45 minutes. `WARMUP_SECONDS`/`POLL_TIMEOUT` are passed from the workflow with extra headroom for slow shared runners, and `POLL_TIMEOUT` is now env-overridable.

## Verification

Verified locally from a cold start, both scopes:

- `make run-telemetry-tests` → **67 passed**, demo torn down, no timeouts
- `make run-telemetry-tests-minimal` → **54 passed**, demo torn down, no timeouts
- End-to-end signals confirmed flowing: traces (18 services in Jaeger incl. multi-service edges), metrics (21 services in Prometheus), logs (~8k records in OpenSearch), load generator producing traffic
- `make build` from source produces fresh `demo:latest-*` images; `docker save | gzip | docker load` round-trip confirmed

## Merge Requirements

* [x] `CHANGELOG.md` updated
* [ ] Appropriate documentation updates in the docs
* [ ] Appropriate Helm chart updates in the helm-charts
