### PR TITLE
ci: scope Docker gha build cache per image

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -305,5 +305,5 @@ jobs:
             ${{ inputs.dockerhub_repo }}:latest-${{matrix.file_tag.tag_suffix }}
             ${{ inputs.ghcr_repo }}:${{ inputs.version }}-${{ matrix.file_tag.tag_suffix }}
             ${{ inputs.ghcr_repo }}:latest-${{ matrix.file_tag.tag_suffix }}
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=gha,scope=${{ matrix.file_tag.tag_suffix }}
+          cache-to: type=gha,scope=${{ matrix.file_tag.tag_suffix }}


### PR DESCRIPTION
The component image build matrix runs 26 builds that all shared a single type=gha cache scope, so they evicted each other's layers. Set the buildx cache scope to the per-service matrix tag_suffix to isolate each image's cache.

Assisted-by: Claude Opus 4.8

# Changes

The `component-build-images.yml` workflow builds 26 component images in a matrix.
Every build used `cache-from`/`cache-to: type=gha` with no `scope`, so all 26 builds
shared a single GitHub Actions cache namespace and continuously evicted each other's
layers.

This change sets the buildx cache `scope` to the per-service `matrix.file_tag.tag_suffix`
(e.g. `accounting`, `cart`, `checkout`), giving each image its own cache namespace:

```yaml
cache-from: type=gha,scope=${{ matrix.file_tag.tag_suffix }}
cache-to: type=gha,scope=${{ matrix.file_tag.tag_suffix }}
```

With a shared scope, each build overwrites the shared cache, so most builds get few or
no cache hits and rebuild layers from scratch. Isolating the scope per image lets each
service reuse its own layers across runs, improving cache hit rates and reducing build
times.

`scope` is the standard cache namespacing option that `docker/build-push-action` passes
through to the buildx `type=gha` backend. `matrix.file_tag.tag_suffix` is already used for
this workflow's image tags and job names, so it is a stable per-service key. This only
affects CI build caching and cannot be meaningfully exercised locally; the improved hit
rate becomes visible across GitHub Actions runs once the per-scope caches warm up.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
