### PR TITLE
[fraud-detection] fix dropped gRPC service files in shadow jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,10 @@ the release.
 * [telemetry] Split cart and payment attributes out of the order telemetry
   schema into their own domain files.
   ([#3484](https://github.com/open-telemetry/opentelemetry-demo/pull/3484))
+* [fraud-detection] fix gRPC service files dropped from the shadow jar by
+  setting `duplicatesStrategy` to `INCLUDE`, restoring the DNS name resolver
+  registration needed to connect to flagd
+  ([#3501](https://github.com/open-telemetry/opentelemetry-demo/pull/3501))
 
 ## 2.2.0
 

--- a/src/fraud-detection/build.gradle.kts
+++ b/src/fraud-detection/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
 
 tasks {
     shadowJar {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
         mergeServiceFiles()
     }
 }


### PR DESCRIPTION
# Changes

Shadow 9 defaults duplicatesStrategy to EXCLUDE, which drops duplicate META-INF/services files before mergeServiceFiles() can merge them. As a result the DNS name resolver registration from grpc-core was lost and gRPC fell back to the unix scheme as default, breaking the flagd provider connection:

```
  GenericConfigException: Error with gRPC target string configuration
  Caused by: IllegalArgumentException: Address types of NameResolver
  'unix' for 'unix:///localhost:8013' not supported by transport
```
Regression introduced by the Shadow 8.1.1 -> 9.4.2 bump in 36e2ce4d. Setting duplicatesStrategy to INCLUDE restores service file merging, as recommended by the Shadow 9.0.1 release notes.

See https://github.com/GradleUp/shadow/issues/1348 and https://github.com/grpc/grpc-java/issues/12282

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
