### PR TITLE
Prototype: end-to-end pipeline latency probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the release.
   emits synthetic probe logs (`eventName == synthetic.e2e.probe`) and an
   OpenSearch ingest pipeline computes ingest-time minus emit-time, visualized
   by a new "E2E Pipeline Latency" Grafana dashboard.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-demo/pull/XXXX))
+  ([#3692](https://github.com/open-telemetry/opentelemetry-demo/pull/3692))
 * [frontend] Add custom `404` and `500` error pages. Without them, `_app.tsx`'s
   custom `getInitialProps` disables Next.js's automatic static optimization
   for the built-in error pages too, so a server-side error crashes with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ the release.
 
 ## Unreleased
 
+* [prototype] Add an end-to-end pipeline latency probe: the load generator
+  emits synthetic probe logs (`eventName == synthetic.e2e.probe`) and an
+  OpenSearch ingest pipeline computes ingest-time minus emit-time, visualized
+  by a new "E2E Pipeline Latency" Grafana dashboard.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-demo/pull/XXXX))
 * [frontend] Add custom `404` and `500` error pages. Without them, `_app.tsx`'s
   custom `getInitialProps` disables Next.js's automatic static optimization
   for the built-in error pages too, so a server-side error crashes with

--- a/compose.observability.yaml
+++ b/compose.observability.yaml
@@ -134,6 +134,39 @@ services:
         max-size: "5m"
         max-file: "2"
 
+  # E2E latency bootstrap (prototype, one-shot): registers the OpenSearch ingest
+  # pipeline and index template that compute end-to-end pipeline latency for
+  # synthetic probe logs, then exits. The probes themselves are emitted by the
+  # load generator (E2E_LATENCY_PROBE_ENABLED).
+  e2e-latency-init:
+    image: curlimages/curl:8.11.1
+    container_name: e2e-latency-init
+    restart: "no"
+    environment:
+      - OPENSEARCH_URL=http://opensearch:9200
+    volumes:
+      - ./src/opensearch/e2e-latency-bootstrap.sh:/bootstrap/e2e-latency-bootstrap.sh:ro
+      - ./src/opensearch/e2e-latency-ingest-pipeline.json:/bootstrap/e2e-latency-ingest-pipeline.json:ro
+      - ./src/opensearch/e2e-latency-index-template.json:/bootstrap/e2e-latency-index-template.json:ro
+    entrypoint: ["sh", "/bootstrap/e2e-latency-bootstrap.sh"]
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "2"
+
+  # Enable the E2E latency probe emitter in the load generator when the
+  # observability stack (with OpenSearch) is running.
+  load-generator:
+    environment:
+      - E2E_LATENCY_PROBE_ENABLED=true
+    depends_on:
+      e2e-latency-init:
+        condition: service_completed_successfully
+
   # OpAMP Server
   # The collector connects to this control plane and reports status through the
   # opampextension.

