### PR TITLE
feat(product-catalog): Add otelsql SQLCommenter instrumentation

### DIFF
--- a/src/product-catalog/README.md
+++ b/src/product-catalog/README.md
@@ -23,6 +23,27 @@ From the root directory, run:
 docker compose build product-catalog
 ```
 
+## Database Instrumentation
+
+PostgreSQL queries are instrumented with
+[otelsql](https://pkg.go.dev/github.com/XSAM/otelsql), with SQLCommenter enabled
+to append trace context to SQL statements (for example, `traceparent` key-value
+pairs in query comments).
+
+The option is configured in `main.go` when opening the database connection:
+
+```go
+db, err = otelsql.Open("postgres", connStr,
+    dbAttrs,
+    otelsql.WithSQLCommenter(true),
+    otelsql.WithSpanOptions(...),
+)
+```
+
+Queries must use context-aware methods such as `QueryContext` and
+`QueryRowContext` so the active trace context is available when SQL comments
+are injected.
+
 ## Regenerate protos
 
 To build the protos, run from the root directory:

--- a/src/product-catalog/README.md
+++ b/src/product-catalog/README.md
@@ -23,7 +23,7 @@ From the root directory, run:
 docker compose build product-catalog
 ```
 
-## Database Instrumentation
+Database Calls Instrumentation
 
 PostgreSQL queries are instrumented with
 [otelsql](https://pkg.go.dev/github.com/XSAM/otelsql), with SQLCommenter enabled

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -75,6 +75,7 @@ func initDatabase() error {
 	var err error
 	db, err = otelsql.Open("postgres", connStr,
 		dbAttrs,
+		otelsql.WithSQLCommenter(true),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			OmitConnResetSession: true,
 			OmitRows:             true,


### PR DESCRIPTION
## Summary
- Add `otelsql.WithSQLCommenter(true)` in product-catalog's PostgreSQL connection setup
- Document database instrumentation in the product-catalog README
## Why this is useful
SQLCommenter appends OpenTelemetry trace context (e.g. `traceparent`) to SQL statements as comments. When PostgreSQL logs statements (`log_statement=all`), those logs can be correlated with distributed traces.
## Test plan
- [x] `go build` in `src/product-catalog`
- [x] `docker compose up -d --build product-catalog`
- [x] Container healthy; gRPC calls succeed
- [x] `docker logs astronomy-db` shows SQL with `traceparent` comments