### PR TITLE
fix(shipping): use OnceLock for Resource to avoid redundant detector runs

### DIFF
--- a/src/shipping/src/telemetry_conf.rs
+++ b/src/shipping/src/telemetry_conf.rs
@@ -11,14 +11,21 @@ use opentelemetry_resource_detectors::{OsResourceDetector, ProcessResourceDetect
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator, resource::ResourceDetector, Resource,
 };
+use std::sync::OnceLock;
+
+static RESOURCE: OnceLock<Resource> = OnceLock::new();
 
 fn get_resource() -> Resource {
-    let detectors: Vec<Box<dyn ResourceDetector>> = vec![
-        Box::new(OsResourceDetector),
-        Box::new(ProcessResourceDetector),
-    ];
+    RESOURCE
+        .get_or_init(|| {
+            let detectors: Vec<Box<dyn ResourceDetector>> = vec![
+                Box::new(OsResourceDetector),
+                Box::new(ProcessResourceDetector),
+            ];
 
-    Resource::builder().with_detectors(&detectors).build()
+            Resource::builder().with_detectors(&detectors).build()
+        })
+        .clone()
 }
 
 fn init_tracer_provider() {


### PR DESCRIPTION
Resource was built 3 times (once per provider), running OS and Process detectors each time. Use OnceLock to build once and clone.