### PR TITLE
fix(currency): use BatchProcessor instead of SimpleProcessor

### DIFF
--- a/src/currency/src/logger_common.h
+++ b/src/currency/src/logger_common.h
@@ -5,7 +5,7 @@
 #include "opentelemetry/logs/provider.h"
 #include "opentelemetry/sdk/logs/logger.h"
 #include "opentelemetry/sdk/logs/logger_provider_factory.h"
-#include "opentelemetry/sdk/logs/simple_log_record_processor_factory.h"
+#include "opentelemetry/sdk/logs/batch_log_record_processor_factory.h"
 #include "opentelemetry/sdk/logs/logger_context_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_factory.h"
 
@@ -20,7 +20,7 @@ namespace
   void initLogger() {
     otlp::OtlpGrpcLogRecordExporterOptions loggerOptions;
     auto exporter  = otlp::OtlpGrpcLogRecordExporterFactory::Create(loggerOptions);
-    auto processor = logs_sdk::SimpleLogRecordProcessorFactory::Create(std::move(exporter));
+    auto processor = logs_sdk::BatchLogRecordProcessorFactory::Create(std::move(exporter), {});
     std::vector<std::unique_ptr<logs_sdk::LogRecordProcessor>> processors;
     processors.push_back(std::move(processor));
     auto context = logs_sdk::LoggerContextFactory::Create(std::move(processors));

--- a/src/currency/src/tracer_common.h
+++ b/src/currency/src/tracer_common.h
@@ -7,7 +7,7 @@
 #include "opentelemetry/context/propagation/text_map_propagator.h"
 #include "opentelemetry/exporters/ostream/span_exporter_factory.h"
 #include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/sdk/trace/tracer_context_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
@@ -74,7 +74,7 @@ void initTracer()
 {
   auto exporter = opentelemetry::exporter::otlp::OtlpGrpcExporterFactory::Create();
   auto processor =
-      opentelemetry::sdk::trace::SimpleSpanProcessorFactory::Create(std::move(exporter));
+      opentelemetry::sdk::trace::BatchSpanProcessorFactory::Create(std::move(exporter), {});
   std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor>> processors;
   processors.push_back(std::move(processor));
 


### PR DESCRIPTION
SimpleProcessor exports synchronously on the calling thread, blocking the request path. Switch to BatchProcessor for both traces and logs, which is the recommended default.