### PR TITLE
feat(product-catalog): Add otelsql SQLCommenter instrumentation

### DIFF
--- a/src/product-catalog/README.md
+++ b/src/product-catalog/README.md
@@ -23,6 +23,27 @@ From the root directory, run:
 docker compose build product-catalog
 ```
 
+## Database Instrumentation
+
+PostgreSQL queries are instrumented with
+[otelsql](https://pkg.go.dev/github.com/XSAM/otelsql), with SQLCommenter enabled
+to append trace context to SQL statements (for example, `traceparent` key-value
+pairs in query comments).
+
+The option is configured in `main.go` when opening the database connection:
+
+```go
+db, err = otelsql.Open("postgres", connStr,
+    dbAttrs,
+    otelsql.WithSQLCommenter(true),
+    otelsql.WithSpanOptions(...),
+)
+```
+
+Queries must use context-aware methods such as `QueryContext` and
+`QueryRowContext` so the active trace context is available when SQL comments
+are injected.
+
 ## Regenerate protos
 
 To build the protos, run from the root directory:

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -75,6 +75,7 @@ func initDatabase() error {
 	var err error
 	db, err = otelsql.Open("postgres", connStr,
 		dbAttrs,
+		otelsql.WithSQLCommenter(true),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			OmitConnResetSession: true,
 			OmitRows:             true,


### PR DESCRIPTION
## Summary

This adds [SQLCommenter](https://google.github.io/sqlcommenter/) support to the product-catalog service using the existing [otelsql](https://pkg.go.dev/github.com/XSAM/otelsql) instrumentation.

When enabled, each SQL statement sent to PostgreSQL includes a trailing comment with OpenTelemetry context, for example:

```sql
SELECT p.id, p.name, p.description, p.picture,
       p.price_usd, c.name as category
FROM catalog.products p
/*traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-c57d2bc1cc3aea31-01'*/
```

## Why this is useful

Product-catalog is a PostgreSQL-backed Go service in the demo. It already emits database spans via otelsql, but PostgreSQL statement logs do not include trace context by default.

SQLCommenter closes that gap by propagating the active `traceparent` into the SQL statement itself. When PostgreSQL is configured to log statements (`log_statement=all`), those logs contain trace identifiers that match the application's distributed traces.

That enables practical correlation workflows described in the [OpenTelemetry database semantic conventions for SQL commenter](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sql-commenter):

- From a slow trace, identify the exact SQL logged by the database for that request
- From an expensive query in database logs, jump back to the full distributed trace
- Attribute database load to specific services and requests

Incoming W3C `traceparent` headers are preserved: the trace ID in the SQL comment matches the request trace, while the span ID reflects the active database operation span at query time.

## Implementation

- Add `otelsql.WithSQLCommenter(true)` in `initDatabase()` when opening the PostgreSQL connection
- Document the setup in the product-catalog README

No new dependencies are required; otelsql v0.42.0 is already in use. Queries already use context-aware methods (`QueryContext`, `QueryRowContext`), which SQLCommenter requires.

## Test plan

- [x] `go build` in `src/product-catalog`
- [x] `docker compose up -d --build product-catalog`
- [x] Container reaches healthy state
- [x] gRPC `GetProduct` and `ListProducts` succeed
- [x] PostgreSQL logs (`docker logs astronomy-db`) show SQL statements with `traceparent` comments
- [x] Injected `traceparent` request header trace ID appears in the SQL comment


Made with [Cursor](https://cursor.com)