### PR TITLE
fix(react-native-app): render missing City and State input fields in CheckoutForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+* [react-native-app] Render missing `City` and `State` input fields in `CheckoutForm`
+  ([#3754](https://github.com/open-telemetry/opentelemetry-demo/issues/3754))
 * [react-native-app] Fix `ProductCard` price calculation where `nanos` was
   divided by `100_000_000` (1e8) instead of `1_000_000_000` (1e9), inflating
   the displayed price

--- a/src/react-native-app/components/CheckoutForm/CheckoutForm.tsx
+++ b/src/react-native-app/components/CheckoutForm/CheckoutForm.tsx
@@ -92,6 +92,34 @@ const CheckoutForm = ({ onSubmit }: IProps) => {
         rules={{ required: true }}
         render={({ field: { onChange, onBlur, value } }) => (
           <Field
+            label="City"
+            placeholder="City"
+            onBlur={onBlur}
+            onChangeText={onChange}
+            value={value}
+          />
+        )}
+        name="city"
+      />
+      <Controller
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Field
+            label="State"
+            placeholder="State"
+            onBlur={onBlur}
+            onChangeText={onChange}
+            value={value}
+          />
+        )}
+        name="state"
+      />
+      <Controller
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, onBlur, value } }) => (
+          <Field
             label="Country"
             placeholder="Country"
             onBlur={onBlur}


### PR DESCRIPTION
# Changes

Fixes #3754

`CheckoutForm` in `src/react-native-app/components/CheckoutForm/CheckoutForm.tsx` defines `city` and `state` in both the `IFormData` interface and the `useForm` default values (`Mountain View` and `CA` respectively), but neither field has a rendered `Controller` input in the form. The fields for `City` and `State` were simply never added when the component was copied from the web frontend.

The practical effect is that every order placed through the mobile app silently uses the hard-coded defaults — `city: "Mountain View"` and `state: "CA"` — regardless of what the user intends. There is no way for the user to see or change these values at checkout.

Added `Controller` fields for `city` and `state` between the existing `zipCode` and `country` inputs, matching the field order in `src/frontend/components/CheckoutForm/CheckoutForm.tsx`. Both fields are marked required and use the same `Field` component pattern as the rest of the form.

## Merge Requirements

This is a bug fix rather than a new feature, so most of this doesn't apply, but going through it:

* [x] `CHANGELOG.md` updated to document the fix
* [ ] Appropriate documentation updates in the docs (not applicable, this only adds missing fields to the mobile checkout form)
* [ ] Appropriate Helm chart updates (not applicable, no config surface changed)
