### PR TITLE
fix(payment): Set transaction counter unit

### DIFF
--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -11,7 +11,9 @@ const flagProvider = new FlagdProvider();
 const logger = require('./logger');
 const tracer = trace.getTracer('payment');
 const meter = metrics.getMeter('payment');
-const transactionsCounter = meter.createCounter('demo.payment.transactions');
+const transactionsCounter = meter.createCounter('demo.payment.transactions', {
+  unit: '{transaction}',
+});
 
 const LOYALTY_LEVEL = ['platinum', 'gold', 'silver', 'bronze'];
 


### PR DESCRIPTION
## Changes

Set `{transaction}` as the unit for `demo.payment.transactions`, matching its declaration in `telemetry-schema/metrics/payment.yaml`.

The mismatch was found while using Weaver to compare emitted Demo telemetry against the telemetry schema: the schema expected `{transaction}`, but the Payment service emitted the metric with an empty unit.

