### PR TITLE
chore: remove leftover Tracetest env vars and build-arg

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,6 @@ IMAGE_NAME=ghcr.io/open-telemetry/demo
 DEMO_VERSION=latest
 
 # Build Args
-TRACETEST_IMAGE_VERSION=v1.7.1
 OTEL_JAVA_AGENT_VERSION=2.28.1
 OPENTELEMETRY_CPP_VERSION=1.27.0
 
@@ -17,7 +16,6 @@ OPENSEARCH_DOCKERFILE=./src/opensearch/Dockerfile
 POSTGRES_IMAGE=postgres:17.8
 PROMETHEUS_IMAGE=quay.io/prometheus/prometheus:v3.9.1
 VALKEY_IMAGE=ghcr.io/valkey-io/valkey:9.0.2-alpine3.23
-TRACETEST_IMAGE=kubeshop/tracetest:${TRACETEST_IMAGE_VERSION}
 
 # Demo Platform
 ENV_PLATFORM=local

--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -283,7 +283,6 @@ jobs:
           build-args: |
             OTEL_JAVA_AGENT_VERSION=${{ env.OTEL_JAVA_AGENT_VERSION }}
             OPENTELEMETRY_CPP_VERSION=${{ env.OPENTELEMETRY_CPP_VERSION }}
-            TRACETEST_IMAGE_VERSION=${{ env.TRACETEST_IMAGE_VERSION }}
           tags: |
             ${{ inputs.dockerhub_repo }}:${{ inputs.version }}-${{matrix.file_tag.tag_suffix }}
             ${{ inputs.dockerhub_repo }}:latest-${{matrix.file_tag.tag_suffix }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the release.
 
 ## Unreleased
 
+* [testing] Remove defunct Tracetest trace-based integration tests. The
+  `test/tracetesting/` directory and associated env vars are no longer needed
+  since the telemetry sanity tests (`test/telemetry/`) now provide comprehensive
+  end-to-end observability validation across all three signal pillars
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,8 +287,8 @@ the release.
 * [cleanup] Remove LLM service
   ([#3599](https://github.com/open-telemetry/opentelemetry-demo/pull/3599))
 * [cleanup] Remove tracetest
-  ([#3602](https://github.com/open-telemetry/opentelemetry-demo/pull/3602))
-  ([#3603](https://github.com/open-telemetry/opentelemetry-demo/pull/3603))
+([#3602](https://github.com/open-telemetry/opentelemetry-demo/pull/3602),
+  [#3603](https://github.com/open-telemetry/opentelemetry-demo/pull/3603))
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ the release.
 
 ## Unreleased
 
-* [testing] Remove defunct Tracetest trace-based integration tests. The
-  `test/tracetesting/` directory and associated env vars are no longer needed
-  since the telemetry sanity tests (`test/telemetry/`) now provide comprehensive
-  end-to-end observability validation across all three signal pillars
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))
@@ -292,6 +288,7 @@ the release.
   ([#3599](https://github.com/open-telemetry/opentelemetry-demo/pull/3599))
 * [cleanup] Remove tracetest
   ([#3602](https://github.com/open-telemetry/opentelemetry-demo/pull/3602))
+  ([#3603](https://github.com/open-telemetry/opentelemetry-demo/pull/3603))
 
 ## 2.2.0
 


### PR DESCRIPTION
## Summary

- Remove orphaned `TRACETEST_IMAGE_VERSION` and `TRACETEST_IMAGE` from `.env`
- Remove the `TRACETEST_IMAGE_VERSION` build-arg from the component-build-images workflow

The `test/tracetesting/` directory was removed previously but these references were left behind. No Dockerfile or compose service uses them they are dead code from the defunct Tracetest integration that was replaced by the telemetry sanity tests (`test/telemetry/`).

## Test plan

- [ ] CI passes (no build-arg references break image builds)
- [ ] `grep -rniE 'TRACETEST_IMAGE' .` returns only the README vendor-fork link
  and historical CHANGELOG entries