### PR TITLE
Fix recommendation feature flag lookup

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -123,7 +123,7 @@ def must_map_env(key: str):
 def check_feature_flag(flag_name: str):
     # Initialize OpenFeature
     client = api.get_client()
-    return client.get_boolean_value("recommendationCacheFailure", False)
+    return client.get_boolean_value(flag_name, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR fixes the `check_feature_flag` helper in the recommendation service.

The function accepts a `flag_name` argument, but it was always checking the hardcoded `recommendationCacheFailure` flag instead. This change makes the helper use the provided `flag_name`, so it can correctly evaluate whichever feature flag the caller requests.

## Change

```diff
- return client.get_boolean_value("recommendationCacheFailure", False)
+ return client.get_boolean_value(flag_name, False)