### PR TITLE
Fix observability stack configuration for Jaeger, Grafana, Prometheus, and OpenSearch

### DIFF
--- a/compose.observability.yaml
+++ b/compose.observability.yaml
@@ -21,8 +21,8 @@ services:
           memory: 1200M
     restart: unless-stopped
     ports:
-      - "${JAEGER_UI_PORT}"
-      - "${JAEGER_GRPC_PORT}"
+      - "${JAEGER_UI_PORT}:${JAEGER_UI_PORT}"
+      - "${JAEGER_GRPC_PORT}:${JAEGER_GRPC_PORT}"
     environment:
       - JAEGER_HOST
       - JAEGER_GRPC_PORT
@@ -54,7 +54,7 @@ services:
       - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./src/grafana/provisioning/:/etc/grafana/provisioning/
     ports:
-      - "${GRAFANA_PORT}"
+      - "${GRAFANA_PORT}:${GRAFANA_PORT}"
     logging:
       driver: "json-file"
       options:
@@ -122,7 +122,7 @@ services:
         soft: 65536
         hard: 65536
     ports:
-      - "9200"
+      - "${OPENSEARCH_PORT}:${OPENSEARCH_PORT}"
     healthcheck:
       test: curl -s http://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
       start_period: 10s

--- a/src/otel-collector/otelcol-config-observability.yml
+++ b/src/otel-collector/otelcol-config-observability.yml
@@ -67,7 +67,28 @@ service:
     traces:
       exporters: [debug, otlp_grpc/jaeger, span_metrics]
     metrics:
-      exporters: [debug, otlp_http/prometheus]
+      receivers:
+        [
+          docker_stats,
+          http_check/frontend-proxy,
+          host_metrics,
+          nginx,
+          otlp,
+          redis,
+          postgresql,
+          prometheus/ad,
+          span_metrics
+        ]
+      processors:
+        [
+          resourcedetection,
+          memory_limiter
+        ]
+      exporters:
+        [
+          debug,
+          otlp_http/prometheus
+        ]
     logs:
       exporters: [debug, opensearch]
     profiles:


### PR DESCRIPTION
## Summary

This pull request resolves multiple configuration issues that prevented the OpenTelemetry Demo observability stack from functioning correctly. The fixes restore end-to-end telemetry visibility across Jaeger, Grafana, Prometheus, and OpenSearch.

## Background

While setting up the OpenTelemetry Demo locally, the observability dashboards were not displaying telemetry despite active application traffic. Jaeger UI was initially inaccessible, Grafana dashboards showed no metrics, and Prometheus was not receiving metric data from the OpenTelemetry Collector.

This PR documents the configuration changes made to restore the complete observability pipeline.

## Changes

### Docker Compose

- Exposed Jaeger UI port
- Exposed Jaeger OTLP gRPC port
- Exposed Grafana port
- Exposed OpenSearch port

### OpenTelemetry Collector

- Updated the observability metrics pipeline
- Configured metrics export to Prometheus
- Preserved trace export to Jaeger
- Preserved log export to OpenSearch
- Verified spanmetrics connector integration

## Validation Performed

The following components were successfully validated:

- ✅ Jaeger UI accessible
- ✅ Grafana dashboards loading correctly
- ✅ Prometheus healthy and receiving telemetry
- ✅ OpenTelemetry Collector exporting traces and metrics
- ✅ Load Generator producing continuous traffic
- ✅ RED metrics displayed in Grafana
- ✅ Distributed traces available in Jaeger

## Troubleshooting Highlights

Resolved issues including:

- Docker port exposure
- Grafana subpath access
- Prometheus metrics ingestion
- OpenTelemetry Collector exporter configuration
- Metrics pipeline validation
- End-to-end telemetry verification

## Testing

Performed end-to-end validation by:

- Accessing the demo application
- Generating continuous application traffic
- Verifying traces in Jaeger
- Confirming metrics in Prometheus
- Confirming RED metrics in Grafana

## Documentation

A detailed implementation guide, troubleshooting walkthrough, architecture explanation, screenshots, and lessons learned have been documented separately in Notion.

This documentation covers:

- OpenTelemetry fundamentals
- Distributed tracing
- Metrics
- Logs
- OpenTelemetry Collector architecture
- Jaeger
- Grafana
- Prometheus
- OpenSearch
- Troubleshooting methodology
- Validation steps

