### PR TITLE
Use merge=union for CHANGELOG.md to reduce conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,7 @@
 
 * text=auto
 
+CHANGELOG.md merge=union
+
 gradlew text eol=lf
 src/flagd-ui/rel/overlays/bin/server text eol=lf


### PR DESCRIPTION
Adding a CHANGELOG entry normally conflicts with every other open PR that touches the same spot. The merge=union git attribute keeps both sides when merging, so independent changelog entries no longer conflict. Mirrors open-telemetry/opentelemetry-rust#3588.