### PR TITLE
Make cartFailure rate configurable instead of a fixed toggle

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -15,6 +15,7 @@ exclude = [
   "^https://www\\.gnu\\.org",
   "^https://platform\\.openai\\.com",
   "^https://www\\.robotstxt\\.org",
+  "^https://community\\.splunk\\.com",
 ]
 
 exclude_path = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ the release.
 
 ## Unreleased
 
-* [cart] Make the `cartFailure` feature flag rate configurable (10%-100%)
-  instead of a fixed all-or-nothing toggle, matching the `paymentFailure`
-  pattern
+* [cart] Make the `cartFailure` feature flag rate configurable as percentage
+  (off - no failures, 10%, 25%, 50%, 75%, 90%, 100% - always fail) instead of
+  a fixed all-or-nothing toggle, matching the `paymentFailure` pattern
   ([#1721](https://github.com/open-telemetry/opentelemetry-demo/issues/1721))
 * [frontend] Avoid hardcoded `localhost:8080` image URLs during SSR and
   normalize leading slashes in the custom image loader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the release.
 
 ## Unreleased
 
+* [cart] Make the `cartFailure` feature flag rate configurable (10%-100%)
+  instead of a fixed all-or-nothing toggle, matching the `paymentFailure`
+  pattern
+  ([#1721](https://github.com/open-telemetry/opentelemetry-demo/issues/1721))
 * [frontend] Avoid hardcoded `localhost:8080` image URLs during SSR and
   normalize leading slashes in the custom image loader
   ([#3582](https://github.com/open-telemetry/opentelemetry-demo/pull/3582))

--- a/src/cart/src/services/CartService.cs
+++ b/src/cart/src/services/CartService.cs
@@ -80,7 +80,8 @@ public class CartService : Oteldemo.CartService.CartServiceBase
 
         try
         {
-            if (await _featureFlagHelper.GetBooleanValueAsync("cartFailure", false))
+            var cartFailureRate = await _featureFlagHelper.GetDoubleValueAsync("cartFailure", 0);
+            if (cartFailureRate > 0 && random.NextDouble() < cartFailureRate)
             {
                 await _badCartStore.EmptyCartAsync(request.UserId);
             }

--- a/src/cart/src/services/CartService.cs
+++ b/src/cart/src/services/CartService.cs
@@ -13,7 +13,6 @@ namespace cart.services;
 public class CartService : Oteldemo.CartService.CartServiceBase
 {
     private static readonly Empty Empty = new();
-    private readonly Random random = new Random();
     private readonly ICartStore _badCartStore;
     private readonly ICartStore _cartStore;
     private readonly IFeatureClient _featureFlagHelper;
@@ -81,7 +80,7 @@ public class CartService : Oteldemo.CartService.CartServiceBase
         try
         {
             var cartFailureRate = await _featureFlagHelper.GetDoubleValueAsync("cartFailure", 0);
-            if (cartFailureRate > 0 && random.NextDouble() < cartFailureRate)
+            if (cartFailureRate > 0 && Random.Shared.NextDouble() < cartFailureRate)
             {
                 await _badCartStore.EmptyCartAsync(request.UserId);
             }

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -70,11 +70,16 @@
       "defaultVariant": "off"
     },
     "cartFailure": {
-      "description": "Fail cart service",
+      "description": "Fail cart service n% of the time",
       "state": "ENABLED",
       "variants": {
-        "on": true,
-        "off": false
+        "100%": 1,
+        "90%": 0.9,
+        "75%": 0.75,
+        "50%": 0.5,
+        "25%": 0.25,
+        "10%": 0.1,
+        "off": 0
       },
       "defaultVariant": "off"
     },


### PR DESCRIPTION
# Changes

The `cartFailure` feature flag was a plain boolean, so a demo operator could
only ever make the cart service fail 100% of the time or 0% of the time.
There was no way to dial in an intermittent failure rate, which is what most
demo scenarios actually want (see #1721).

This changes `cartFailure` from an on/off toggle to a set of percentage
variants (`10%`, `25%`, `50%`, `75%`, `90%`, `100%`, `off`), the same pattern
already used by the `paymentFailure` flag. `CartService.EmptyCart` now reads
the flag as a double and rolls against it instead of checking a boolean.

- `src/flagd/demo.flagd.json`: `cartFailure` variants changed from
  `on`/`off` booleans to percentage doubles, matching `paymentFailure`.
- `src/cart/src/services/CartService.cs`: read `cartFailure` with
  `GetDoubleValueAsync` and compare against `random.NextDouble()` instead of
  `GetBooleanValueAsync`.
- `CHANGELOG.md`: added an entry under Unreleased.

Default behavior is unchanged (`defaultVariant` stays `off`, i.e. 0% failure
rate). Existing users of the flag who only ever selected `on`/`off` can now
pick `100%` for the old "always fail" behavior.

## Merge Requirements

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][] — no external docs
  reference this flag today, so none needed
* [ ] Appropriate Helm chart updates in the [helm-charts][] — not needed,
  this only changes flag variant values already delivered via
  `demo.flagd.json`

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

Fixes #1721
