### PR TITLE
chore(tests): Warmup imrpovements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 * text=auto
 
 gradlew text eol=lf
+src/flagd-ui/rel/overlays/bin/server text eol=lf

--- a/.github/workflows/run-telemetry-tests.yml
+++ b/.github/workflows/run-telemetry-tests.yml
@@ -159,6 +159,8 @@ jobs:
           # per-test polls begin; the warmup gate waits for all three backends.
           WARMUP_SECONDS: "300"
           POLL_TIMEOUT: "240"
+          WARMUP_PROBE_TIMEOUT: "180"
+          PYTEST_ADDOPTS: "--capture=tee-sys --maxfail=1"
         run: make run-telemetry-tests
 
       - name: Print service logs on failure
@@ -203,6 +205,8 @@ jobs:
         env:
           WARMUP_SECONDS: "300"
           POLL_TIMEOUT: "240"
+          WARMUP_PROBE_TIMEOUT: "180"
+          PYTEST_ADDOPTS: "--capture=tee-sys --maxfail=1"
         run: make run-telemetry-tests-minimal
 
       - name: Print service logs on failure

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ run-telemetry-tests: start
 		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
 		-e WARMUP_PROBE_ENABLED=$${WARMUP_PROBE_ENABLED:-true} \
 		-e WARMUP_PROBE_CHECKOUTS=$${WARMUP_PROBE_CHECKOUTS:-5} \
+		-e WARMUP_PROBE_TIMEOUT=$${WARMUP_PROBE_TIMEOUT:-120} \
 		opentelemetry-demo-telemetry-tests; \
 	rc=$$?; \
 	$(MAKE) stop; \
@@ -223,6 +224,7 @@ run-telemetry-tests-minimal: start-minimal
 		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
 		-e WARMUP_PROBE_ENABLED=$${WARMUP_PROBE_ENABLED:-true} \
 		-e WARMUP_PROBE_CHECKOUTS=$${WARMUP_PROBE_CHECKOUTS:-5} \
+		-e WARMUP_PROBE_TIMEOUT=$${WARMUP_PROBE_TIMEOUT:-120} \
 		opentelemetry-demo-telemetry-tests; \
 	rc=$$?; \
 	$(MAKE) stop; \

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -140,6 +140,7 @@ make run-telemetry-tests-minimal   # Minimal scope
 | `POLL_TIMEOUT`           | `180`        | Per-test seconds to poll a backend for data     |
 | `WARMUP_PROBE_ENABLED`   | `true`       | Drive checkouts during warmup (see Approach)    |
 | `WARMUP_PROBE_CHECKOUTS` | `5`          | Number of checkouts the warmup probe drives     |
+| `WARMUP_PROBE_TIMEOUT`   | `120`        | Max seconds to complete warmup probe checkouts  |
 
 ## CI Integration
 
@@ -152,7 +153,7 @@ touching `src/`, `test/telemetry/`, or compose files.
 - **New service**: Add one entry to `SIGNAL_MATRIX` in `services.py`
 - **New service edge**: Add one tuple to `SERVICE_EDGES` in `services.py`
 - **New backend**: Add a new `test_*.py` file
-- **Adjust timeouts**: Set `WARMUP_SECONDS` or `POLL_TIMEOUT` env vars
+- **Adjust timeouts**: Set `WARMUP_SECONDS`, `POLL_TIMEOUT`, or `WARMUP_PROBE_TIMEOUT` env vars
 - **Run single test**: `pytest test_traces.py -k "checkout" -v`
 - **Run single edge**: `pytest test_traces_edges.py -k "frontend->cart" -v`
 

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -153,7 +153,8 @@ touching `src/`, `test/telemetry/`, or compose files.
 - **New service**: Add one entry to `SIGNAL_MATRIX` in `services.py`
 - **New service edge**: Add one tuple to `SERVICE_EDGES` in `services.py`
 - **New backend**: Add a new `test_*.py` file
-- **Adjust timeouts**: Set `WARMUP_SECONDS`, `POLL_TIMEOUT`, or `WARMUP_PROBE_TIMEOUT` env vars
+- **Adjust timeouts**: Set `WARMUP_SECONDS`, `POLL_TIMEOUT`,
+  or `WARMUP_PROBE_TIMEOUT` env vars
 - **Run single test**: `pytest test_traces.py -k "checkout" -v`
 - **Run single edge**: `pytest test_traces_edges.py -k "frontend->cart" -v`
 

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -47,6 +47,16 @@ WARMUP_SECONDS = int(os.environ.get("WARMUP_SECONDS", "240"))
 # generator happening to run a checkout (~6% task weight) within the test window.
 WARMUP_PROBE_ENABLED = os.environ.get("WARMUP_PROBE_ENABLED", "true").lower() == "true"
 WARMUP_PROBE_CHECKOUTS = int(os.environ.get("WARMUP_PROBE_CHECKOUTS", "5"))
