### PR TITLE
fix(shipping): follow semantic convention style for event names

### DIFF
--- a/src/shipping/src/main.rs
+++ b/src/shipping/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> std::io::Result<()> {
 
     let addr = format!("{}:{}", ip, port);
     info!(
-        name = "ServerStartedSuccessfully",
+        name: "shipping.server.started",
         addr = addr.as_str(),
         message = "Shipping service is running"
     );
@@ -63,7 +63,10 @@ async fn main() -> std::io::Result<()> {
             .wrap(RequestMetrics::default())
             .service(get_quote)
             .service(ship_order)
-            .route("/health", web::get().to(|| async { HttpResponse::Ok().finish() }))
+            .route(
+                "/health",
+                web::get().to(|| async { HttpResponse::Ok().finish() }),
+            )
     })
     .bind(&addr)?
     .run()

--- a/src/shipping/src/shipping_service.rs
+++ b/src/shipping/src/shipping_service.rs
@@ -37,7 +37,7 @@ pub async fn get_quote(req: web::Json<GetQuoteRequest>) -> impl Responder {
     };
 
     info!(
-        name: "SendingQuoteValue",
+        name: "shipping.quote.sent",
         dollars = quote.dollars,
         cents = quote.cents,
         "Sending Quote"
@@ -68,7 +68,7 @@ pub async fn ship_order(
             .await
             .map(|res| {
                 info!(
-                    name: "FeatureFlagEvaluated",
+                    name: "shipping.feature_flag.evaluated",
                     feature_flag_key = "intlShippingSlowdown",
                     feature_flag_provider_name = "flagd",
                     feature_flag_variant = res.variant.as_deref().unwrap_or("unknown"),
@@ -76,7 +76,7 @@ pub async fn ship_order(
                 res.value
             })
             .unwrap_or_else(|e| {
-                warn!(name: "FeatureFlagEvaluationFailed", error = ?e);
+                warn!(name: "shipping.feature_flag.evaluation_failed", error = ?e);
                 0
             })
     } else {
@@ -85,7 +85,7 @@ pub async fn ship_order(
 
     if slowdown_secs > 0 {
         info!(
-            name: "IntlShippingSlowdown",
+            name: "shipping.international.slowdown",
             delay_secs = slowdown_secs,
             "Delaying international shipment due to intlShippingSlowdown feature flag"
         );
@@ -94,7 +94,7 @@ pub async fn ship_order(
 
     let tid = create_tracking_id();
     info!(
-        name: "CreatingTrackingId",
+        name: "shipping.tracking_id.created",
         tracking_id = tid.as_str(),
         "Tracking ID Created"
     );
@@ -120,16 +120,14 @@ mod tests {
         address: Option<Address>,
         provider: web::Data<dyn FeatureProvider>,
     ) -> ShipOrderResponse {
-        let app = test::init_service(
-            App::new()
-                .app_data(provider)
-                .service(ship_order),
-        )
-        .await;
+        let app = test::init_service(App::new().app_data(provider).service(ship_order)).await;
         let req = test::TestRequest::post()
             .uri("/ship-order")
             .insert_header(ContentType::json())
-            .set_json(&ShipOrderRequest { address, items: vec![] })
+            .set_json(&ShipOrderRequest {
+                address,
+                items: vec![],
+            })
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());

--- a/src/shipping/src/shipping_service/quote.rs
+++ b/src/shipping/src/shipping_service/quote.rs
@@ -36,7 +36,7 @@ pub async fn create_quote_from_count(count: u32) -> Result<Quote, tonic::Status>
         if span.is_recording() {
             let cost = format!("{}", q);
             span.add_event(
-                "Received Quote".to_string(),
+                "shipping.quote.received".to_string(),
                 vec![KeyValue::new("demo.shipping.cost.total", cost.clone())],
             );
             span.set_attribute(KeyValue::new("demo.shipping.cost.total", cost));
@@ -57,7 +57,7 @@ async fn request_quote(count: u32) -> Result<f64, anyhow::Error> {
     );
 
     info!(
-        name: "RequestingQuote",
+        name: "shipping.quote.requested",
         quote_service_addr = quote_service_addr.as_str(),
         "Requesting quote"
     );


### PR DESCRIPTION
Follows sem cnventions guide: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md#event-name

https://github.com/open-telemetry/opentelemetry-demo/discussions/2602#discussioncomment-17420705