### PR TITLE
feat(email): set event_name on order-confirmation log record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [email] Set `event_name` on the order-confirmation log record
+  (`email.confirmation_sent`), using the OTel Ruby Logs API's `event_name`
+  parameter directly.
 * [cart] Make the `cartFailure` feature flag rate configurable as percentage
   (off - no failures, 10%, 25%, 50%, 75%, 90%, 100% - always fail) instead of
   a fixed all-or-nothing toggle, matching the `paymentFailure` pattern

--- a/src/email/email_server.rb
+++ b/src/email/email_server.rb
@@ -90,6 +90,7 @@ def send_email(data)
       severity_text: 'INFO',
       body: 'Order confirmation email sent',
       attributes: { 'demo.order.id' => data.order.order_id },
+      event_name: 'email.confirmation_sent',
     )
 
     puts "Order confirmation email sent for order #{data.order.order_id}"


### PR DESCRIPTION
The `email` service calls the OTel Ruby Logs API directly (`OpenTelemetry.logger_provider.logger(name: 'email')` + `on_emit`), rather than going through a native Ruby logging framework. Ruby's `Logger#on_emit` supports an `event_name:` parameter, which wasn't being set.

Added `event_name: 'email.confirmation_sent'`, matching the naming convention already used consistently elsewhere in the demo: `currency` (C++, `eventName("currency.conversion")`), `shipping` (Rust, `info!(name: "shipping.quote.sent", ...)`), and `cart`/`accounting` (.NET, `[LoggerMessage(EventName = "cart.add_item")]`) all already set this field — `email` was the one outlier missing it.