### PR TITLE
fix(llm): increase memory limit to 100M to prevent restart loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
+  startup restart loop caused by the container exceeding its memory limit
+  ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))
 * [testing] Add telemetry sanity tests to validate end-to-end observability
   pipeline, including service-to-service edge verification via Jaeger trace walks
   ([#3356](https://github.com/open-telemetry/opentelemetry-demo/pull/3356))

--- a/compose.yaml
+++ b/compose.yaml
@@ -691,7 +691,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 50M
+          memory: 100M
     restart: unless-stopped
     environment:
       - FLAGD_HOST


### PR DESCRIPTION
The llm service was configured with a 50M memory limit. The service is a Flask app that also loads the OpenFeature flagd gRPC provider and two product-review JSON datasets, and idles around 38-40 MiB. At 50M that leaves almost no headroom (~76% utilization at idle), so the transient startup memory spike intermittently exceeds the limit and the container is OOM-killed, producing a restart loop where the service never becomes ready.

Raising the limit to 100M matches the neighboring telemetry-docs service and gives comfortable headroom (~39% utilization at idle). Verified locally with docker compose: the container starts and stays up with 0 restarts and serves requests.

Fixes #2944


# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
