### PR TITLE
chore(checkout): ignore GO-2026-5932 security advisory

### DIFF
--- a/src/checkout/osv-scanner.toml
+++ b/src/checkout/osv-scanner.toml
@@ -1,0 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "The checkout service does not import the affected golang.org/x/crypto/openpgp packages."


### PR DESCRIPTION
# Changes

Add a manifest-local OSV Scanner exception for `GO-2026-5932` in the checkout
service.

The advisory applies specifically to the unmaintained
`golang.org/x/crypto/openpgp` packages. The checkout module has
`golang.org/x/crypto` in its transitive dependency graph, but the service does
not import any of the affected OpenPGP packages. Scorecard nevertheless reports
the advisory from the module version because its OSV integration does not use
Go call analysis.

There is no fixed `golang.org/x/crypto` version for this advisory because the
OpenPGP packages are deprecated rather than patched. The exception is therefore
kept next to `src/checkout/go.mod`, limiting it to that service and documenting
why the advisory is not applicable.

Local validation with Scorecard's `Vulnerabilities` check:

* Before the exception: 2 findings, score 8/10, including `GO-2026-5932`.
* After the exception: 1 findings, score 9/10, with `GO-2026-5932` absent.

Under the hood scorecard is calling osv analyzer without downloading dependencies and calling govulncheck.
Local execution govulncheck returns no issues. If the deep analysis is disabled the same issue occurs. It is safe to mute this issue.

## Merge Requirements

This change is scanner configuration only and does not add a new feature:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
