### PR TITLE
fix(shipping): guard span event/attribute behind is_recording()

### DIFF
--- a/src/shipping/src/shipping_service/quote.rs
+++ b/src/shipping/src/shipping_service/quote.rs
@@ -27,11 +27,14 @@ pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status>
 
     Ok(get_active_span(|span| {
         let q = create_quote_from_float(f);
-        span.add_event(
-            "Received Quote".to_string(),
-            vec![KeyValue::new("demo.shipping.cost.total", format!("{}", q))],
-        );
-        span.set_attribute(KeyValue::new("demo.shipping.cost.total", format!("{}", q)));
+        if span.is_recording() {
+            let cost = format!("{}", q);
+            span.add_event(
+                "Received Quote".to_string(),
+                vec![KeyValue::new("demo.shipping.cost.total", cost.clone())],
+            );
+            span.set_attribute(KeyValue::new("demo.shipping.cost.total", cost));
+        }
         q
     }))
 }


### PR DESCRIPTION
Avoids format! allocations when span is not recording.