### PR TITLE
[chore] profiling: Update firepit to use first tagged version v0.1.0

### DIFF
--- a/compose.profiling.yaml
+++ b/compose.profiling.yaml
@@ -29,7 +29,7 @@ services:
       - otel-collector
 
   firepit:
-    image: ghcr.io/florianl/firepit:df1dcbe
+    image: ghcr.io/florianl/firepit:v0.1.0
     container_name: firepit
     ports:
       - "${FIREPIT_PORT}"


### PR DESCRIPTION
# Changes

Update the firepit dependency, that visualizes profiling data, to use the first tagged version [v0.1.0](https://github.com/florianl/firepit/pkgs/container/firepit/960401332?tag=v0.1.0).

As this is just a dependency update without introducing changes, no entry in CHANGELOG.md or other documentation is added. Please let me know, if there is a place to document such dependency updates.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
