### PR TITLE
chore(infra): set up BEAM for FOSSA scan

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,6 +26,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Erlang and Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124  # v1.24.1
+        with:
+          otp-version: "28.4"
+          elixir-version: "1.20.1"
+          version-type: strict
+
       - name: Run FOSSA scan
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c  # v2.0.0
         with:


### PR DESCRIPTION

# Changes

chore(infra): set up BEAM for FOSSA scan
Assisted-by: Codex

Should fix:

```log
2026-07-13T09:53:48.2541829Z [ERROR] An issue occurred
2026-07-13T09:53:48.2543858Z 
2026-07-13T09:53:48.2544315Z   *** Relevant Errors ***
2026-07-13T09:53:48.2545950Z 
2026-07-13T09:53:48.2548014Z       [0;91mError: [0mCommand execution failed
2026-07-13T09:53:48.2549087Z         Attempted to run the command 'MIX_ENV=<REDACTED> mix deps.tree --format plain'
2026-07-13T09:53:48.2550777Z         inside the working directory '/home/runner/work/opentelemetry-demo/opentelemetry-demo/src/flagd-ui/',
2026-07-13T09:53:48.2552100Z         but failed, because the command exited with code '1'.
2026-07-13T09:53:48.2552750Z 
2026-07-13T09:53:48.2553378Z         Often, this kind of error is caused by the project not being ready to build;
2026-07-13T09:53:48.2631967Z         please ensure that the project at '/home/runner/work/opentelemetry-demo/opentelemetry-demo/src/flagd-ui/'
2026-07-13T09:53:48.2633411Z         builds successfully before running fossa.
2026-07-13T09:53:48.2634468Z 
2026-07-13T09:53:48.2634892Z         The logs for the command are listed below.
2026-07-13T09:53:48.2636640Z         They will likely provide guidance on how to resolve this error.
2026-07-13T09:53:48.2637641Z         Command did not write a standard log.
2026-07-13T09:53:48.2682012Z 
2026-07-13T09:53:48.2682492Z         Command error log:
2026-07-13T09:53:48.2683292Z           mix: startProcess: execvpe: does not exist (No such file or directory)
2026-07-13T09:53:48.2685312Z       [0;94mSupport: [0mIf you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com
2026-07-13T09:53:48.2742733Z 
2026-07-13T09:53:48.2781056Z 
2026-07-13T09:53:48.2781678Z       [0;91mError: [0mCommand execution failed
2026-07-13T09:53:48.2782848Z         Attempted to run the command 'mix deps.tree --format plain --only prod'
2026-07-13T09:53:48.2784014Z         inside the working directory '/home/runner/work/opentelemetry-demo/opentelemetry-demo/src/flagd-ui/',
2026-07-13T09:53:48.2785052Z         but failed, because the command exited with code '1'.
2026-07-13T09:53:48.2785499Z 
2026-07-13T09:53:48.2785872Z         Often, this kind of error is caused by the project not being ready to build;
2026-07-13T09:53:48.2787010Z         please ensure that the project at '/home/runner/work/opentelemetry-demo/opentelemetry-demo/src/flagd-ui/'
2026-07-13T09:53:48.2787954Z         builds successfully before running fossa.
2026-07-13T09:53:48.2788300Z 
2026-07-13T09:53:48.2788499Z         The logs for the command are listed below.
2026-07-13T09:53:48.2789191Z         They will likely provide guidance on how to resolve this error.
2026-07-13T09:53:48.2790131Z         Command did not write a standard log.
2026-07-13T09:53:48.2790784Z 
2026-07-13T09:53:48.2790966Z         Command error log:
2026-07-13T09:53:48.2791592Z           mix: startProcess: execvp: does not exist (No such file or directory)
2026-07-13T09:53:48.2793065Z       [0;94mSupport: [0mIf you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com
2026-07-13T09:53:48.2793914Z 
````



## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
