### PR TITLE
feat(collector): add gen_ai_normalizer processor for Traceloop telemetry

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ OTEL_JAVA_AGENT_VERSION=2.28.1
 OPENTELEMETRY_CPP_VERSION=1.27.0
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.151.0
+COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.155.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.14.2
 GRAFANA_IMAGE=grafana/grafana:13.0.1
 JAEGERTRACING_IMAGE=quay.io/jaegertracing/jaeger:2.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ the release.
 * [accounting] Run the Kafka consumer as a hosted background service so process
   shutdown can stop the consumer cleanly
   ([#3608](https://github.com/open-telemetry/opentelemetry-demo/pull/3608))
+* [collector] Add `gen_ai_normalizer` processor to the traces pipeline to
+  convert OpenLLMetry/Traceloop instrumentation telemetry (from the agent
+  service) into official GenAI semantic conventions (`gen_ai.*` attributes).
+  Bump collector-contrib to v0.155.0 which includes the processor
+  ([#3526](https://github.com/open-telemetry/opentelemetry-demo/issues/3526))
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/src/otel-collector/otelcol-config.yml
+++ b/src/otel-collector/otelcol-config.yml
@@ -187,6 +187,10 @@ processors:
           # Upstream Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/15221
           - set(attributes["otelcol_signal"], attributes["otelcol.signal"]) where attributes["otelcol.signal"] != nil and not IsMap(attributes["otelcol.signal"])
           - delete_key(attributes, "otelcol.signal") where attributes["otelcol_signal"] != nil
+  gen_ai_normalizer:
+    sources:
+      - name: openllmetry
+
   transform/sanitize_spans:
     error_mode: ignore
     trace_statements:
@@ -240,7 +244,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [resourcedetection, memory_limiter, transform/sanitize_spans]
+      processors: [resourcedetection, memory_limiter, transform/sanitize_spans, gen_ai_normalizer]
       exporters: [debug, span_metrics]
     metrics:
       receivers: [docker_stats, http_check/frontend-proxy, host_metrics, nginx, otlp, redis, postgresql, prometheus/ad, span_metrics]


### PR DESCRIPTION
## Summary

- Add `gen_ai_normalizer` processor to the OTel Collector traces pipeline with the built-in `openllmetry` source mapping
- Bump collector-contrib from v0.151.0 to v0.155.0 (processor added in v0.154.0, Alpha stability)

The agent service uses Traceloop OpenLLMetry instrumentation (`traceloop-sdk`) which emits LLM spans with Traceloop-specific attributes. The `gen_ai_normalizer` processor converts these in-flight to official [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (`gen_ai.*` attributes) before they reach Jaeger/exporters.

Closes #3526 (first task: Add GenAI semantic convention normalizer showcase)

## What the normalizer does to span attributes

Example from the `ChatLLM.chat` span (agent calling the LLM):

**`gen_ai.*` attributes (ADDED by normalizer - GenAI semconv):**
```
gen_ai.system = Langchain
gen_ai.operation.name = chat
gen_ai.request.model = azure/gpt-5.5
gen_ai.response.model = azure/gpt-5.5
gen_ai.prompt.0.role = system
gen_ai.prompt.0.content = You are a helpful assistant. Be concise and accurate.
gen_ai.prompt.1.role = user
gen_ai.prompt.1.content = Show all available products in the store.
gen_ai.completion.0.role = assistant
gen_ai.completion.0.content = Available products in the Astronomy Shop: ...
```

**`llm.*` attributes (ORIGINAL OpenLLMetry, preserved alongside):**
```
llm.request.functions.0.name = add_to_cart
llm.request.functions.0.description = Add a product to the shopping cart...
llm.request.functions.1.name = checkout
... (31 total)
```

**`traceloop.*` attributes (ORIGINAL, preserved):**
```
traceloop.association.properties.langgraph_node = model
traceloop.association.properties.langgraph_step = 3
```

The processor adds standardized GenAI semantic convention attributes while preserving the original OpenLLMetry/Traceloop attributes, so both are visible in Jaeger for comparison.

## Test plan

- [x] Collector starts without errors
- [x] Minimal telemetry tests pass (54 passed, no regression)
- [x] Agent spans in Jaeger show gen_ai.* attributes alongside original llm.*/traceloop.* attributes
- [ ] Agentic telemetry tests pass in CI (requires approving review to trigger)