### PR TITLE
[cleanup] Remove loadgen traffic to product reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,8 @@ the release.
   ([#3521](https://github.com/open-telemetry/opentelemetry-demo/pull/3521))
 * [cart,accounting] Use source-generated logging with EventName
   ([#3559](https://github.com/open-telemetry/opentelemetry-demo/pull/3559))
+* [cleanup] Remove loadgen traffic to product reviews
+  ([#3567](https://github.com/open-telemetry/opentelemetry-demo/pull/3567))
 
 ## 2.2.0
 

--- a/src/load-generator/locustfile.py
+++ b/src/load-generator/locustfile.py
@@ -140,24 +140,6 @@ class WebsiteUser(HttpUser):
             }
             self.client.get("/api/recommendations", params=params)
 
-    @task(2)
-    def get_product_reviews(self):
-        product = random.choice(products)
-        with self.tracer.start_as_current_span("user_get_product_reviews", context=Context(), attributes={"product.id": product}):
-            logging.info(f"User getting product reviews for product: {product}")
-            self.client.get("/api/product-reviews/" + product)
-
-    @task(1)
-    def ask_product_ai_assistant(self):
-        product = random.choice(products)
-        question = 'Can you summarize the product reviews?'
-        with self.tracer.start_as_current_span("user_ask_product_ai_assistant", context=Context(), attributes={"product.id": product, "question": question}):
-            logging.info(f"Asking the AI Assistant a question for: {product} {question}")
-            question = {
-                "question": question
-            }
-            self.client.post("/api/product-ask-ai-assistant/" + product, json=question)
-
     @task(3)
     def get_ads(self):
         category = random.choice(categories)


### PR DESCRIPTION
# Changes

With the merge of #3455, it was agreed on previous SIG meetings that the service Product Reviews will be removed.
To keep each PR easy to review I'll split the work.
This PR removed the loadgen calls to the product reviews service.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