+WARMUP_PROBE_TIMEOUT = int(os.environ.get("WARMUP_PROBE_TIMEOUT", "120"))
+
+# These services are expected to emit logs from the checkout path driven by the
+# warmup probe. Gate on them explicitly so CI fails in setup with a useful
+# message instead of spending one POLL_TIMEOUT per missing log test.
+WARMUP_PROBE_LOG_SERVICES = tuple(
+    svc
+    for svc in ("email", "frontend-proxy", "quote")
+    if svc in services_with_signal("logs", TEST_SCOPE)
+)
 
 POLL_INTERVAL = 5
 POLL_TIMEOUT = int(os.environ.get("POLL_TIMEOUT", "180"))
@@ -83,6 +93,26 @@ def _opensearch_log_count():
     if resp.status_code != 200:
         return 0
     return int(resp.json().get("count", 0))
+
+
+def _opensearch_service_log_count(service):
+    """Number of log records OpenSearch has indexed for one service."""
+    ppl = f"source=otel-logs-* | where resource.service.name = '{service}' | stats count()"
+    resp = requests.post(
+        f"{OPENSEARCH_URL}/_plugins/_ppl",
+        json={"query": ppl},
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    rows = resp.json().get("datarows", [])
+    if not rows:
+        return 0
+    return int(rows[0][0])
+
+
+def _opensearch_service_log_counts(services):
+    return {svc: _opensearch_service_log_count(svc) for svc in services}
 
 
 # Minimum distinct services / records each backend must report before we treat
@@ -128,39 +158,75 @@ PROBE_PERSON = {
 }
 
 
+def _raise_for_status(resp, description):
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as e:
+        body = resp.text.strip().replace("\n", " ")[:300]
+        raise requests.HTTPError(
+            f"{description} returned HTTP {resp.status_code}: {body}",
+            response=resp,
+        ) from e
+
+
 def _drive_checkout(session, product_id):
     """Add one product to a fresh cart and check out via the frontend proxy.
-
-    Best-effort: the demo may still be starting, so any request error is swallowed
-    and reported rather than raised - the warmup readiness loop is what actually
-    gates the tests.
     """
     user_id = str(uuid.uuid4())
-    try:
-        session.post(
-            f"{FRONTEND_PROXY_URL}/api/cart",
-            json={"item": {"productId": product_id, "quantity": 1}, "userId": user_id},
-            timeout=10,
-        )
-        person = dict(PROBE_PERSON, userId=user_id)
-        session.post(f"{FRONTEND_PROXY_URL}/api/checkout", json=person, timeout=15)
-        return True
-    except requests.RequestException as e:
-        print(f"  warmup probe checkout failed (ignored): {e}")
-        return False
+    cart_resp = session.post(
+        f"{FRONTEND_PROXY_URL}/api/cart",
+        json={"item": {"productId": product_id, "quantity": 1}, "userId": user_id},
+        timeout=10,
+    )
+    _raise_for_status(cart_resp, "cart warmup request")
+
+    person = dict(PROBE_PERSON, userId=user_id)
+    checkout_resp = session.post(
+        f"{FRONTEND_PROXY_URL}/api/checkout",
+        json=person,
+        timeout=15,
+    )
+    _raise_for_status(checkout_resp, "checkout warmup request")
 
 
 def _run_warmup_probe():
     """Drive a handful of real checkouts so the full service graph - including
     low-frequency services like email and quote that only emit on the checkout
     path - produces telemetry deterministically before the readiness poll."""
-    print(f"Driving {WARMUP_PROBE_CHECKOUTS} warmup checkout(s) via {FRONTEND_PROXY_URL}...")
+    if WARMUP_PROBE_CHECKOUTS <= 0:
+        print("Warmup probe requested 0 checkouts, skipping checkout traffic.")
+        return
+
+    print(
+        f"Driving {WARMUP_PROBE_CHECKOUTS} warmup checkout(s) via "
+        f"{FRONTEND_PROXY_URL} for up to {WARMUP_PROBE_TIMEOUT}s..."
+    )
+    deadline = time.time() + WARMUP_PROBE_TIMEOUT
     ok = 0
+    attempts = 0
+    last_error = None
     with requests.Session() as session:
-        for i in range(WARMUP_PROBE_CHECKOUTS):
-            product_id = PROBE_PRODUCTS[i % len(PROBE_PRODUCTS)]
-            if _drive_checkout(session, product_id):
+        while ok < WARMUP_PROBE_CHECKOUTS and time.time() < deadline:
+            product_id = PROBE_PRODUCTS[attempts % len(PROBE_PRODUCTS)]
+            attempts += 1
+            try:
+                _drive_checkout(session, product_id)
                 ok += 1
+                print(f"  warmup checkout {ok}/{WARMUP_PROBE_CHECKOUTS} succeeded")
+            except requests.RequestException as e:
+                last_error = e
+                print(f"  warmup checkout attempt {attempts} failed: {e}")
+                time.sleep(POLL_INTERVAL)
+
+    if ok < WARMUP_PROBE_CHECKOUTS:
+        msg = (
+            f"Warmup probe completed only {ok}/{WARMUP_PROBE_CHECKOUTS} "
+            f"checkout(s) within {WARMUP_PROBE_TIMEOUT}s"
+        )
+        if last_error:
+            msg += f"; last error: {last_error}"
+        pytest.fail(msg)
+
     print(f"  warmup probe completed: {ok}/{WARMUP_PROBE_CHECKOUTS} checkout(s) succeeded")
 
 
@@ -187,24 +253,55 @@ def wait_for_warmup():
     if WARMUP_PROBE_ENABLED:
         _run_warmup_probe()
     print(f"\nWaiting for backends to be ready (up to {WARMUP_SECONDS}s)...")
+    required_probe_log_services = (
+        WARMUP_PROBE_LOG_SERVICES
+        if WARMUP_PROBE_ENABLED and WARMUP_PROBE_CHECKOUTS > 0
+        else ()
+    )
+    if required_probe_log_services:
+        print(
+            "Waiting for checkout-path logs in OpenSearch: "
+            + ", ".join(required_probe_log_services)
+        )
     deadline = time.time() + WARMUP_SECONDS
     backends_ready = False
+    last_state = None
+    last_error = None
     while time.time() < deadline:
         try:
             jaeger = _jaeger_service_count()
             prom = _prometheus_service_count()
             logs = _opensearch_log_count()
+            probe_logs = _opensearch_service_log_counts(required_probe_log_services)
+            last_state = (jaeger, prom, logs, probe_logs)
             if (
                 jaeger > WARMUP_MIN_SERVICES
                 and prom > WARMUP_MIN_SERVICES
                 and logs >= WARMUP_MIN_LOGS
+                and all(count > 0 for count in probe_logs.values())
             ):
                 backends_ready = True
                 break
-        except (requests.RequestException, ValueError):
-            pass
+        except (requests.RequestException, ValueError) as e:
+            last_error = e
         time.sleep(POLL_INTERVAL)
     if not backends_ready:
+        if required_probe_log_services:
+            probe_logs = last_state[3] if last_state else {}
+            missing_logs = [
+                svc
+                for svc in required_probe_log_services
+                if probe_logs.get(svc, 0) <= 0
+            ]
+            if missing_logs:
+                msg = (
+                    "Warmup checkouts completed, but checkout-path logs did not "
+                    f"reach OpenSearch within {WARMUP_SECONDS}s. Missing logs: "
+                    f"{', '.join(missing_logs)}. Last counts: {probe_logs}"
+                )
+                if last_error:
+                    msg += f"; last backend error: {last_error}"
+                pytest.fail(msg)
         remaining = max(0, int(deadline - time.time()))
         print(f"Backends not fully ready after {WARMUP_SECONDS - remaining}s, proceeding with poll-based checks...")
     else:


### PR DESCRIPTION
The previous warmup probe could report success even when checkout traffic returned failing HTTP responses. When checkout-path services like `email`, `quote`, or `frontend-proxy` did not produce indexed logs, each log assertion waited the full `POLL_TIMEOUT`, and GitHub Actions could kill the step before pytest printed the useful failure.

This change makes the CI failure mode deterministic and easier to debug:

- Warmup checkouts now retry until real non-error responses are observed.
- `WARMUP_PROBE_TIMEOUT` bounds how long checkout warmup can spend retrying.
- Tests wait for checkout-path logs from `email`, `frontend-proxy`, and `quote` before running per-service assertions.
- CI streams pytest output and stops on the first telemetry failure, preserving the root cause in logs.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
