### PR TITLE
fix(shipping): add graceful shutdown for OTel providers

### DIFF
--- a/src/shipping/src/main.rs
+++ b/src/shipping/src/main.rs
@@ -16,9 +16,10 @@ use shipping_service::{get_quote, ship_order};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    match init_otel() {
-        Ok(_) => {
+    let otel_guard = match init_otel() {
+        Ok(guard) => {
             info!("Successfully configured OTel");
+            guard
         }
         Err(err) => {
             panic!("Couldn't start OTel: {0}", err);
@@ -66,5 +67,8 @@ async fn main() -> std::io::Result<()> {
     })
     .bind(&addr)?
     .run()
-    .await
+    .await?;
+
+    otel_guard.shutdown();
+    Ok(())
 }

--- a/src/shipping/src/telemetry_conf.rs
+++ b/src/shipping/src/telemetry_conf.rs
@@ -4,6 +4,9 @@
 use anyhow::Result;
 use opentelemetry::global;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
@@ -21,10 +24,10 @@ fn get_resource() -> Resource {
     Resource::builder().with_detectors(&detectors).build()
 }
 
-fn init_tracer_provider() {
+fn init_tracer_provider() -> SdkTracerProvider {
     global::set_text_map_propagator(TraceContextPropagator::new());
 
-    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+    let tracer_provider = SdkTracerProvider::builder()
         .with_resource(get_resource())
         .with_batch_exporter(
             opentelemetry_otlp::SpanExporter::builder()
@@ -34,11 +37,12 @@ fn init_tracer_provider() {
         )
         .build();
 
-    global::set_tracer_provider(tracer_provider);
+    global::set_tracer_provider(tracer_provider.clone());
+    tracer_provider
 }
 
-fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
-    let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+fn init_meter_provider() -> SdkMeterProvider {
+    let meter_provider = SdkMeterProvider::builder()
         .with_resource(get_resource())
         .with_periodic_exporter(
             opentelemetry_otlp::MetricExporter::builder()
@@ -52,8 +56,8 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     meter_provider
 }
 
-fn init_logger_provider() {
-    let logger_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+fn init_logger_provider() -> SdkLoggerProvider {
+    let logger_provider = SdkLoggerProvider::builder()
         .with_resource(get_resource())
         .with_batch_exporter(
             opentelemetry_otlp::LogExporter::builder()
@@ -68,11 +72,41 @@ fn init_logger_provider() {
     let otel_layer = otel_layer.with_filter(filter_otel);
 
     tracing_subscriber::registry().with(otel_layer).init();
+
+    logger_provider
 }
 
-pub fn init_otel() -> Result<()> {
-    init_logger_provider();
-    init_tracer_provider();
-    init_meter_provider();
-    Ok(())
+/// Holds all OTel provider handles for graceful shutdown.
+pub struct OtelGuard {
+    tracer_provider: SdkTracerProvider,
+    logger_provider: SdkLoggerProvider,
+    meter_provider: SdkMeterProvider,
+}
+
+impl OtelGuard {
+    /// Shuts down all providers, flushing any buffered telemetry.
+    /// Order: tracer → logger → meter (meter last because BatchLogProcessor
+    /// may emit self-diagnostic metrics during its shutdown).
+    pub fn shutdown(self) {
+        if let Err(e) = self.tracer_provider.shutdown() {
+            eprintln!("Failed to shutdown TracerProvider: {e}");
+        }
+        if let Err(e) = self.logger_provider.shutdown() {
+            eprintln!("Failed to shutdown LoggerProvider: {e}");
+        }
+        if let Err(e) = self.meter_provider.shutdown() {
+            eprintln!("Failed to shutdown MeterProvider: {e}");
+        }
+    }
+}
+
+pub fn init_otel() -> Result<OtelGuard> {
+    let logger_provider = init_logger_provider();
+    let tracer_provider = init_tracer_provider();
+    let meter_provider = init_meter_provider();
+    Ok(OtelGuard {
+        tracer_provider,
+        logger_provider,
+        meter_provider,
+    })
 }


### PR DESCRIPTION
Ensures all OTel providers are shut down on exit, flushing buffered telemetry.