### PR TITLE
[chore] Add tests to agentic services

### DIFF
--- a/.github/workflows/run-agentic-telemetry-tests.yml
+++ b/.github/workflows/run-agentic-telemetry-tests.yml
@@ -1,0 +1,189 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+name: Agentic Telemetry Tests
+
+on:
+  # Dependabot PRs only. GitHub Actions does not support actor filters in the
+  # on: block, so the gate job below enforces the dependabot-only rule.
+  # Human PRs that touch these paths must be approved first — see
+  # pull_request_review below.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/agent/**'
+      - 'src/mcp/**'
+      - 'src/chatbot/**'
+      - 'compose.agent.yaml'
+      - 'test/telemetry/**'
+      - '.env'
+      - '.github/workflows/run-agentic-telemetry-tests.yml'
+  # Human PRs: run after a reviewer approves a PR that touches agentic paths.
+  # Path filtering is done inside the gate job because GitHub does not apply
+  # paths filters to the pull_request_review event.
+  pull_request_review:
+    types: [submitted]
+  # Post-merge validation on main.
+  push:
+    branches: [main]
+    paths:
+      - 'src/agent/**'
+      - 'src/mcp/**'
+      - 'src/chatbot/**'
+      - 'compose.agent.yaml'
+      - 'test/telemetry/**'
+      - '.env'
+      - '.github/workflows/run-agentic-telemetry-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentic-telemetry-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Decide whether the test jobs should run.
+  # For push/dispatch the paths filter above already ensures relevance.
+  # For pull_request_review we must check changed files ourselves because
+  # GitHub does not apply paths filters to that event.
+  gate:
+    name: "Agentic Test Gate"
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          PR_STATE: ${{ github.event.pull_request.state }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # push / workflow_dispatch: paths filter already ensured relevance.
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "push" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # pull_request: only dependabot PRs run without approval.
+          # Human PRs must go through pull_request_review instead.
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          # pull_request_review: run when a human approves a PR that touches
+          # agentic paths. This is the only path for non-dependabot contributors.
+          # Dependabot PRs are skipped here — they already ran on pull_request.
+          if [[ "$EVENT_NAME" == "pull_request_review" \
+             && "$REVIEW_STATE" == "approved" \
+             && "$PR_STATE" == "open" \
+             && "$PR_AUTHOR" != "dependabot[bot]" ]]; then
+            git fetch --quiet origin "$BASE_SHA"
+            AGENTIC_PATTERN='^(src/(agent|mcp|chatbot)/|compose\.agent\.yaml|test/telemetry/|\.env$|\.github/workflows/run-agentic-telemetry-tests\.yml)'
+            if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "$AGENTIC_PATTERN"; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+
+  build-images:
+    name: "Build demo images"
+    needs: gate
+    if: ${{ needs.gate.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          docker system prune -af
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Create .env.override if missing
+        run: touch .env.override
+
+      - name: Build demo images
+        run: make build-agentic
+
+      - name: Save demo images to an artifact tarball
+        run: |
+          IMAGES=$(docker images 'ghcr.io/open-telemetry/demo:latest-*' --format '{{.Repository}}:{{.Tag}}')
+          echo "Saving images:"; echo "$IMAGES"
+          docker save $IMAGES | zstd -3 -T0 -o demo-images.tar.zst
+          ls -lh demo-images.tar.zst
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: demo-images-agentic-${{ github.run_id }}
+          path: demo-images.tar.zst
+          retention-days: 1
+          compression-level: 0
+
+  agentic-telemetry-tests:
+    needs: [gate, build-images]
+    if: ${{ needs.gate.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: "Agentic Telemetry Tests"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          docker system prune -af
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: demo-images-agentic-${{ github.run_id }}
+
+      - name: Load demo images
+        run: zstd -d -c demo-images.tar.zst | docker load
+
+      - name: Create .env.override if missing
+        run: touch .env.override
+
+      - name: Run agentic telemetry tests
+        timeout-minutes: 15
+        env:
+          WARMUP_SECONDS: "300"
+          POLL_TIMEOUT: "240"
+          WARMUP_PROBE_TIMEOUT: "180"
+          PYTEST_ADDOPTS: "--capture=tee-sys --maxfail=1"
+        run: make run-telemetry-tests-agentic
+
+      - name: Print service logs on failure
+        if: failure()
+        run: docker compose -f compose.yaml -f compose.full.yaml -f compose.observability.yaml -f compose.extras.yaml -f compose.agent.yaml logs --tail=50
+
+      - name: Stop demo
+        if: always()
+        run: make stop

--- a/.github/workflows/run-agentic-telemetry-tests.yml
+++ b/.github/workflows/run-agentic-telemetry-tests.yml
@@ -13,7 +13,9 @@ on:
       - 'src/agent/**'
       - 'src/mcp/**'
       - 'src/chatbot/**'
-      - 'compose.agent.yaml'
+      - 'src/shared/**'
+      - 'compose*.yaml'
+      - 'Makefile'
       - 'test/telemetry/**'
       - '.env'
       - '.github/workflows/**'
@@ -29,7 +31,9 @@ on:
       - 'src/agent/**'
       - 'src/mcp/**'
       - 'src/chatbot/**'
-      - 'compose.agent.yaml'
+      - 'src/shared/**'
+      - 'compose*.yaml'
+      - 'Makefile'
       - 'test/telemetry/**'
       - '.env'
       - '.github/workflows/**'
@@ -94,7 +98,7 @@ jobs:
              && "$PR_STATE" == "open" \
              && "$PR_AUTHOR" != "dependabot[bot]" ]]; then
             git fetch --quiet origin "$BASE_SHA"
-            AGENTIC_PATTERN='^(src/(agent|mcp|chatbot)/|compose\.agent\.yaml|test/telemetry/|\.env$|\.github/workflows/)'
+            AGENTIC_PATTERN='^(src/(agent|mcp|chatbot|shared)/|compose[^/]*\.yaml|Makefile$|test/telemetry/|\.env$|\.github/workflows/)'
             if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "$AGENTIC_PATTERN"; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/run-agentic-telemetry-tests.yml
+++ b/.github/workflows/run-agentic-telemetry-tests.yml
@@ -16,7 +16,7 @@ on:
       - 'compose.agent.yaml'
       - 'test/telemetry/**'
       - '.env'
-      - '.github/workflows/run-agentic-telemetry-tests.yml'
+      - '.github/workflows/**'
   # Human PRs: run after a reviewer approves a PR that touches agentic paths.
   # Path filtering is done inside the gate job because GitHub does not apply
   # paths filters to the pull_request_review event.
@@ -32,7 +32,7 @@ on:
       - 'compose.agent.yaml'
       - 'test/telemetry/**'
       - '.env'
-      - '.github/workflows/run-agentic-telemetry-tests.yml'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:
@@ -53,7 +53,8 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
@@ -93,7 +94,7 @@ jobs:
              && "$PR_STATE" == "open" \
              && "$PR_AUTHOR" != "dependabot[bot]" ]]; then
             git fetch --quiet origin "$BASE_SHA"
-            AGENTIC_PATTERN='^(src/(agent|mcp|chatbot)/|compose\.agent\.yaml|test/telemetry/|\.env$|\.github/workflows/run-agentic-telemetry-tests\.yml)'
+            AGENTIC_PATTERN='^(src/(agent|mcp|chatbot)/|compose\.agent\.yaml|test/telemetry/|\.env$|\.github/workflows/)'
             if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "$AGENTIC_PATTERN"; then
               echo "should_run=true" >> "$GITHUB_OUTPUT"
             else
@@ -111,7 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
@@ -137,7 +139,8 @@ jobs:
           docker save $IMAGES | zstd -3 -T0 -o demo-images.tar.zst
           ls -lh demo-images.tar.zst
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      - name: Upload demo images artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: demo-images-agentic-${{ github.run_id }}
           path: demo-images.tar.zst
@@ -151,7 +154,8 @@ jobs:
     timeout-minutes: 30
     name: "Agentic Telemetry Tests"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
@@ -161,7 +165,8 @@ jobs:
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
           docker system prune -af
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      - name: Download demo images artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: demo-images-agentic-${{ github.run_id }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,8 @@ the release.
 * [cleanup] Remove tracetest
 ([#3602](https://github.com/open-telemetry/opentelemetry-demo/pull/3602),
   [#3603](https://github.com/open-telemetry/opentelemetry-demo/pull/3603))
+* [chore] Add tests to agentic services
+  ([#3611](https://github.com/open-telemetry/opentelemetry-demo/pull/3611))
 
 ## 2.2.0
 

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,13 @@ else
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build
 endif
 
+# Build all services including the agentic layer (agent, mcp, chatbot).
+# Used by the agentic CI workflow so those images are present when
+# make run-telemetry-tests-agentic loads them from the artifact.
+.PHONY: build-agentic
+build-agentic:
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_FILES_AGENT) build
+
 .PHONY: build-and-push
 build-and-push:
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) build --push
@@ -219,6 +226,25 @@ run-telemetry-tests-minimal: start-minimal
 		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
 		-e WARMUP_PROBE_ENABLED=$${WARMUP_PROBE_ENABLED:-true} \
 		-e WARMUP_PROBE_CHECKOUTS=$${WARMUP_PROBE_CHECKOUTS:-5} \
+		-e WARMUP_PROBE_TIMEOUT=$${WARMUP_PROBE_TIMEOUT:-120} \
+		opentelemetry-demo-telemetry-tests; \
+	rc=$$?; \
+	$(MAKE) stop; \
+	exit $$rc
+
+.PHONY: run-telemetry-tests-agentic
+run-telemetry-tests-agentic:
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_FILES_AGENT) up --force-recreate --remove-orphans --detach
+	$(DOCKER_CMD) build -t opentelemetry-demo-telemetry-tests ./test/telemetry
+	@touch .env.override
+	@set +e; \
+	$(DOCKER_CMD) run --rm --network opentelemetry-demo \
+		--env-file .env --env-file .env.override \
+		-e TEST_SCOPE=agentic \
+		-e WARMUP_SECONDS=$${WARMUP_SECONDS:-240} \
+		-e POLL_TIMEOUT=$${POLL_TIMEOUT:-180} \
+		-e WARMUP_PROBE_ENABLED=false \
+		-e WARMUP_PROBE_CHECKOUTS=0 \
 		-e WARMUP_PROBE_TIMEOUT=$${WARMUP_PROBE_TIMEOUT:-120} \
 		opentelemetry-demo-telemetry-tests; \
 	rc=$$?; \

--- a/compose.agent.yaml
+++ b/compose.agent.yaml
@@ -33,13 +33,13 @@ services:
       - GRAPH_RECURSION_LIMIT
       - MCP_ENDPOINT
       - MCP_PORT
-      - MCP_ENABLED=${MCP_ENABLED}
+      - MCP_ENABLED
       - AGENT_ENDPOINT
       - AGENT_PORT
       - LLM_BASE_URL
       - LLM_MODEL
       - API_KEY
-      - USE_VCR=${USE_VCR}
+      - USE_VCR
       - OPENAI_API_KEY=${API_KEY}
       - APPLICATION_ENDPOINT=frontend:8080
       - OTEL_EXPORTER_OTLP_INSECURE=true

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -146,13 +146,13 @@ make run-telemetry-tests-agentic   # Agentic scope (agent, mcp, chatbot)
 
 Two separate workflows handle telemetry tests:
 
-- **`.github/workflows/run-telemetry-tests.yml`** — two parallel jobs (full
+- **`.github/workflows/run-telemetry-tests.yml`** - two parallel jobs (full
   and minimal). Triggered on every PR touching `src/`, `test/telemetry/`, or
   core compose files.
-- **`.github/workflows/run-agentic-telemetry-tests.yml`** — agentic scope.
+- **`.github/workflows/run-agentic-telemetry-tests.yml`** - agentic scope.
   Runs on dependabot PRs automatically; for human PRs it runs after reviewer
   approval. Only fires when `src/agent/`, `src/mcp/`, `src/chatbot/`,
-  `compose.agent.yaml`, or `test/telemetry/` are modified.
+  `compose.agent.yaml`, `test/telemetry/`, or `.github/workflows/` are modified.
 
 ## Extending
 

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -138,12 +138,6 @@ make run-telemetry-tests-agentic   # Agentic scope (agent, mcp, chatbot)
 | `WARMUP_PROBE_ENABLED`   | `true`       | Drive checkouts during warmup (see Approach)    |
 | `WARMUP_PROBE_CHECKOUTS` | `5`          | Number of checkouts the warmup probe drives     |
 | `WARMUP_PROBE_TIMEOUT`   | `120`        | Max seconds to complete warmup probe checkouts  |
-| `AGENT_HOST`             | `agent`      | Agent service hostname (agentic scope)          |
-| `AGENT_PORT`             | `8010`       | Agent service port (agentic scope)              |
-| `MCP_HOST`               | `mcp`        | MCP service hostname (agentic scope)            |
-| `MCP_PORT`               | `8011`       | MCP service port (agentic scope)                |
-| `CHATBOT_HOST`           | `chatbot`    | Chatbot service hostname (agentic scope)        |
-| `CHATBOT_PORT`           | `7860`       | Chatbot service port (agentic scope)            |
 
 ## CI Integration
 

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -152,7 +152,8 @@ Two separate workflows handle telemetry tests:
 - **`.github/workflows/run-agentic-telemetry-tests.yml`** - agentic scope.
   Runs on dependabot PRs automatically; for human PRs it runs after reviewer
   approval. Only fires when `src/agent/`, `src/mcp/`, `src/chatbot/`,
-  `compose.agent.yaml`, `test/telemetry/`, or `.github/workflows/` are modified.
+  `src/shared/`, any `compose*.yaml`, `Makefile`, `test/telemetry/`, or
+  `.github/workflows/` are modified.
 
 ## Extending
 

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -138,9 +138,12 @@ make run-telemetry-tests-agentic   # Agentic scope (agent, mcp, chatbot)
 | `WARMUP_PROBE_ENABLED`   | `true`       | Drive checkouts during warmup (see Approach)    |
 | `WARMUP_PROBE_CHECKOUTS` | `5`          | Number of checkouts the warmup probe drives     |
 | `WARMUP_PROBE_TIMEOUT`   | `120`        | Max seconds to complete warmup probe checkouts  |
-| `AGENT_URL`              | (derived)    | Override agent service URL (agentic scope)      |
-| `MCP_URL`                | (derived)    | Override MCP service URL (agentic scope)        |
-| `CHATBOT_URL`            | (derived)    | Override chatbot service URL (agentic scope)    |
+| `AGENT_HOST`             | `agent`      | Agent service hostname (agentic scope)          |
+| `AGENT_PORT`             | `8010`       | Agent service port (agentic scope)              |
+| `MCP_HOST`               | `mcp`        | MCP service hostname (agentic scope)            |
+| `MCP_PORT`               | `8011`       | MCP service port (agentic scope)                |
+| `CHATBOT_HOST`           | `chatbot`    | Chatbot service hostname (agentic scope)        |
+| `CHATBOT_PORT`           | `7860`       | Chatbot service port (agentic scope)            |
 
 ## CI Integration
 

--- a/test/telemetry/README.md
+++ b/test/telemetry/README.md
@@ -49,6 +49,7 @@ test/telemetry/
 |-- conftest.py
 |-- services.py
 |-- test_collector.py
+|-- test_agentic.py
 |-- test_traces.py
 |-- test_traces_edges.py
 |-- test_metrics.py
@@ -80,6 +81,9 @@ signals it emits:
 | accounting       | yes    | yes     | yes   | full    |
 | fraud-detection  | yes    | yes     | yes   | full    |
 | load-generator   | yes    | yes     | yes   | minimal |
+| agent            | yes    | no      | no    | agentic |
+| mcp              | yes    | no      | no    | agentic |
+| chatbot          | yes    | no      | no    | agentic |
 
 ## Backend API Queries
 
@@ -115,6 +119,7 @@ signals it emits:
 ```bash
 make run-telemetry-tests           # Full scope (all services)
 make run-telemetry-tests-minimal   # Minimal scope
+make run-telemetry-tests-agentic   # Agentic scope (agent, mcp, chatbot)
 ```
 
 ## Environment Variables
@@ -127,18 +132,27 @@ make run-telemetry-tests-minimal   # Minimal scope
 | `PROMETHEUS_PORT`        | `9090`       | Prometheus query port                           |
 | `OPENSEARCH_HOST`        | `opensearch` | OpenSearch hostname                             |
 | `OPENSEARCH_PORT`        | `9200`       | OpenSearch port                                 |
-| `TEST_SCOPE`             | `minimal`    | `minimal` or `full`                             |
+| `TEST_SCOPE`             | `minimal`    | `minimal`, `full`, or `agentic`                 |
 | `WARMUP_SECONDS`         | `240`        | Max seconds to wait for backends before testing |
 | `POLL_TIMEOUT`           | `180`        | Per-test seconds to poll a backend for data     |
 | `WARMUP_PROBE_ENABLED`   | `true`       | Drive checkouts during warmup (see Approach)    |
 | `WARMUP_PROBE_CHECKOUTS` | `5`          | Number of checkouts the warmup probe drives     |
 | `WARMUP_PROBE_TIMEOUT`   | `120`        | Max seconds to complete warmup probe checkouts  |
+| `AGENT_URL`              | (derived)    | Override agent service URL (agentic scope)      |
+| `MCP_URL`                | (derived)    | Override MCP service URL (agentic scope)        |
+| `CHATBOT_URL`            | (derived)    | Override chatbot service URL (agentic scope)    |
 
 ## CI Integration
 
-Separate workflow (`.github/workflows/run-telemetry-tests.yml`)
-with two parallel jobs: full and minimal. Triggered on PRs
-touching `src/`, `test/telemetry/`, or compose files.
+Two separate workflows handle telemetry tests:
+
+- **`.github/workflows/run-telemetry-tests.yml`** — two parallel jobs (full
+  and minimal). Triggered on every PR touching `src/`, `test/telemetry/`, or
+  core compose files.
+- **`.github/workflows/run-agentic-telemetry-tests.yml`** — agentic scope.
+  Runs on dependabot PRs automatically; for human PRs it runs after reviewer
+  approval. Only fires when `src/agent/`, `src/mcp/`, `src/chatbot/`,
+  `compose.agent.yaml`, or `test/telemetry/` are modified.
 
 ## Extending
 

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -26,6 +26,18 @@ OPENSEARCH_URL = os.environ.get("OPENSEARCH_URL", f"http://{OPENSEARCH_HOST}:{OP
 COLLECTOR_HOST = os.environ.get("OTEL_COLLECTOR_HOST", "otel-collector")
 COLLECTOR_PORT = int(os.environ.get("OTEL_COLLECTOR_PORT_GRPC", "4317"))
 
+AGENT_HOST = os.environ.get("AGENT_ENDPOINT", "agent")
+AGENT_PORT = os.environ.get("AGENT_PORT", "8010")
+AGENT_URL = os.environ.get("AGENT_URL", f"http://{AGENT_HOST}:{AGENT_PORT}")
+
+MCP_HOST = os.environ.get("MCP_ENDPOINT", "mcp")
+MCP_PORT_VAL = os.environ.get("MCP_PORT", "8011")
+MCP_URL = os.environ.get("MCP_URL", f"http://{MCP_HOST}:{MCP_PORT_VAL}")
+
+CHATBOT_HOST = os.environ.get("CHATBOT_HOST", "chatbot")
+CHATBOT_PORT_VAL = os.environ.get("CHATBOT_PORT", "7860")
+CHATBOT_URL = os.environ.get("CHATBOT_URL", f"http://{CHATBOT_HOST}:{CHATBOT_PORT_VAL}")
+
 # Entrypoint the warmup probe drives traffic through. Envoy fans the request out
 # to the whole service graph, exactly like the load generator does.
 #
@@ -230,6 +242,112 @@ def _run_warmup_probe():
     print(f"  warmup probe completed: {ok}/{WARMUP_PROBE_CHECKOUTS} checkout(s) succeeded")
 
 
+def _run_agentic_warmup_probe():
+    """Drive one request to each agentic service so all three appear in Jaeger
+    before test assertions begin.
+
+    * agent  — POST /prompt (required): FastAPIInstrumentor and the Traceloop
+               @workflow decorator emit spans even when the LLM call fails, so
+               any HTTP response (including 5xx) is treated as success.
+    * mcp    — POST /mcp with an MCP initialize message (best-effort): the
+               FastMCP handler creates a span on the first inbound request.
+    * chatbot — POST /run/predict (best-effort): triggers chatbot→agent HTTP
+               call so both services emit linked spans via traceparent injection.
+    """
+    deadline = time.time() + WARMUP_PROBE_TIMEOUT
+    print(
+        f"\nDriving agentic warmup probes (agent, chatbot) for up to "
+        f"{WARMUP_PROBE_TIMEOUT}s..."
+    )
+
+    # --- agent: required ---
+    # POST /prompt causes FastAPI + Traceloop @workflow spans to be emitted.
+    # Any HTTP response (including 5xx) is sufficient: FastAPIInstrumentor and
+    # the @workflow decorator both record spans regardless of whether the LLM
+    # call inside succeeds. We only retry on connection errors (service not up).
+    agent_ok = False
+    last_error = None
+    with requests.Session() as session:
+        while not agent_ok and time.time() < deadline:
+            try:
+                resp = session.post(
+                    f"{AGENT_URL}/prompt",
+                    json={"message": "List available products in the store.", "history": []},
+                    timeout=30,
+                )
+                agent_ok = True
+                print(f"  agent warmup probe: HTTP {resp.status_code}")
+            except requests.RequestException as e:
+                last_error = e
+                time.sleep(POLL_INTERVAL)
+
+    if not agent_ok:
+        msg = f"Agent at {AGENT_URL} did not respond within {WARMUP_PROBE_TIMEOUT}s"
+        if last_error:
+            msg += f"; last error: {last_error}"
+        pytest.fail(msg)
+
+    # --- mcp: best-effort direct probe ---
+    # FastMCP uses MCP Streamable HTTP transport which requires:
+    #   Accept: application/json, text/event-stream  (else 406)
+    #   Mcp-Session-Id: <id>  on all requests after initialize
+    # The server returns Mcp-Session-Id in the initialize response headers;
+    # without it on tools/call the server rejects the request before invoking
+    # any tool, so no HTTPX span is emitted.
+    # list_products triggers an outbound httpx call to product-catalog —
+    # the only code path HTTPXClientInstrumentor reliably captures as a span.
+    try:
+        mcp_headers = {"Accept": "application/json, text/event-stream"}
+        init_resp = requests.post(
+            f"{MCP_URL}/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "telemetry-warmup", "version": "1.0"},
+                },
+                "id": 1,
+            },
+            headers=mcp_headers,
+            timeout=10,
+        )
+        session_id = init_resp.headers.get("Mcp-Session-Id")
+        call_headers = {**mcp_headers}
+        if session_id:
+            call_headers["Mcp-Session-Id"] = session_id
+        mcp_resp = requests.post(
+            f"{MCP_URL}/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "list_products", "arguments": {}},
+                "id": 2,
+            },
+            headers=call_headers,
+            timeout=15,
+        )
+        print(f"  mcp warmup probe: HTTP {mcp_resp.status_code}")
+    except Exception as e:
+        print(f"  mcp warmup probe skipped: {e}")
+
+    # --- chatbot: best-effort Gradio API call ---
+    # Gradio 6.x moved all API routes to /gradio_api/.  POST to
+    # /gradio_api/call/respond queues and executes the respond() handler,
+    # which calls requests.post(agent_url).  RequestsInstrumentor injects
+    # traceparent so the chatbot→agent edge appears in Jaeger.
+    try:
+        chatbot_resp = requests.post(
+            f"{CHATBOT_URL}/gradio_api/call/respond",
+            json={"data": ["List available products in the store.", []]},
+            timeout=60,
+        )
+        print(f"  chatbot warmup probe: HTTP {chatbot_resp.status_code}")
+    except Exception as e:
+        print(f"  chatbot warmup probe skipped: {e}")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def wait_for_warmup():
     """Wait for Jaeger, Prometheus, and OpenSearch to all ingest telemetry
@@ -250,7 +368,7 @@ def wait_for_warmup():
     reliably produce telemetry rather than relying on the load generator's ~6%
     checkout task weight landing inside the test window.
     """
-    if WARMUP_PROBE_ENABLED:
+    if WARMUP_PROBE_ENABLED and TEST_SCOPE != "agentic":
         _run_warmup_probe()
     print(f"\nWaiting for backends to be ready (up to {WARMUP_SECONDS}s)...")
     required_probe_log_services = (
@@ -307,6 +425,9 @@ def wait_for_warmup():
     else:
         elapsed = WARMUP_SECONDS - int(deadline - time.time())
         print(f"Backends ready after {elapsed}s, starting tests...")
+
+    if TEST_SCOPE == "agentic":
+        _run_agentic_warmup_probe()
 
 
 @pytest.fixture(scope="session")

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -26,17 +26,17 @@ OPENSEARCH_URL = os.environ.get("OPENSEARCH_URL", f"http://{OPENSEARCH_HOST}:{OP
 COLLECTOR_HOST = os.environ.get("OTEL_COLLECTOR_HOST", "otel-collector")
 COLLECTOR_PORT = int(os.environ.get("OTEL_COLLECTOR_PORT_GRPC", "4317"))
 
-AGENT_HOST = os.environ.get("AGENT_ENDPOINT", "agent")
+AGENT_HOST = os.environ.get("AGENT_HOST", "agent")
 AGENT_PORT = os.environ.get("AGENT_PORT", "8010")
-AGENT_URL = os.environ.get("AGENT_URL", f"http://{AGENT_HOST}:{AGENT_PORT}")
+AGENT_URL = f"http://{AGENT_HOST}:{AGENT_PORT}"
 
-MCP_HOST = os.environ.get("MCP_ENDPOINT", "mcp")
-MCP_PORT_VAL = os.environ.get("MCP_PORT", "8011")
-MCP_URL = os.environ.get("MCP_URL", f"http://{MCP_HOST}:{MCP_PORT_VAL}")
+MCP_HOST = os.environ.get("MCP_HOST", "mcp")
+MCP_PORT = os.environ.get("MCP_PORT", "8011")
+MCP_URL = f"http://{MCP_HOST}:{MCP_PORT}"
 
 CHATBOT_HOST = os.environ.get("CHATBOT_HOST", "chatbot")
-CHATBOT_PORT_VAL = os.environ.get("CHATBOT_PORT", "7860")
-CHATBOT_URL = os.environ.get("CHATBOT_URL", f"http://{CHATBOT_HOST}:{CHATBOT_PORT_VAL}")
+CHATBOT_PORT = os.environ.get("CHATBOT_PORT", "7860")
+CHATBOT_URL = f"http://{CHATBOT_HOST}:{CHATBOT_PORT}"
 
 # Entrypoint the warmup probe drives traffic through. Envoy fans the request out
 # to the whole service graph, exactly like the load generator does.

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -26,11 +26,11 @@ OPENSEARCH_URL = os.environ.get("OPENSEARCH_URL", f"http://{OPENSEARCH_HOST}:{OP
 COLLECTOR_HOST = os.environ.get("OTEL_COLLECTOR_HOST", "otel-collector")
 COLLECTOR_PORT = int(os.environ.get("OTEL_COLLECTOR_PORT_GRPC", "4317"))
 
-AGENT_HOST = os.environ.get("AGENT_HOST", "agent")
+AGENT_HOST = os.environ.get("AGENT_ENDPOINT", "agent")
 AGENT_PORT = os.environ.get("AGENT_PORT", "8010")
 AGENT_URL = f"http://{AGENT_HOST}:{AGENT_PORT}"
 
-MCP_HOST = os.environ.get("MCP_HOST", "mcp")
+MCP_HOST = os.environ.get("MCP_ENDPOINT", "mcp")
 MCP_PORT = os.environ.get("MCP_PORT", "8011")
 MCP_URL = f"http://{MCP_HOST}:{MCP_PORT}"
 

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -246,13 +246,13 @@ def _run_agentic_warmup_probe():
     """Drive one request to each agentic service so all three appear in Jaeger
     before test assertions begin.
 
-    * agent  — POST /prompt (required): FastAPIInstrumentor and the Traceloop
-               @workflow decorator emit spans even when the LLM call fails, so
-               any HTTP response (including 5xx) is treated as success.
-    * mcp    — POST /mcp with an MCP initialize message (best-effort): the
-               FastMCP handler creates a span on the first inbound request.
-    * chatbot — POST /run/predict (best-effort): triggers chatbot→agent HTTP
-               call so both services emit linked spans via traceparent injection.
+    * agent   - POST /prompt (required): FastAPIInstrumentor and the Traceloop
+                @workflow decorator emit spans even when the LLM call fails, so
+                any HTTP response (including 5xx) is treated as success.
+    * mcp     - POST /mcp tools/call list_products (best-effort): triggers an
+                outbound httpx call that HTTPXClientInstrumentor captures as a span.
+    * chatbot - POST /gradio_api/call/respond (best-effort): triggers the
+                chatbot->agent HTTP call so both services emit linked spans.
     """
     deadline = time.time() + WARMUP_PROBE_TIMEOUT
     print(
@@ -294,7 +294,7 @@ def _run_agentic_warmup_probe():
     # The server returns Mcp-Session-Id in the initialize response headers;
     # without it on tools/call the server rejects the request before invoking
     # any tool, so no HTTPX span is emitted.
-    # list_products triggers an outbound httpx call to product-catalog —
+    # list_products triggers an outbound httpx call to product-catalog,
     # the only code path HTTPXClientInstrumentor reliably captures as a span.
     try:
         mcp_headers = {"Accept": "application/json, text/event-stream"}
@@ -336,7 +336,7 @@ def _run_agentic_warmup_probe():
     # Gradio 6.x moved all API routes to /gradio_api/.  POST to
     # /gradio_api/call/respond queues and executes the respond() handler,
     # which calls requests.post(agent_url).  RequestsInstrumentor injects
-    # traceparent so the chatbot→agent edge appears in Jaeger.
+    # traceparent so the chatbot->agent edge appears in Jaeger.
     try:
         chatbot_resp = requests.post(
             f"{CHATBOT_URL}/gradio_api/call/respond",

--- a/test/telemetry/services.py
+++ b/test/telemetry/services.py
@@ -101,7 +101,7 @@ SERVICE_EDGES = [
 
 # Directed edges expected in the agentic service graph:
 # chatbot calls agent via HTTP (RequestsInstrumentor injects traceparent).
-# Note: the agent→mcp edge requires MCP_ENABLED=True and a cassette recorded
+# Note: the agent->mcp edge requires MCP_ENABLED=True and a cassette recorded
 # with MCP tools; it is not asserted here to keep the default test run stable.
 AGENTIC_EDGES = [
     ("chatbot", "agent"),

--- a/test/telemetry/services.py
+++ b/test/telemetry/services.py
@@ -6,6 +6,7 @@ Service-signal matrix: single source of truth for which services emit which tele
 
 To add a new service: add an entry to SIGNAL_MATRIX.
 To mark a service as full-only (Kafka-dependent): add it to FULL_ONLY_SERVICES.
+To mark a service as agentic-only (compose.agent.yaml): add it to AGENTIC_ONLY_SERVICES.
 """
 
 SIGNAL_MATRIX = {
@@ -27,6 +28,11 @@ SIGNAL_MATRIX = {
     "accounting": {"traces": True, "metrics": True, "logs": True},
     "fraud-detection": {"traces": True, "metrics": True, "logs": True},
     "load-generator": {"traces": True, "metrics": True, "logs": True},
+    # Agentic services (compose.agent.yaml only): traces via Traceloop SDK /
+    # OTel SDK; no OTLP metrics or log exporters configured.
+    "agent":   {"traces": True, "metrics": False, "logs": False},
+    "mcp":     {"traces": True, "metrics": False, "logs": False},
+    "chatbot": {"traces": True, "metrics": False, "logs": False},
 }
 
 # Services excluded from minimal scope:
@@ -35,14 +41,21 @@ SIGNAL_MATRIX = {
 #   without browser traffic, so traces don't appear within the test timeout
 FULL_ONLY_SERVICES = {"accounting", "fraud-detection", "frontend-web", "kafka"}
 
-MINIMAL_SERVICES = [s for s in SIGNAL_MATRIX if s not in FULL_ONLY_SERVICES]
-ALL_SERVICES = list(SIGNAL_MATRIX.keys())
+# Services that only run when compose.agent.yaml is included (make start-agentic).
+# Excluded from minimal/full scopes; covered by the agentic scope.
+AGENTIC_ONLY_SERVICES = {"agent", "mcp", "chatbot"}
+
+MINIMAL_SERVICES = [s for s in SIGNAL_MATRIX if s not in FULL_ONLY_SERVICES and s not in AGENTIC_ONLY_SERVICES]
+ALL_SERVICES = [s for s in SIGNAL_MATRIX if s not in AGENTIC_ONLY_SERVICES]
+AGENTIC_SERVICES = [s for s in SIGNAL_MATRIX if s in AGENTIC_ONLY_SERVICES]
 
 
 def services_for_scope(scope: str) -> list[str]:
     """Return service list based on test scope."""
     if scope == "full":
         return ALL_SERVICES
+    if scope == "agentic":
+        return AGENTIC_SERVICES
     return MINIMAL_SERVICES
 
 
@@ -86,11 +99,21 @@ SERVICE_EDGES = [
     # different pattern than the parent->child walker used here.
 ]
 
+# Directed edges expected in the agentic service graph:
+# chatbot calls agent via HTTP (RequestsInstrumentor injects traceparent).
+# Note: the agent→mcp edge requires MCP_ENABLED=True and a cassette recorded
+# with MCP tools; it is not asserted here to keep the default test run stable.
+AGENTIC_EDGES = [
+    ("chatbot", "agent"),
+]
+
 
 def edges_for_scope(scope: str) -> list[tuple[str, str]]:
     """Return the inter-service edges applicable to the given scope."""
     if scope == "full":
         return SERVICE_EDGES
+    if scope == "agentic":
+        return AGENTIC_EDGES
     return [
         (p, c) for p, c in SERVICE_EDGES
         if p not in FULL_ONLY_SERVICES and c not in FULL_ONLY_SERVICES

--- a/test/telemetry/test_agentic.py
+++ b/test/telemetry/test_agentic.py
@@ -1,0 +1,49 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent-specific telemetry assertions.
+
+These tests supplement the parametrised trace/metric/log checks in
+test_traces.py / test_metrics.py / test_logs.py.  They only run when
+TEST_SCOPE=agentic and verify telemetry that is unique to the agentic
+service graph (e.g. the LangGraph workflow span emitted by Traceloop).
+"""
+
+import os
+
+import pytest
+import requests
+
+from conftest import poll_until
+
+TEST_SCOPE = os.environ.get("TEST_SCOPE", "minimal")
+
+
+def _find_span_by_operation(traces, operation_fragment: str) -> bool:
+    """Return True if any span in the trace list contains *operation_fragment*."""
+    for trace in traces:
+        for span in trace.get("spans", []):  # Jaeger returns spans as a list
+            if operation_fragment in span.get("operationName", ""):
+                return True
+    return False
+
+
+@pytest.mark.skipif(TEST_SCOPE != "agentic", reason="agentic scope only")
+def test_agent_has_workflow_span(jaeger_url):
+    """Verify the Traceloop @workflow decorator emits an
+    'astronomy_shop_agent_workflow' span that reaches Jaeger."""
+
+    def check():
+        resp = requests.get(
+            f"{jaeger_url}/jaeger/ui/api/traces",
+            params={"service": "agent", "limit": 20, "lookback": "1h"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        traces = resp.json().get("data", [])
+        return _find_span_by_operation(traces, "astronomy_shop_agent_workflow")
+
+    poll_until(
+        check,
+        "span containing 'astronomy_shop_agent_workflow' in Jaeger for service 'agent'",
+    )


### PR DESCRIPTION
# Changes

## Add telemetry tests for agentic services

Adds trace coverage for the `agent`, `mcp`, and `chatbot` services introduced by `compose.agent.yaml`, along with a dedicated CI workflow that only runs when those services are modified.

### What changed

**Test infrastructure**
- `test/telemetry/services.py` — extended `SIGNAL_MATRIX` with the three agentic services (traces only; no OTLP metrics or log exporters configured). Added `AGENTIC_ONLY_SERVICES`, `AGENTIC_SERVICES`, and `AGENTIC_EDGES` (`chatbot→agent`). New `agentic` scope is handled by `services_for_scope` and `edges_for_scope`.
- `test/telemetry/test_agentic.py` — new test that asserts the Traceloop `@workflow` decorator emits an `astronomy_shop_agent_workflow` span in Jaeger for the `agent` service.
- `test/telemetry/conftest.py` — added agentic warmup probe: hits `agent /prompt` (any HTTP response confirms spans are emitted), then calls `list_products` via the MCP Streamable HTTP transport (preserving `Mcp-Session-Id` from the `initialize` response) to trigger an outbound httpx call that `HTTPXClientInstrumentor` captures as a span. Chatbot probe uses Gradio 6.x's `/gradio_api/call/respond` endpoint.
- `test/telemetry/README.md` — updated service matrix, `TEST_SCOPE` values, Makefile targets, env vars, and CI section.

**Makefile**
- `run-telemetry-tests-agentic` — starts the full stack with `compose.agent.yaml`, runs the test container with `TEST_SCOPE=agentic`.
- `build-agentic` — builds all services including `compose.agent.yaml` so `latest-agent`, `latest-mcp`, and `latest-chatbot` images are present in the CI artifact.

**CI workflow** (`.github/workflows/run-agentic-telemetry-tests.yml`)
- Triggered on `push` to `main` and `workflow_dispatch` when agentic paths change.
- On `pull_request`: runs automatically for dependabot PRs only.
- On `pull_request_review`: runs for human PRs after reviewer approval, with path filtering in the gate job. Dependabot PRs are skipped here — they already ran on `pull_request`.

### Notes

- `MCP_ENABLED` is intentionally left `false`. The VCR cassette was recorded with local `@tool` functions; enabling MCP changes the tool schemas and breaks cassette body matching. The `agent→mcp` edge is therefore not asserted; a comment in `services.py` documents this.
- The agentic warmup probe does not drive checkout traffic (`WARMUP_PROBE_ENABLED=false`) since those services have no checkout path.
## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
