### PR TITLE
chore: move Pierre Tessier to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Wednesday at 8:30 AM PST and anyone is welcome.
 
 - [Cyrille Le Clerc](https://github.com/cyrille-leclerc), Datadog
 - [Juliano Costa](https://github.com/julianocosta89), Datadog
-- [Pierre Tessier](https://github.com/puckpuck), Resolve AI
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
@@ -108,6 +107,7 @@ For more information about the approver role, see the [community repository](htt
 - [Mikko Viitanen](https://github.com/mviitane), Maintainer
 - [Morgan McLean](https://github.com/mtwo), Approver
 - [Penghan Wang](https://github.com/wph95), Approver
+- [Pierre Tessier](https://github.com/puckpuck), Maintainer
 - [Reiley Yang](https://github.com/reyang), Approver
 - [Roger Coll](https://github.com/rogercoll), Maintainer
 - [Ziqi Zhao](https://github.com/fatsheep9146), Approver


### PR DESCRIPTION
After being a core maintainer since the SIG's very first repo creation, I'm moving to emeritus status. This project started as an idea to use the GCP microservices example to showcase what OpenTelemetry could do, and watching that idea grow into the most forked repo in OpenTelemetry, and a fixture at vendor booths across the industry, has been the **honor of my career**. Thank you to this community for taking a rough idea and building something far better than I could have on my own. I'll be cheering this project on from the sidelines.

Looking forward to seeing all my OpenTelemetry community at future conferences like KubeCon.