### PR TITLE
fix(accounting): run consumer as hosted service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [accounting] Run the Kafka consumer as a hosted background service so process
+  shutdown can stop the consumer cleanly
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the release.
 
 * [accounting] Run the Kafka consumer as a hosted background service so process
   shutdown can stop the consumer cleanly
+  ([#3608](https://github.com/open-telemetry/opentelemetry-demo/pull/3608))
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/src/accounting/Consumer.cs
+++ b/src/accounting/Consumer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Confluent.Kafka;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Oteldemo;
@@ -25,13 +26,12 @@ internal class DBContext : DbContext
 }
 
 
-internal class Consumer : IDisposable
+internal class Consumer : BackgroundService
 {
     private const string TopicName = "orders";
 
     private readonly ILogger _logger;
-    private IConsumer<string, byte[]> _consumer;
-    private bool _isListening;
+    private readonly IConsumer<string, byte[]> _consumer;
     private readonly string? _dbConnectionString;
     private static readonly ActivitySource MyActivitySource = new("Accounting.Consumer");
 
@@ -50,18 +50,18 @@ internal class Consumer : IDisposable
         _dbConnectionString = Environment.GetEnvironmentVariable("DB_CONNECTION_STRING");
     }
 
-    public void StartListening()
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _isListening = true;
+        await Task.Yield();
 
         try
         {
-            while (_isListening)
+            while (!stoppingToken.IsCancellationRequested)
             {
                 try
                 {
                     using var activity = MyActivitySource.StartActivity("order-consumed",  ActivityKind.Internal);
-                    var consumeResult = _consumer.Consume();
+                    var consumeResult = _consumer.Consume(stoppingToken);
                     ProcessMessage(consumeResult.Message);
                 }
                 catch (ConsumeException e)
@@ -70,10 +70,12 @@ internal class Consumer : IDisposable
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        finally
         {
             Log.ConsumerClosing(_logger);
-
             _consumer.Close();
         }
     }
@@ -152,9 +154,9 @@ internal class Consumer : IDisposable
             .Build();
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
-        _isListening = false;
         _consumer?.Dispose();
+        base.Dispose();
     }
 }

--- a/src/accounting/Program.cs
+++ b/src/accounting/Program.cs
@@ -14,11 +14,8 @@ Environment.GetEnvironmentVariables()
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
-        services.AddSingleton<Consumer>();
+        services.AddHostedService<Consumer>();
     })
     .Build();
 
-var consumer = host.Services.GetRequiredService<Consumer>();
-consumer.StartListening();
-
-host.Run();
+await host.RunAsync();


### PR DESCRIPTION
Runs the accounting Kafka consumer as a hosted background service so the .NET host owns shutdown and can cancel the consume loop on SIGTERM.

Validated with:
- `make build service=accounting`
- `docker stop accounting` exits cleanly and logs `Application is shutting down...` and `Closing consumer`.