### PR TITLE
fix(currency): guard VERSION getenv against nullptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the release.
 * [currency] Guard the `VERSION` environment variable lookup against `nullptr`:
   constructing a `std::string` directly from `std::getenv("VERSION")` crashes
   when the variable is unset, so fall back to `"unknown"` instead
+  ([#3743](https://github.com/open-telemetry/opentelemetry-demo/pull/3743))
 * [kafka] Add `KAFKA_TOPIC` environment variable to configure the Kafka topic
   name used by `checkout`, `accounting`, and `fraud-detection`, defaulting to
   `orders` to preserve existing behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the release.
 
 ## Unreleased
 
+* [currency] Guard the `VERSION` environment variable lookup against `nullptr`:
+  constructing a `std::string` directly from `std::getenv("VERSION")` crashes
+  when the variable is unset, so fall back to `"unknown"` instead
 * [kafka] Add `KAFKA_TOPIC` environment variable to configure the Kafka topic
   name used by `checkout`, `accounting`, and `fraud-detection`, defaulting to
   `orders` to preserve existing behavior

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -91,7 +91,8 @@ namespace
     {"ZAR", 16.0583},
   };
 
-  std::string version = std::getenv("VERSION"); 
+  const char* version_env = std::getenv("VERSION");
+  std::string version = version_env != nullptr ? version_env : "unknown";
   std::string name{ "currency" };
 
   nostd::unique_ptr<metrics_api::Counter<uint64_t>> currency_counter;


### PR DESCRIPTION

# Changes

`std::string version = std::getenv("VERSION")` constructs a `std::string` directly from the `const char*` returned by `getenv`. When `VERSION` is unset, `getenv` returns `nullptr`, and constructing a `std::string` from `nullptr` is undefined behavior in practice libstdc++ throws `std::logic_error` ("basic_string::_M_construct null not valid") and the service aborts on startup.

It doesn't surface in the demo today because `compose.yaml` always sets `VERSION=${IMAGE_VERSION}`, but the currency binary crashes if run without it. This guards the lookup and falls back to `"unknown"`. Same class of unguarded-`getenv` issue as #3735 (the `IPV6_ENABLED` fix in #3741), on a different line.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the [@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
