### PR TITLE
fix(payment): correct nanos handling for demo.payment.amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the release.
   ([#3751](https://github.com/open-telemetry/opentelemetry-demo/issues/3751))
 * [agentic] Move agent, chatbot and mcp to OTLP http exporter
   ([#3745](https://github.com/open-telemetry/opentelemetry-demo/pull/3745))
+* [payment] Fix `demo.payment.amount` telemetry attribute throwing a TypeError
+  at runtime. `Money.units` is an `int64` proto field decoded by
+  `@grpc/proto-loader` as a `Long` object, not a JS number. Adding a `Long` to
+  a float still returns a `Long`, which has no `.toFixed()` method. Wrap
+  `amount.units` in `Number()` before the arithmetic so `.toFixed(2)` works
+  correctly
+  ([#3747](https://github.com/open-telemetry/opentelemetry-demo/issues/3747))
 * [currency] Guard the `VERSION` environment variable lookup against `nullptr`:
   constructing a `std::string` directly from `std::getenv("VERSION")` crashes
   when the variable is unset, so fall back to `"unknown"` instead

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -14,7 +14,7 @@ async function chargeServiceHandler(call, callback) {
   try {
     const amount = call.request.amount
     span?.setAttributes({
-      'demo.payment.amount': parseFloat(`${amount.units}.${amount.nanos}`).toFixed(2)
+      'demo.payment.amount': (Number(amount.units) + amount.nanos / 1000000000).toFixed(2)
     })
     logger.info("Charge request received.")
 


### PR DESCRIPTION
# Changes

Fixes #3747

chargeServiceHandler in src/payment/index.js built the demo.payment.amount span attribute by string concatenating units and the raw nanos integer with a decimal point in between, then parsing that back to a float. Money.nanos is billionths of a unit and needs to be treated as a 9 digit fractional value, so concatenating it raw only works by coincidence when nanos happens to have 9 digits already. Whenever nanos prints with fewer digits, the decimal point ends up in the wrong place.

For example units=19, nanos=5000000 represents $19.005, but the old code produced parseFloat("19.5000000").toFixed(2), which is "19.50", off by close to 50x.

Replaced the string concatenation with units + nanos / 1000000000, the same approach already used for Money to decimal conversion in src/frontend/components/ProductPrice/ProductPrice.tsx, so both places handle nanos the same way. Added a changelog entry under Unreleased.

Tested by checking node -c on the file and running the numbers by hand for a few Money values (19/5000000, 29/990000000, 99/950000000, 5/0), all now produce the correct amount instead of the inflated one.

## Merge Requirements

This is a bug fix rather than a new feature, so most of this doesn't apply, but going through it:

* [x] `CHANGELOG.md` updated to document the fix
* [ ] Appropriate documentation updates in the docs (not applicable, this only fixes the value the telemetry emits, the schema already documents the correct examples)
* [ ] Appropriate Helm chart updates (not applicable, no config surface changed)