### PR TITLE
[chore] move profile images to .env

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,9 @@ OPENTELEMETRY_CPP_VERSION=1.27.0
 OPAMP_GO_REF=fc016b0599ee6cb5ba479452055a3370e7238aaa
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.156.0
+COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
+COLLECTOR_EBPF_PROFILER_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-ebpf-profiler:0.157.0
+FIREPIT_IMAGE=ghcr.io/florianl/firepit:v0.1.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.16.0
 GRAFANA_IMAGE=grafana/grafana:13.1.0
 JAEGERTRACING_IMAGE=quay.io/jaegertracing/jaeger:2.19.0

--- a/compose.profiling.yaml
+++ b/compose.profiling.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   otel-ebpf-profiler:
-    image: otel/opentelemetry-collector-ebpf-profiler:0.151.0
+    image: ${COLLECTOR_EBPF_PROFILER_IMAGE}
     container_name: otel-ebpf-profiler
     command:
       - --config=/etc/ebpf-profiler-config.yaml
@@ -29,7 +29,7 @@ services:
       - otel-collector
 
   firepit:
-    image: ghcr.io/florianl/firepit:v0.1.0
+    image: ${FIREPIT_IMAGE}
     container_name: firepit
     ports:
       - "${FIREPIT_PORT}"


### PR DESCRIPTION
# Changes

This PR moves firepit and ebpf profiler to `.env` file.
This makes controlling versions easier.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
