### PR TITLE
fix(flagd-ui): correct invalid -4 Tailwind class on flag description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ the release.
 
 * [grafana] Add service, EventName, and severity filters to the "Events by Name"
   dashboard.
+* [flagd-ui] Fix invalid `-4` Tailwind class on the flag description text in
+  the dashboard. `-4` has no matching utility and is dropped during the
+  build, so the description ended up with no bottom margin; replaced with
+  `mb-4` to match the flag name above it
+  ([#3715](https://github.com/open-telemetry/opentelemetry-demo/issues/3715))
 * [flagd-ui] Navigate between the `Basic` and `Advanced` tabs with LiveView
   navigation instead of plain links. The plain links triggered a full page
   reload, which tore down the LiveView WebSocket and produced a trace

--- a/src/flagd-ui/lib/flagd_ui_web/live/dashboard.ex
+++ b/src/flagd-ui/lib/flagd_ui_web/live/dashboard.ex
@@ -29,7 +29,7 @@ defmodule FlagdUiWeb.Dashboard do
             >
               <div>
                 <p class="mb-4 text-lg font-semibold">{name}</p>
-                <p class="-4 text-sm">{data["description"]}</p>
+                <p class="mb-4 text-sm">{data["description"]}</p>
               </div>
               <div>
                 <div class="flex items-center justify-between">


### PR DESCRIPTION
# Changes

The flag description paragraph on each flag card in the flagd-ui dashboard
(`src/flagd-ui/lib/flagd_ui_web/live/dashboard.ex`) was using
`class="-4 text-sm"`. Tailwind's negative spacing utilities always carry a
property prefix (e.g. `-mt-4`, `-mx-2`); a bare `-4` matches no utility and
is dropped during the build, so the description ended up styled by
`text-sm` only, with no bottom margin.

The sibling flag-name paragraph directly above it already uses `mb-4`, so
this changes the description to use the same class:

```elixir
<p class="mb-4 text-sm">{data["description"]}</p>
```

## Before / after

```mermaid
flowchart LR
    subgraph Before["Before"]
        direction TB
        B1["p.mb-4.text-lg.font-semibold — flag name"]
        B2["p.-4.text-sm — flag description"]
        B1 --> B2
    end
    subgraph After["After"]
        direction TB
        A1["p.mb-4.text-lg.font-semibold — flag name"]
        A2["p.mb-4.text-sm — flag description"]
        A1 --> A2
    end
    classDef bug fill:#5b1a1a,stroke:#d73a4a,color:#ffffff;
    classDef fixed fill:#123d1f,stroke:#2ea043,color:#ffffff;
    class B2 bug;
    class A2 fixed;
```

`-4` resolves to no CSS rule at all, so the description paragraph rendered
with zero bottom margin. `mb-4` gives it the same 1rem (16px) bottom margin
as the flag name above it, matching the intended card spacing:

```mermaid
flowchart TD
    Card["Flag card"] --> Name["Flag name (mb-4 → 16px bottom margin)"]
    Card --> Desc["Flag description"]
    Name -. "16px gap" .-> Desc
    Desc --> Select["Variant select"]
```

Fixes #3715

## Merge Requirements

* [x] `CHANGELOG.md` updated
* [ ] Appropriate documentation updates in the docs (not applicable, no user-facing behavior/docs change)
* [ ] Appropriate Helm chart updates (not applicable, no deployment/config change)