### PR TITLE
fix(checkout): correct nanos divisor for shipping and order amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ the release.
   constructing a `std::string` directly from `std::getenv("VERSION")` crashes
   when the variable is unset, so fall back to `"unknown"` instead
   ([#3743](https://github.com/open-telemetry/opentelemetry-demo/pull/3743))
+* [checkout] Fix `demo.shipping.amount` and `demo.order.amount` telemetry
+  always dropping the cents. `Money.nanos` is billionths of a unit, so
+  dividing by `1_000_000_000` is integer division of a value that never
+  reaches that divisor, always producing `0`; divide by `10_000_000` instead
+  to get the cents component
+  ([#3742](https://github.com/open-telemetry/opentelemetry-demo/issues/3742))
 * [react-native-app] Use `getUniqueIdSync()` instead of `getDeviceId()` to
   populate the `device.id` resource attribute. `getDeviceId()` returns the
   hardware/model identifier (e.g. `iPhone13,4`), which is the same for every

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -380,8 +380,8 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 		Items:              prep.orderItems,
 	}
 
-	shippingCostFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", prep.shippingCostLocalized.GetUnits(), prep.shippingCostLocalized.GetNanos()/1000000000), 64)
-	totalPriceFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", total.GetUnits(), total.GetNanos()/1000000000), 64)
+	shippingCostFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", prep.shippingCostLocalized.GetUnits(), prep.shippingCostLocalized.GetNanos()/10000000), 64)
+	totalPriceFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", total.GetUnits(), total.GetNanos()/10000000), 64)
 
 	span.SetAttributes(
 		attribute.String("demo.order.id", orderID.String()),
@@ -452,7 +452,7 @@ func (cs *checkout) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Contex
 	for _, ci := range cartItems {
 		totalCart += ci.Quantity
 	}
-	shippingCostFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", shippingPrice.GetUnits(), shippingPrice.GetNanos()/1000000000), 64)
+	shippingCostFloat, _ := strconv.ParseFloat(fmt.Sprintf("%d.%02d", shippingPrice.GetUnits(), shippingPrice.GetNanos()/10000000), 64)
 
 	span.SetAttributes(
 		attribute.Float64("demo.shipping.amount", shippingCostFloat),


### PR DESCRIPTION
# Changes

Fixes #3742

Money.nanos is billionths of a unit and per demo.proto is always in the range -999,999,999 to 999,999,999, so it can never reach 1,000,000,000. The checkout service was dividing nanos by 1,000,000,000 to build the cents portion of demo.shipping.amount and demo.order.amount, which is integer division of a value that never reaches the divisor, so it always evaluated to 0.

The result was that both attributes on the checkout span, and the same fields in the "order placed" log line, always reported a whole dollar amount with the cents dropped, even though the telemetry schema examples for these attributes (shipping.yaml, order.yaml) already show non-integer values like 5.99 and 99.99.

Changed the divisor to 10,000,000 (1 cent = 10,000,000 nanos) at all three call sites in src/checkout/main.go: PlaceOrder computing shippingCostFloat and totalPriceFloat, and prepareOrderItemsAndShippingQuoteFromCart computing shippingCostFloat. This brings main.go in line with shipping_service.rs, which already uses the correct NANOS_MULTIPLE of 10,000,000.

Tested locally by building and vetting the checkout service and running the existing test suite, all passing, and by manually verifying that a Money value like units=5, nanos=990000000 now formats as 5.99 instead of 5.00.

## Merge Requirements

This is a bug fix rather than a new feature, so most of this doesn't apply, but going through it:

* [x] `CHANGELOG.md` updated to document the fix
* [ ] Appropriate documentation updates in the docs (not applicable, this only fixes the value the telemetry emits, the schema already documents the correct examples)
* [ ] Appropriate Helm chart updates (not applicable, no config surface changed)