--- a/src/grafana/provisioning/dashboards/demo/e2e-latency-probe.json
+++ b/src/grafana/provisioning/dashboards/demo/e2e-latency-probe.json
@@ -1,0 +1,171 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "End-to-end pipeline latency measured with synthetic probe logs (eventName == synthetic.e2e.probe). Latency is computed at ingest time by OpenSearch (ingest time minus probe emit time).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+      "description": "Average and p99 end-to-end latency of synthetic probe logs over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 18, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+          "query": "eventName.keyword:\"synthetic.e2e.probe\"",
+          "queryType": "lucene",
+          "timeField": "observedTimestamp",
+          "metrics": [
+            { "id": "1", "type": "avg", "field": "probe_e2e_latency_ms" },
+            { "id": "2", "type": "percentiles", "field": "probe_e2e_latency_ms", "settings": { "percents": ["99"] } }
+          ],
+          "bucketAggs": [
+            { "type": "date_histogram", "field": "observedTimestamp", "id": "3", "settings": { "interval": "auto", "min_doc_count": "0" } }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "E2E Pipeline Latency (avg and p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+      "description": "Average end-to-end latency over the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 2000 } ] },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+          "query": "eventName.keyword:\"synthetic.e2e.probe\"",
+          "queryType": "lucene",
+          "timeField": "observedTimestamp",
+          "metrics": [ { "id": "1", "type": "avg", "field": "probe_e2e_latency_ms" } ],
+          "bucketAggs": [
+            { "type": "date_histogram", "field": "observedTimestamp", "id": "3", "settings": { "interval": "auto", "min_doc_count": "0" } }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+      "description": "p99 end-to-end latency over the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 2000 } ] },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 5 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["max"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "webstore-logs" },
+          "query": "eventName.keyword:\"synthetic.e2e.probe\"",
+          "queryType": "lucene",
+          "timeField": "observedTimestamp",
+          "metrics": [ { "id": "1", "type": "percentiles", "field": "probe_e2e_latency_ms", "settings": { "percents": ["99"] } } ],
+          "bucketAggs": [
+            { "type": "date_histogram", "field": "observedTimestamp", "id": "3", "settings": { "interval": "auto", "min_doc_count": "0" } }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "p99 Latency",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": ["opentelemetry", "latency"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "E2E Pipeline Latency (Synthetic Probes)",
+  "uid": "otel-demo-e2e-latency-probe",
+  "version": 1,
+  "weekStart": ""
+}

--- a/src/load-generator/locustfile.py
+++ b/src/load-generator/locustfile.py
@@ -6,10 +6,12 @@
 import json
 import os
 import random
+import time
 import uuid
 import logging
 
-from locust import HttpUser, task, between
+import gevent
+from locust import HttpUser, task, between, events
 from locust_plugins.users.playwright import PlaywrightUser, pw, PageWithRetry, event
 
 from opentelemetry import context, baggage, trace
@@ -26,10 +28,10 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry._logs import set_logger_provider
+from opentelemetry._logs import set_logger_provider, SeverityNumber
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, SimpleLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 
 from openfeature import api
@@ -62,6 +64,59 @@ root_logger.setLevel(logging.INFO)
 # Configure metrics
 metric_exporter = OTLPMetricExporter(insecure=True)
 set_meter_provider(MeterProvider([PeriodicExportingMetricReader(metric_exporter)]))
+
+# --- E2E pipeline latency probe (prototype) ---
+# Periodically emit a synthetic "probe" log used to measure end-to-end pipeline
+# latency. The probe carries eventName == "synthetic.e2e.probe" and its emit
+# time; an OpenSearch ingest pipeline stamps the ingest time and records
+# probe_e2e_latency_ms = ingest_time - emit_time. Gated by an env var so it is
+# only active when the observability stack (with OpenSearch) is running.
+E2E_PROBE_EVENT_NAME = "synthetic.e2e.probe"
+E2E_PROBE_ENABLED = os.environ.get("E2E_LATENCY_PROBE_ENABLED", "false").lower() == "true"
+E2E_PROBE_INTERVAL_SECONDS = float(os.environ.get("E2E_LATENCY_PROBE_INTERVAL_SECONDS", "1"))
+
+# Dedicated logger provider with a simple (unbatched) processor so probes are
+# exported immediately. This keeps the measured latency focused on the
+# Collector -> backend path rather than the load generator's own log batching.
+probe_logger_provider = LoggerProvider()
+probe_logger_provider.add_log_record_processor(
+    SimpleLogRecordProcessor(OTLPLogExporter(insecure=True))
+)
+probe_logger = probe_logger_provider.get_logger("e2e-latency-probe")
+
+
+def emit_e2e_probe():
+    now_ns = time.time_ns()
+    now_ms = now_ns // 1_000_000
+    probe_logger.emit(
+        timestamp=now_ns,
+        observed_timestamp=now_ns,
+        event_name=E2E_PROBE_EVENT_NAME,
+        body="e2e latency probe",
+        severity_number=SeverityNumber.INFO,
+        attributes={
+            "probe_emitted_at_unix_millis": now_ms,
+            "probe_source": "load-generator",
+            "probe_id": str(uuid.uuid4()),
+        },
+    )
+
+
+def run_e2e_probe_loop():
+    while True:
+        try:
+            emit_e2e_probe()
+        except Exception as e:
+            logging.error(f"e2e latency probe emit failed: {e}")
+        gevent.sleep(E2E_PROBE_INTERVAL_SECONDS)
+
+
+@events.init.add_listener
+def start_e2e_probe(environment, **kwargs):
+    if E2E_PROBE_ENABLED:
+        gevent.spawn(run_e2e_probe_loop)
+        logging.info("E2E latency probe emitter started")
+
 
 # Instrument logging to automatically inject trace context
 LoggingInstrumentor().instrument(set_logging_format=True)

--- a/src/opensearch/e2e-latency-bootstrap.sh
+++ b/src/opensearch/e2e-latency-bootstrap.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# One-shot bootstrap for the E2E latency probe (prototype).
+#
+# Registers an OpenSearch ingest pipeline and index template that compute
+# end-to-end pipeline latency for synthetic probe logs (see
+# e2e-latency-ingest-pipeline.json). Runs once after OpenSearch is healthy,
+# then exits.
+
+set -eu
+
+OPENSEARCH_URL="${OPENSEARCH_URL:-http://opensearch:9200}"
+PIPELINE_ID="e2e-latency-probe"
+TEMPLATE_ID="otel-logs-e2e-latency"
+DIR="$(dirname "$0")"
+
+echo "[e2e-latency-init] waiting for OpenSearch at ${OPENSEARCH_URL}"
+until curl -sf "${OPENSEARCH_URL}/_cluster/health" >/dev/null 2>&1; do
+  sleep 2
+done
+echo "[e2e-latency-init] OpenSearch reachable"
+
+curl -sf -X PUT "${OPENSEARCH_URL}/_ingest/pipeline/${PIPELINE_ID}" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@${DIR}/e2e-latency-ingest-pipeline.json" >/dev/null
+echo "[e2e-latency-init] ingest pipeline '${PIPELINE_ID}' registered"
+
+curl -sf -X PUT "${OPENSEARCH_URL}/_index_template/${TEMPLATE_ID}" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@${DIR}/e2e-latency-index-template.json" >/dev/null
+echo "[e2e-latency-init] index template '${TEMPLATE_ID}' registered"
+
+# Apply to any otel-logs index that already exists (the template only covers
+# indices created after it). Ignore failures when no index exists yet.
+curl -s -X PUT \
+  "${OPENSEARCH_URL}/otel-logs-*/_settings?allow_no_indices=true&ignore_unavailable=true" \
+  -H 'Content-Type: application/json' \
+  -d "{\"index.default_pipeline\":\"${PIPELINE_ID}\"}" >/dev/null || true
+echo "[e2e-latency-init] bootstrap complete"

--- a/src/opensearch/e2e-latency-index-template.json
+++ b/src/opensearch/e2e-latency-index-template.json
@@ -1,0 +1,9 @@
+{
+  "index_patterns": ["otel-logs-*"],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index.default_pipeline": "e2e-latency-probe"
+    }
+  }
+}

