### PR TITLE
fix(ci): exclude Cloudflare-protected Splunk link

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,6 +12,7 @@ max_concurrency = 1
 exclude = [
   "^http://localhost",
   "^https://calendar\\.google\\.com/calendar",
+  "^https://community\\.splunk\\.com/t5/AppDynamics-Knowledge-Base/How-to-observe-Kubernetes-deployment-of-OpenTelemetry-demo-app/ta-p/741454$",
   "^https://www\\.gnu\\.org",
   "^https://platform\\.openai\\.com",
   "^https://www\\.robotstxt\\.org",


### PR DESCRIPTION
# Changes

fix(ci): exclude Cloudflare-protected Splunk link

Assisted-by: Codex GPT-5

I have seen this time multiple times today. It seems that cloudflare is blocking our checks

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
