### PR TITLE
Add opt-in read-only root filesystem support for checkout, product-catalog, shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the release.
 
 ## Unreleased
 
+* [compose] Run `checkout`, `product-catalog`, and `shipping` with a
+  read-only root filesystem (`read_only: true` plus a `/tmp` tmpfs mount),
+  for container platforms that prohibit writable root filesystems. Limited
+  to these three services for now since they're the ones verified to have
+  no runtime file writes of their own; other services write files at
+  startup and need dedicated tmpfs mounts before they can be switched over
+  ([#1731](https://github.com/open-telemetry/opentelemetry-demo/issues/1731))
 * [llm] Increase `llm` service memory limit from 50M to 100M to prevent a
   startup restart loop caused by the container exceeding its memory limit
   ([#2944](https://github.com/open-telemetry/opentelemetry-demo/issues/2944))

--- a/compose.yaml
+++ b/compose.yaml
@@ -165,6 +165,9 @@ services:
         condition: service_started
       flagd:
         condition: service_started
+    read_only: true
+    tmpfs:
+      - /tmp
     logging: *logging
 
   # Currency service
@@ -545,6 +548,9 @@ services:
         condition: service_healthy
     volumes:
       - ./otel-config.yml:/otel-config.yml
+    read_only: true
+    tmpfs:
+      - /tmp
     logging: *logging
 
   # Quote service
@@ -663,6 +669,9 @@ services:
         condition: service_started
       flagd:
         condition: service_started
+    read_only: true
+    tmpfs:
+      - /tmp
     logging: *logging
 
   # ******************


### PR DESCRIPTION
# Changes

Towards #1731.

Environments with hardened container security runtimes (e.g. Kubernetes Pod
Security Standards "restricted") often prohibit writable root filesystems,
which the demo doesn't currently support for any service.

This adds `compose.readonly.yaml` as an additional compose layer, following
the same pattern already used by `compose.full.yaml` and
`compose.observability.yaml`. It covers `checkout`, `product-catalog`, and
`shipping` — the services I could confirm have no runtime file writes in
their own source (all distroless Go/Rust binaries doing network I/O only:
gRPC, Kafka, a DB connection). Each gets `read_only: true` with a `/tmp`
tmpfs mount as a safety margin.

This is intentionally a starting point, not full coverage. Several other
services write files at startup as part of normal operation and would need
dedicated tmpfs mounts of their own before they could be added safely:
nginx (`image-provider`, `telemetry-docs`) and Envoy (`frontend-proxy`) all
render their runtime config from a template into their own filesystem on
every start, and the load generator's headless Chromium session needs
writable scratch space. I didn't want to guess at those without being able
to verify them running.

Usage:

```sh
docker compose -f compose.yaml -f compose.readonly.yaml up
```

- `compose.readonly.yaml`: new opt-in layer.
- `compose.yaml`: documented the new layer alongside the existing ones in
  the top-of-file usage comment.
- `CHANGELOG.md`: added an entry under Unreleased.

## Merge Requirements

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][] — usage documented
  in `compose.yaml`'s own header, matching how the other compose layers are
  documented; no external docs reference this yet
* [ ] Appropriate Helm chart updates in the [helm-charts][] — not needed,
  this only adds a new opt-in Docker Compose layer

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