--- a/src/opensearch/e2e-latency-ingest-pipeline.json
+++ b/src/opensearch/e2e-latency-ingest-pipeline.json
@@ -1,0 +1,25 @@
+{
+  "description": "Compute end-to-end pipeline latency for synthetic e2e probe logs (eventName == synthetic.e2e.probe).",
+  "processors": [
+    {
+      "set": {
+        "if": "ctx.eventName == 'synthetic.e2e.probe'",
+        "field": "_ingest_ts_str",
+        "value": "{{{_ingest.timestamp}}}"
+      }
+    },
+    {
+      "script": {
+        "lang": "painless",
+        "source": "if (ctx.eventName == 'synthetic.e2e.probe' && ctx._ingest_ts_str != null) { def emitted = ctx.attributes?.probe_emitted_at_unix_millis; if (emitted != null) { long ingest = Instant.parse(ctx._ingest_ts_str).toEpochMilli(); ctx.probe_e2e_latency_ms = ingest - (long)emitted; } }"
+      }
+    },
+    {
+      "remove": {
+        "if": "ctx._ingest_ts_str != null",
+        "field": "_ingest_ts_str",
+        "ignore_missing": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Backends that preserve a per-record ingest timestamp can calculate telemetry arrival latency directly. This PR does not replace that capability. It demonstrates a complementary, low-volume synthetic canary for backends where ingest time is not readily exposed or where continuously aggregating latency across the full log volume is undesirable.

## What it does

- The load generator emits an OpenTelemetry Event named `demo.telemetry.pipeline.probe` once per second.
- The probe uses the same batched SDK log processor as other load-generator logs.
- It traverses the normal Collector pipeline, exporter batching, network, and OpenSearch ingest.
- An OpenSearch ingest pipeline calculates latency from the LogRecord timestamp to backend ingest.
- A Grafana dashboard shows avg, p95, and p99 latency, probe arrivals, sample count, and possible clock skew.

Non-probe logs are left unchanged.

## Scope and trade-offs

This measures **backend-observed end-to-end latency for the probe path**, including producer SDK batching. It does not provide a per-processor or per-node breakdown.

The measurement requires synchronized producer and backend clocks, and the probe must follow the same routing and filtering path as the telemetry being evaluated. The dashboard also tracks probe arrivals because missing probes indicate pipeline availability problems.

OpenSearch implements the terminal calculation using an ingest pipeline; other backends would use their own ingestion facilities. If useful, the probe Event and measurement contract could be proposed as an OpenTelemetry semantic convention so producers and backends can interoperate without private agreements.

The probe is enabled only by `compose.observability.yaml`. A related exploration is available in open-telemetry/otel-arrow#3366.
