### PR TITLE
Add Events by Name dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [grafana] Add a "Logs by Event Name" dashboard that shows log record volume
+  by OpenTelemetry Event Name (top event names and volume over time).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-demo/pull/XXXX))
 * [opamp-server] Bump `OPAMP_GO_REF` to pick up example-server UI improvements
   from `opamp-go` (improved agent list, agent uptime on the agent page, and
   startup logging of the OpAMP/admin UI addresses).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ the release.
 
 * [grafana] Add a "Logs by Event Name" dashboard that shows log record volume
   by OpenTelemetry Event Name (top event names and volume over time).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-demo/pull/XXXX))
+  ([#3691](https://github.com/open-telemetry/opentelemetry-demo/pull/3691))
 * [opamp-server] Bump `OPAMP_GO_REF` to pick up example-server UI improvements
   from `opamp-go` (improved agent list, agent uptime on the agent page, and
   startup logging of the OpAMP/admin UI addresses).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ the release.
 
 ## Unreleased
 
-* [grafana] Add a "Logs by Event Name" dashboard that shows log record volume
-  by OpenTelemetry Event Name (top event names and volume over time).
+* [grafana] Add an "Events by Name" dashboard that shows Event volume by
+  OpenTelemetry `EventName` (top events and volume over time). A log record
+  with an `EventName` is an OpenTelemetry Event.
   ([#3691](https://github.com/open-telemetry/opentelemetry-demo/pull/3691))
 * [frontend] Add custom `404` and `500` error pages. Without them, `_app.tsx`'s
   custom `getInitialProps` disables Next.js's automatic static optimization

--- a/src/grafana/provisioning/dashboards/demo/events-by-name.json
+++ b/src/grafana/provisioning/dashboards/demo/events-by-name.json
@@ -26,7 +26,7 @@
         "type": "grafana-opensearch-datasource",
         "uid": "webstore-logs"
       },
-      "description": "Log records grouped by their Event Name, ordered by volume.",
+      "description": "Events grouped by their EventName, ordered by volume.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -98,7 +98,7 @@
             },
             "renameByName": {
               "eventName": "Event Name",
-              "log_count": "Log Records"
+              "log_count": "Events"
             }
           }
         }
@@ -110,7 +110,7 @@
         "type": "grafana-opensearch-datasource",
         "uid": "webstore-logs"
       },
-      "description": "Log record volume over time, split by the top Event Names.",
+      "description": "Event volume over time, split by the top Event Names.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -124,7 +124,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 15,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -133,7 +133,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -142,7 +142,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"

--- a/src/grafana/provisioning/dashboards/demo/events-by-name.json
+++ b/src/grafana/provisioning/dashboards/demo/events-by-name.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Explore logs by their OpenTelemetry Event Name, a durable identifier for a log record.",
+  "description": "Explore Events: log records that carry an OpenTelemetry EventName, a durable identifier for the class of event.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -243,8 +243,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Logs by Event Name",
-  "uid": "otel-demo-logs-by-event-name",
+  "title": "Events by Name",
+  "uid": "otel-demo-events-by-name",
   "version": 1,
   "weekStart": ""
 }

--- a/src/grafana/provisioning/dashboards/demo/logs-by-event-name.json
+++ b/src/grafana/provisioning/dashboards/demo/logs-by-event-name.json
@@ -1,0 +1,250 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Explore logs by their OpenTelemetry Event Name, a durable identifier for a log record.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-opensearch-datasource",
+        "uid": "webstore-logs"
+      },
+      "description": "Log records grouped by their Event Name, ordered by volume.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-opensearch-datasource",
+            "uid": "webstore-logs"
+          },
+          "format": "table",
+          "query": "source=otel-logs-*\n| where eventName != ''\n| stats count() as log_count by eventName\n| sort - log_count\n| head 20",
+          "queryType": "PPL",
+          "refId": "A",
+          "timeField": "observedTimestamp"
+        }
+      ],
+      "title": "Top Event Names by Volume",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "eventName": 0,
+              "log_count": 1
+            },
+            "renameByName": {
+              "eventName": "Event Name",
+              "log_count": "Log Records"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-opensearch-datasource",
+        "uid": "webstore-logs"
+      },
+      "description": "Log record volume over time, split by the top Event Names.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 10,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "eventName.keyword",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_count",
+                "size": "5"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "observedTimestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "grafana-opensearch-datasource",
+            "uid": "webstore-logs"
+          },
+          "format": "time_series",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "eventName:*",
+          "queryType": "lucene",
+          "refId": "A",
+          "timeField": "observedTimestamp"
+        }
+      ],
+      "title": "Event Volume Over Time (Top Event Names)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "opentelemetry",
+    "logs"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs by Event Name",
+  "uid": "otel-demo-logs-by-event-name",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Adds a minimal "Events by Name" Grafana dashboard that showcases the OpenTelemetry `EventName` as a first-class way to slice telemetry.

A log record that carries an `EventName` is an OpenTelemetry Event ("Events are OpenTelemetry's standardized format for LogRecords", per the [logs data model](https://opentelemetry.io/docs/specs/otel/logs/data-model/#events)), and `EventName` is a durable identifier for the class of event. The dashboard has two panels:

- **Top Event Names by Volume** (table)
- **Event Volume Over Time**, split by the top Event Names (time series)

This is made possible by [open-telemetry/opentelemetry-collector-contrib#49314](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49314), which preserves the LogRecord `EventName` field in the OpenSearch exporter (released in collector-contrib v0.156.0, which the demo now uses). Before that fix the event name was dropped on export, so it was not available to query in OpenSearch.

Both panels query the existing OpenSearch logs datasource; there are no other changes. Kept intentionally minimal to start. Possible follow-ups (e.g. an index-template mapping so `eventName` is stored as a `keyword` rather than analyzed text, plus more panels) can come later if there is interest.

From local run of the new dashboard.
<img width="1534" height="492" alt="image" src="https://github.com/user-attachments/assets/4cfcaa01-e9d9-4d0b-b5bd-3afc141f3d6d" />

