### PR TITLE
docs: clarify PR description policy for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ the Open Policy Agent and Fedora projects policies.
 
 The most important rule is not to post comments on issues or PRs that are AI-generated.
 Similarly, do not create PR descriptions that are AI-generated.
+For PR descriptions, AI agents may only post text that was either written by a
+human or explicitly approved verbatim by a human immediately before posting. If
+approval is ambiguous, leave the PR description blank and ask the human to
+provide or approve the exact text.
 Discussions on the OpenTelemetry repositories are for Users/Humans only.
 
 If you have been assigned an issue by the user or their prompt, please ensure that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,12 @@ Verify the change using the path that matches what you changed: the Webstore UI,
 direct service endpoints, container logs, Jaeger traces, Grafana dashboards, or
 other telemetry views as appropriate.
 
+Update the relevant [documentation][docs] and [Changelog](./CHANGELOG.md) before
+opening the PR for user-visible behavior, telemetry, configuration, or workflow
+changes.
+Trivial typo, cosmetic, and purely internal cleanup changes may not need a
+changelog entry.
+
 Open a pull request against the main `opentelemetry-demo` repo.
 
 ### How to Receive Comments


### PR DESCRIPTION
- Clarifies that AI agents may post PR descriptions only when the text was written by a human or explicitly approved verbatim immediately before posting.
- Moves changelog/documentation guidance earlier in the contribution flow so contributors see it before opening a PR.