### PR TITLE
fix(currency): correct IPV6_ENABLED string comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the release.
 
 ## Unreleased
 
+* [currency] Fix `IPV6_ENABLED` check comparing a `const char*` pointer
+  against a string literal instead of the string's contents, so the check
+  was always false and the service could never bind to `[::]`
+  ([#3735](https://github.com/open-telemetry/opentelemetry-demo/issues/3735))
 * [kafka] Add `KAFKA_TOPIC` environment variable to configure the Kafka topic
   name used by `checkout`, `accounting`, and `fraud-detection`, defaulting to
   `orders` to preserve existing behavior

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -254,8 +254,8 @@ void RunServer(uint16_t port)
   std::string ip("0.0.0.0");
 
   const char* ipv6_enabled = std::getenv("IPV6_ENABLED");
-  
-  if (ipv6_enabled == "true") {
+
+  if (ipv6_enabled != nullptr && std::string(ipv6_enabled) == "true") {
     ip = "[::]";
     logger->Info(eventName("currency.server.ip_overwrite"),
                  "Overwriting Localhost IP",


### PR DESCRIPTION
# Changes

Fixes #3735

IPV6_ENABLED is supposed to switch the currency service from binding 0.0.0.0 to binding [::], same as payment, shipping and quote already do. The check here compared the const char* returned by std::getenv directly against a string literal, which compares pointers, not the actual string contents. That can never be true, so the branch was dead code no matter what the env var was set to.

Fixed by wrapping the value in std::string before comparing, and added a null check since getenv returns nullptr when the variable isn't set at all (the old code only "handled" that case by accident).

Checked the equivalent logic in payment/index.js, shipping/src/main.rs and quote/public/index.php to confirm the comparison now matches how the other three services do it.

## Merge Requirements

This is a bug fix rather than a new feature, so most of this doesn't apply, but going through it:

* [x] `CHANGELOG.md` updated to document the fix
* [x] Documentation updates in the [docs][]: none needed, IPV6_ENABLED isn't called out anywhere in the docs today, this just makes the currency service match the behavior payment/shipping/quote already have
* [x] Helm chart updates in the [helm-charts][]: none needed, currency already has IPV6_ENABLED wired through in values.yaml, this only changes how the currency binary interprets the value it's given

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts