### PR TITLE
[flagd] Fix OTel exporter config

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ OPAMP_GO_REF=11e70c0be7d71e833506610ebf3668267b663ad0
 
 # Dependent images
 COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.155.0
-FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.14.2
+FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.16.0
 GRAFANA_IMAGE=grafana/grafana:13.0.1
 JAEGERTRACING_IMAGE=quay.io/jaegertracing/jaeger:2.14.1
 OPENSEARCH_DOCKERFILE=./src/opensearch/Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,8 @@ the release.
   ([#3633](https://github.com/open-telemetry/opentelemetry-demo/pull/3633))
 * [profiles] Add resource attributes to profiles
   ([#3659](https://github.com/open-telemetry/opentelemetry-demo/pull/3659))
+* [flagd] Fix OTel exporter config
+  ([#3667](https://github.com/open-telemetry/opentelemetry-demo/pull/3667))
 
 ## 2.2.0
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -688,8 +688,8 @@ services:
           memory: 75M
     restart: unless-stopped
     environment:
-      - FLAGD_OTEL_COLLECTOR_URI=${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
-      - FLAGD_METRICS_EXPORTER=otel
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - GOMEMLIMIT=60MiB
       - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.criticality=low
       - OTEL_SERVICE_NAME=flagd


### PR DESCRIPTION
# Changes

This PR fixes the endpoint from `flagd`.
The OTel data was not being exported.

Flagd supports OTel default env vars now, this PR used the OTel env vars and bumps flagd version to latest.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
