### PR TITLE
fix: filter checkout and product-catalog health telemetry

### DIFF
--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -31,6 +31,7 @@ import (
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
@@ -258,7 +259,9 @@ func main() {
 	}
 
 	srv := grpc.NewServer(
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler(
+			otelgrpc.WithFilter(filters.Not(filters.HealthCheck())),
+		)),
 	)
 	pb.RegisterCheckoutServiceServer(srv, svc)
 

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/lib/pq"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/contrib/otelconf"
 	"go.opentelemetry.io/otel"
@@ -171,7 +172,9 @@ func main() {
 	}
 
 	srv := grpc.NewServer(
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler(
+			otelgrpc.WithFilter(filters.Not(filters.HealthCheck())),
+		)),
 	)
 
 	reflection.Register(srv)


### PR DESCRIPTION
This PR filters checkout and product-catalog gRPC health-check requests from OpenTelemetry instrumentation.

Both services run frequent healthchecks via `grpc_health_probe`, and those `grpc.health.v1.Health/Check` spans can dominate Jaeger search results. This change suppresses only the standard gRPC health-check service at the source instrumentation layer.

This PR intentionally touches only checkout and product-catalog. Other services may have similar health-check telemetry noise, but those should be reviewed and fixed separately in follow-up PRs.