### PR TITLE
fix(load-generator): stop discarding synthetic_request baggage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ the release.
 * [frontend] Avoid hardcoded `localhost:8080` image URLs during SSR and
   normalize leading slashes in the custom image loader
   ([#3582](https://github.com/open-telemetry/opentelemetry-demo/pull/3582))
+* [load-generator] Fix `synthetic_request` (and `session.id`) baggage being
+  discarded before reaching any backend service, due to the baggage-bearing
+  context being attached inside a span's `with` block so that the span's exit
+  detached past it. Regression introduced in #2265
+  ([#3627](https://github.com/open-telemetry/opentelemetry-demo/pull/3627))
 * [payment] Annotate synthetic load-generator payment requests with the
   `user_agent.synthetic.type` semantic convention attribute.
 * [checkout] Migrate OTLP exporters (traces, metrics, logs) from gRPC to

--- a/src/load-generator/locustfile.py
+++ b/src/load-generator/locustfile.py
@@ -119,21 +119,21 @@ class WebsiteUser(HttpUser):
 
     @task(1)
     def index(self):
-        with self.tracer.start_as_current_span("user_index", context=Context()):
+        with self.tracer.start_as_current_span("user_index", context=context.get_current()):
             logging.info("User accessing index page")
             self.client.get("/")
 
     @task(10)
     def browse_product(self):
         product = random.choice(products)
-        with self.tracer.start_as_current_span("user_browse_product", context=Context(), attributes={"product.id": product}):
+        with self.tracer.start_as_current_span("user_browse_product", context=context.get_current(), attributes={"product.id": product}):
             logging.info(f"User browsing product: {product}")
             self.client.get("/api/products/" + product)
 
     @task(3)
     def get_recommendations(self):
         product = random.choice(products)
-        with self.tracer.start_as_current_span("user_get_recommendations", context=Context(), attributes={"product.id": product}):
+        with self.tracer.start_as_current_span("user_get_recommendations", context=context.get_current(), attributes={"product.id": product}):
             logging.info(f"User getting recommendations for product: {product}")
             params = {
                 "productIds": [product],
@@ -143,7 +143,7 @@ class WebsiteUser(HttpUser):
     @task(3)
     def get_ads(self):
         category = random.choice(categories)
-        with self.tracer.start_as_current_span("user_get_ads", context=Context(), attributes={"category": str(category)}):
+        with self.tracer.start_as_current_span("user_get_ads", context=context.get_current(), attributes={"category": str(category)}):
             logging.info(f"User getting ads for category: {category}")
             params = {
                 "contextKeys": [category],
@@ -152,7 +152,7 @@ class WebsiteUser(HttpUser):
 
     @task(3)
     def view_cart(self):
-        with self.tracer.start_as_current_span("user_view_cart", context=Context()):
+        with self.tracer.start_as_current_span("user_view_cart", context=context.get_current()):
             logging.info("User viewing cart")
             self.client.get("/api/cart")
 
@@ -162,7 +162,7 @@ class WebsiteUser(HttpUser):
             user = str(uuid.uuid1())
         product = random.choice(products)
         quantity = random.choice([1, 2, 3, 4, 5, 10])
-        with self.tracer.start_as_current_span("user_add_to_cart", context=Context(), attributes={"user.id": user, "product.id": product, "quantity": quantity}):
+        with self.tracer.start_as_current_span("user_add_to_cart", context=context.get_current(), attributes={"user.id": user, "product.id": product, "quantity": quantity}):
             logging.info(f"User {user} adding {quantity} of product {product} to cart")
             self.client.get("/api/products/" + product)
             cart_item = {
@@ -177,7 +177,7 @@ class WebsiteUser(HttpUser):
     @task(1)
     def checkout(self):
         user = str(uuid.uuid1())
-        with self.tracer.start_as_current_span("user_checkout_single", context=Context(), attributes={"user.id": user}):
+        with self.tracer.start_as_current_span("user_checkout_single", context=context.get_current(), attributes={"user.id": user}):
             self.add_to_cart(user=user)
             checkout_person = random.choice(people)
             checkout_person["userId"] = user
@@ -188,7 +188,7 @@ class WebsiteUser(HttpUser):
     def checkout_multi(self):
         user = str(uuid.uuid1())
         item_count = random.choice([2, 3, 4])
-        with self.tracer.start_as_current_span("user_checkout_multi", context=Context(),
+        with self.tracer.start_as_current_span("user_checkout_multi", context=context.get_current(),
                                             attributes={"user.id": user, "item.count": item_count}):
             for i in range(item_count):
                 self.add_to_cart(user=user)
@@ -201,18 +201,22 @@ class WebsiteUser(HttpUser):
     def flood_home(self):
         flood_count = get_flagd_value("loadGeneratorFloodHomepage")
         if flood_count > 0:
-            with self.tracer.start_as_current_span("user_flood_home",  context=Context(), attributes={"flood.count": flood_count}):
+            with self.tracer.start_as_current_span("user_flood_home",  context=context.get_current(), attributes={"flood.count": flood_count}):
                 logging.info(f"User flooding homepage {flood_count} times")
                 for _ in range(0, flood_count):
                     self.client.get("/")
 
     def on_start(self):
-        with self.tracer.start_as_current_span("user_session_start", context=Context()):
-            session_id = str(uuid.uuid4())
-            logging.info(f"Starting user session: {session_id}")
-            ctx = baggage.set_baggage("session.id", session_id)
-            ctx = baggage.set_baggage("synthetic_request", "true", context=ctx)
-            context.attach(ctx)
+        session_id = str(uuid.uuid4())
+        logging.info(f"Starting user session: {session_id}")
+        # Attach the baggage-bearing context OUTSIDE of any span's `with` block.
+        # If this were attached *inside* start_as_current_span(...)'s `with` block,
+        # that block's own exit would detach past this manual attach and silently
+        # discard the baggage for the rest of the user's session.
+        ctx = baggage.set_baggage("session.id", session_id)
+        ctx = baggage.set_baggage("synthetic_request", "true", context=ctx)
+        context.attach(ctx)
+        with self.tracer.start_as_current_span("user_session_start", context=context.get_current()):
             self.index()
 
 


### PR DESCRIPTION
`on_start()` attached the baggage-bearing context (`synthetic_request=true`, `session.id=...`) *inside* the `with self.tracer.start_as_current_span("user_session_start", ...)` block. When that block exited, its own automatic detach unwound past the manual `context.attach()`, silently discarding the baggage before any subsequent `@task` ever ran — for the rest of that simulated user's entire session.

This meant no backend service ever actually received `synthetic_request` baggage from real load-generator traffic, despite `on_start()` appearing to set it correctly. It's been broken since #2265 (2025-06-24), which restructured `on_start()` to wrap it in a span for log-trace correlation, without realizing the nested attach would be silently discarded on that span's exit.

Fixed by attaching the baggage context before entering the span's `with` block, so it persists for the session's lifetime as originally intended (matching the pre-#2265 behavior).

Verified live: after this fix, real load-generator checkout traffic now correctly shows `demo.payment.charged: false` in payment's traces (previously always `true`, for every trace, forever). This also means #3613's `user_agent.synthetic.type` attribute (merged today) will now actually populate from real traffic for the first time.