### PR TITLE
fix(accounting): handle duplicate order from Kafka redelivery

### DIFF
--- a/src/accounting/Consumer.cs
+++ b/src/accounting/Consumer.cs
@@ -3,6 +3,7 @@
 
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using Oteldemo;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
@@ -131,6 +132,10 @@ internal class Consumer : IDisposable
             };
             dbContext.Add(shipping);
             dbContext.SaveChanges();
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+        {
+            _logger.LogInformation("Duplicate order received, skipping.");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes #2783

Kafka delivers messages with at-least-once semantics, so the accounting service can receive the same order message more than once (e.g. after a restart). The second attempt to insert the same order fails with a PostgreSQL unique constraint violation, which was logged as an error.

This change catches `DbUpdateException` when the inner exception is a `PostgresException` with `SqlState 23505` (unique violation) and logs it at `Information` level instead, making the consumer idempotent.