### PR TITLE
fix(shipping): create meter and counter once via LazyLock

### DIFF
--- a/src/shipping/src/shipping_service/quote.rs
+++ b/src/shipping/src/shipping_service/quote.rs
@@ -3,7 +3,9 @@
 
 use core::fmt;
 use opentelemetry::global;
+use opentelemetry::metrics::Counter;
 use opentelemetry_instrumentation_actix_web::ClientExt;
+use std::sync::LazyLock;
 use std::{collections::HashMap, env};
 
 use anyhow::{Context, Result};
@@ -11,6 +13,12 @@ use opentelemetry::{trace::get_active_span, KeyValue};
 use tracing::info;
 
 use super::shipping_types::Quote;
+
+static ITEMS_SHIPPED_COUNTER: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter("otel_demo.shipping.quote")
+        .u64_counter("demo.shipping.items_shipped")
+        .build()
+});
 
 pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status> {
     let f = match request_quote(count).await {
@@ -21,9 +29,7 @@ pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status>
         }
     };
 
-    let meter = global::meter("otel_demo.shipping.quote");
-    let counter = meter.u64_counter("demo.shipping.items_shipped").build();
-    counter.add(count as u64, &[]);
+    ITEMS_SHIPPED_COUNTER.add(count as u64, &[]);
 
     Ok(get_active_span(|span| {
         let q = create_quote_from_float(f);


### PR DESCRIPTION
Avoids recreating meter/counter on every request.