### PR TITLE
fix(frontend-proxy): pass CHATBOT_HOST/PORT in base compose so Envoy renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the release.
 
 ## Unreleased
 
+* [frontend-proxy] Pass `CHATBOT_HOST`/`CHATBOT_PORT` to the frontend-proxy in
+  the base compose file. The chatbot upstream cluster lives in the base
+  `envoy.tmpl.yaml` and `envsubst` runs in-container, so without these vars the
+  proxy rendered an empty chatbot address and failed Envoy bootstrap validation
+  whenever the agent stack was not layered on
+  ([#3570](https://github.com/open-telemetry/opentelemetry-demo/pull/3570))
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/compose.yaml
+++ b/compose.yaml
@@ -348,6 +348,8 @@ services:
       - FLAGD_UI_PORT
       - TELEMETRY_DOCS_HOST
       - TELEMETRY_DOCS_PORT
+      - CHATBOT_HOST
+      - CHATBOT_PORT
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${ENVOY_PORT}"]
       start_period: 10s


### PR DESCRIPTION
# Changes

Fixes the telemetry-test failures on `main` (and any `make start` without the agent layer) caused by the frontend-proxy crashing on startup.

## Root cause

`#3455` (Agent/MCP/Chatbot) added a `chatbot` upstream cluster to the **base** `src/frontend-proxy/envoy.tmpl.yaml`, referencing `${CHATBOT_HOST}` / `${CHATBOT_PORT}`. The frontend-proxy entrypoint renders its config with `envsubst < envoy.tmpl.yaml` using **only the container's own environment**. But `CHATBOT_HOST`/`CHATBOT_PORT` were added to frontend-proxy's environment **only** by the optional `compose.agent.yaml` patch the base `compose.yaml` `frontend-proxy.environment` list didn't include them.

So whenever the proxy renders its config without those vars present, `envsubst` substitutes empty strings and Envoy fails bootstrap validation:

```
StaticResources.Clusters[10] ... SocketAddressValidationError.Address:
value length must be at least 1 characters
```

(`Clusters[10]` is the `chatbot` cluster.) The proxy never starts, all traffic through it stops, and the telemetry tests time out (`email`, `quote`, `frontend-proxy` log checks) which is what's been failing on `main` since `#3455` merged.

Reproduced deterministically by running `envsubst` over the template without `CHATBOT_HOST`/`CHATBOT_PORT` set the chatbot cluster renders an empty `address:`.

## Fix

Pass `CHATBOT_HOST`/`CHATBOT_PORT` to frontend-proxy in the **base** `compose.yaml`, so a valid chatbot address is always rendered regardless of whether the agent stack (`compose.agent.yaml`) is layered on. The cluster lives in the base template, so its env vars belong in the base service definition. `compose.agent.yaml` keeps its `depends_on: chatbot`.

## Verification

- `docker compose -f compose.yaml config` now passes `CHATBOT_HOST=chatbot` / `CHATBOT_PORT=7860` to frontend-proxy (previously absent).
- `envsubst` over `envoy.tmpl.yaml` with `.env` loaded now renders `address: chatbot`, `port_value: 7860` for the chatbot cluster; all 13 socket addresses are populated, none empty.
- `docker compose config -q` valid for both the base stack and the full agent-layered stack.

## Merge Requirements

* [x] `CHANGELOG.md` updated
* [ ] Appropriate documentation updates in the docs
* [ ] Appropriate Helm chart updates in the helm-charts
