### PR TITLE
feat(payment): annotate synthetic test requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the release.
 * [frontend] Avoid hardcoded `localhost:8080` image URLs during SSR and
   normalize leading slashes in the custom image loader
   ([#3582](https://github.com/open-telemetry/opentelemetry-demo/pull/3582))
+* [payment] Annotate synthetic load-generator payment requests with the
+  `user_agent.synthetic.type` semantic convention attribute.
 * [accounting] Run the Kafka consumer as a hosted background service so process
   shutdown can stop the consumer cleanly
   ([#3608](https://github.com/open-telemetry/opentelemetry-demo/pull/3608))

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -73,7 +73,9 @@ module.exports.charge = async request => {
 
     // Check baggage for synthetic_request=true, and add charged attribute accordingly
     const baggage = propagation.getBaggage(context.active());
-    if (baggage && baggage.getEntry('synthetic_request') && baggage.getEntry('synthetic_request').value === 'true') {
+    const syntheticRequest = baggage?.getEntry('synthetic_request')?.value === 'true';
+    if (syntheticRequest) {
+      span.setAttribute('user_agent.synthetic.type', 'test');
       span.setAttribute('demo.payment.charged', false);
     } else {
       span.setAttribute('demo.payment.charged', true);

--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -25,6 +25,13 @@ module.exports.charge = async request => {
   const span = tracer.startSpan('charge');
 
   try {
+    const baggage = propagation.getBaggage(context.active());
+    const syntheticRequest = baggage?.getEntry('synthetic_request')?.value === 'true';
+
+    if (syntheticRequest) {
+      span.setAttribute('user_agent.synthetic.type', 'test');
+    }
+
     await OpenFeature.setProviderAndWait(flagProvider);
 
     const numberVariant = await OpenFeature.getClient().getNumberValue("paymentFailure", 0);
@@ -71,11 +78,8 @@ module.exports.charge = async request => {
       throw new Error(`The credit card (ending ${lastFourDigits}) expired on ${month}/${year}.`);
     }
 
-    // Check baggage for synthetic_request=true, and add charged attribute accordingly
-    const baggage = propagation.getBaggage(context.active());
-    const syntheticRequest = baggage?.getEntry('synthetic_request')?.value === 'true';
+    // Do not charge synthetic requests.
     if (syntheticRequest) {
-      span.setAttribute('user_agent.synthetic.type', 'test');
       span.setAttribute('demo.payment.charged', false);
     } else {
       span.setAttribute('demo.payment.charged', true);

--- a/telemetry-schema/services/payment.yaml
+++ b/telemetry-schema/services/payment.yaml
@@ -8,6 +8,7 @@ attribute_groups:
     brief: Payment service attributes
     stability: stable
     attributes:
+      - ref: user_agent.synthetic.type
       - ref: enduser.id
       - ref: demo.user_context.loyalty_level
       - ref: demo.payment.card_type


### PR DESCRIPTION
- Payment now annotates load-generator payment charge spans with `user_agent.synthetic.type = "test"` when `synthetic_request=true` is present in baggage.
- This follows the OpenTelemetry semantic convention for synthetic traffic: https://opentelemetry.io/docs/specs/semconv/attributes-registry/user-agent/#user-agent-synthetic-type
- The payment telemetry schema now references `user_agent.synthetic.type`.