### PR TITLE
fix(cart): make cart mutations atomic and stop checkout from wiping concurrent adds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,6 +145,34 @@ jobs:
             "${WEAVER_IMAGE}" \
             registry check -r source
 
+  cart-unit-tests:
+    name: Cart unit tests
+    runs-on: ubuntu-latest
+    services:
+      valkey:
+        image: ghcr.io/valkey-io/valkey:9.0.4-alpine3.23
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+      - name: Run cart unit tests
+        working-directory: src/cart
+        env:
+          VALKEY_ADDR: localhost:6379
+        run: dotnet test tests/cart.tests.csproj
+
   check-react-native-changes:
     name: Check React Native changes
     runs-on: ubuntu-latest
@@ -198,6 +226,7 @@ jobs:
       sanity,
       checklicense,
       weaver-check,
+      cart-unit-tests,
       react-native-build,
       codeql-analysis,
       zizmor

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       valkey:
-        image: ghcr.io/valkey-io/valkey:9.0.4-alpine3.23
+        image: ghcr.io/valkey-io/valkey:9.0.4-alpine3.23@sha256:107b203169a20ef7c87548c157f4e4a833dbbbd20fefd3a26740b7f98ac80216
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,6 +145,34 @@ jobs:
             "${WEAVER_IMAGE}" \
             registry check -r source
 
+  cart-unit-tests:
+    name: Cart unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Start Valkey
+        run: |
+          VALKEY_IMAGE=$(grep -oP '(?<=^VALKEY_IMAGE=)\S*' .env)
+          docker run -d --rm --name valkey -p 6379:6379 "${VALKEY_IMAGE}"
+          for i in {1..30}; do
+            if docker exec valkey valkey-cli ping 2>/dev/null | grep -q PONG; then
+              break
+            fi
+            sleep 1
+          done
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+      - name: Run cart unit tests
+        working-directory: src/cart
+        env:
+          VALKEY_ADDR: localhost:6379
+        run: dotnet test tests/cart.tests.csproj
+
   check-react-native-changes:
     name: Check React Native changes
     runs-on: ubuntu-latest
@@ -190,6 +218,7 @@ jobs:
       sanity,
       checklicense,
       weaver-check,
+      cart-unit-tests,
       react-native-build,
       codeql-analysis
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ the release.
   v1.46.0/v0.71.0 release line, picking up otelgrpc recording `error.type`
   on RPC duration metrics for failed calls
   ([#3901](https://github.com/open-telemetry/opentelemetry-demo/issues/3901))
+* [cart] Make cart mutations atomic using Redis optimistic concurrency
+  transactions, and update checkout to only remove ordered items
+  ([#3825](https://github.com/open-telemetry/opentelemetry-demo/pull/3825))
 * [collector] Add a data redaction/deletion example: delete, hash, and partially
   mask sensitive attributes with the transform processor, plus a documented
   redaction-processor fallback

--- a/src/cart/src/cartstore/ValkeyCartStore.cs
+++ b/src/cart/src/cartstore/ValkeyCartStore.cs
@@ -18,6 +18,7 @@ public class ValkeyCartStore : ICartStore
     private readonly ILogger _logger;
     private const string CartFieldName = "cart";
     private const int RedisRetryNumber = 30;
+    private const int CartMutationMaxAttempts = 30;
 
     private volatile ConnectionMultiplexer _redis;
     private volatile bool _isRedisConnectionOpened;
@@ -132,38 +133,28 @@ public class ValkeyCartStore : ICartStore
 
         try
         {
-            EnsureRedisConnected();
-
-            var db = _redis.GetDatabase();
-
-            // Access the cart from the cache
-            var value = await db.HashGetAsync(userId, CartFieldName);
-
-            Oteldemo.Cart cart;
-            if (value.IsNull)
+            await MutateCartAsync(userId, cart =>
             {
-                cart = new Oteldemo.Cart
-                {
-                    UserId = userId
-                };
-                cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
-            }
-            else
-            {
-                cart = Oteldemo.Cart.Parser.ParseFrom((byte[])value);
                 var existingItem = cart.Items.SingleOrDefault(i => i.ProductId == productId);
                 if (existingItem == null)
                 {
-                    cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
+                    if (quantity > 0)
+                    {
+                        cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
+                    }
+                    return;
                 }
-                else
-                {
-                    existingItem.Quantity += quantity;
-                }
-            }
 
-            await db.HashSetAsync(userId, new[]{ new HashEntry(CartFieldName, cart.ToByteArray()) });
-            await db.KeyExpireAsync(userId, TimeSpan.FromMinutes(60));
+                existingItem.Quantity += quantity;
+                if (existingItem.Quantity <= 0)
+                {
+                    cart.Items.Remove(existingItem);
+                }
+            });
+        }
+        catch (RpcException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -173,6 +164,42 @@ public class ValkeyCartStore : ICartStore
         {
             addItemHistogram.Record(stopwatch.Elapsed.TotalSeconds);
         }
+    }
+
+    private async Task MutateCartAsync(string userId, Action<Oteldemo.Cart> mutate)
+    {
+        EnsureRedisConnected();
+
+        var db = _redis.GetDatabase();
+
+        for (var attempt = 0; attempt < CartMutationMaxAttempts; attempt++)
+        {
+            var existingValue = await db.HashGetAsync(userId, CartFieldName);
+
+            var cart = existingValue.IsNull
+                ? new Oteldemo.Cart { UserId = userId }
+                : Oteldemo.Cart.Parser.ParseFrom((byte[])existingValue);
+
+            mutate(cart);
+
+            var transaction = db.CreateTransaction();
+            transaction.AddCondition(existingValue.IsNull
+                ? Condition.HashNotExists(userId, CartFieldName)
+                : Condition.HashEqual(userId, CartFieldName, existingValue));
+
+            _ = transaction.HashSetAsync(userId, new[] { new HashEntry(CartFieldName, cart.ToByteArray()) });
+            _ = transaction.KeyExpireAsync(userId, TimeSpan.FromMinutes(60));
+
+            if (await transaction.ExecuteAsync())
+            {
+                return;
+            }
+
+            await Task.Delay(Random.Shared.Next(2, 10) * (attempt + 1));
+        }
+
+        throw new RpcException(new Status(StatusCode.Aborted,
+            $"Couldn't update cart for user {userId} after {CartMutationMaxAttempts} attempts due to concurrent modifications."));
     }
 
     public async Task EmptyCartAsync(string userId)

--- a/src/cart/src/cartstore/ValkeyCartStore.cs
+++ b/src/cart/src/cartstore/ValkeyCartStore.cs
@@ -18,6 +18,7 @@ public class ValkeyCartStore : ICartStore
     private readonly ILogger _logger;
     private const string CartFieldName = "cart";
     private const int RedisRetryNumber = 30;
+    private const int CartMutationMaxAttempts = 30;
 
     private volatile ConnectionMultiplexer _redis;
     private volatile bool _isRedisConnectionOpened;
@@ -132,38 +133,29 @@ public class ValkeyCartStore : ICartStore
 
         try
         {
-            EnsureRedisConnected();
-
-            var db = _redis.GetDatabase();
-
-            // Access the cart from the cache
-            var value = await db.HashGetAsync(userId, CartFieldName);
-
-            Oteldemo.Cart cart;
-            if (value.IsNull)
+            await MutateCartAsync(userId, cart =>
             {
-                cart = new Oteldemo.Cart
-                {
-                    UserId = userId
-                };
-                cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
-            }
-            else
-            {
-                cart = Oteldemo.Cart.Parser.ParseFrom((byte[])value);
                 var existingItem = cart.Items.SingleOrDefault(i => i.ProductId == productId);
                 if (existingItem == null)
                 {
-                    cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
+                    // A negative delta for a product that isn't in the cart has nothing to remove.
+                    if (quantity > 0)
+                    {
+                        cart.Items.Add(new Oteldemo.CartItem { ProductId = productId, Quantity = quantity });
+                    }
+                    return;
                 }
-                else
-                {
-                    existingItem.Quantity += quantity;
-                }
-            }
 
-            await db.HashSetAsync(userId, new[]{ new HashEntry(CartFieldName, cart.ToByteArray()) });
-            await db.KeyExpireAsync(userId, TimeSpan.FromMinutes(60));
+                existingItem.Quantity += quantity;
+                if (existingItem.Quantity <= 0)
+                {
+                    cart.Items.Remove(existingItem);
+                }
+            });
+        }
+        catch (RpcException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -173,6 +165,48 @@ public class ValkeyCartStore : ICartStore
         {
             addItemHistogram.Record(stopwatch.Elapsed.TotalSeconds);
         }
+    }
+
+    // Applies `mutate` to the user's current cart and writes it back with an optimistic-concurrency
+    // check (Redis transaction conditioned on the hash field still matching what we just read), retrying
+    // on conflict. This closes the lost-update window that a plain read -> modify -> write sequence has
+    // when two callers mutate the same cart concurrently.
+    private async Task MutateCartAsync(string userId, Action<Oteldemo.Cart> mutate)
+    {
+        EnsureRedisConnected();
+
+        var db = _redis.GetDatabase();
+
+        for (var attempt = 0; attempt < CartMutationMaxAttempts; attempt++)
+        {
+            var existingValue = await db.HashGetAsync(userId, CartFieldName);
+
+            var cart = existingValue.IsNull
+                ? new Oteldemo.Cart { UserId = userId }
+                : Oteldemo.Cart.Parser.ParseFrom((byte[])existingValue);
+
+            mutate(cart);
+
+            var transaction = db.CreateTransaction();
+            transaction.AddCondition(existingValue.IsNull
+                ? Condition.HashNotExists(userId, CartFieldName)
+                : Condition.HashEqual(userId, CartFieldName, existingValue));
+
+            _ = transaction.HashSetAsync(userId, new[] { new HashEntry(CartFieldName, cart.ToByteArray()) });
+            _ = transaction.KeyExpireAsync(userId, TimeSpan.FromMinutes(60));
+
+            if (await transaction.ExecuteAsync())
+            {
+                return;
+            }
+
+            // Another writer changed the cart between our read and write. Back off briefly with jitter
+            // so a burst of concurrent writers to the same cart doesn't keep colliding in lockstep.
+            await Task.Delay(Random.Shared.Next(2, 10) * (attempt + 1));
+        }
+
+        throw new RpcException(new Status(StatusCode.Aborted,
+            $"Couldn't update cart for user {userId} after {CartMutationMaxAttempts} attempts due to concurrent modifications."));
     }
 
     public async Task EmptyCartAsync(string userId)

--- a/src/cart/tests/CartServiceTests.cs
+++ b/src/cart/tests/CartServiceTests.cs
@@ -1,12 +1,20 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
 using Oteldemo;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenFeature;
 using Xunit;
+using cart.cartstore;
 using static Oteldemo.CartService;
 
 namespace cart.tests;
@@ -17,59 +25,68 @@ public class CartServiceTests
 
     public CartServiceTests()
     {
+        var valkeyAddress = Environment.GetEnvironmentVariable("VALKEY_ADDR") ?? "localhost:6379";
+
         _host = new HostBuilder().ConfigureWebHost(webBuilder =>
         {
             webBuilder
-                //  .UseStartup<Startup>()
-                .UseTestServer();
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddGrpc();
+                    services.AddSingleton<ICartStore>(_ =>
+                    {
+                        var store = new ValkeyCartStore(NullLogger<ValkeyCartStore>.Instance, valkeyAddress);
+                        store.Initialize();
+                        return store;
+                    });
+                    services.AddSingleton(sp =>
+                        new cart.services.CartService(
+                            sp.GetRequiredService<ICartStore>(),
+                            new ValkeyCartStore(NullLogger<ValkeyCartStore>.Instance, "badhost:1234"),
+                            Api.Instance.GetClient()));
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints => endpoints.MapGrpcService<cart.services.CartService>());
+                });
         });
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
-    public async Task GetItem_NoAddItemBefore_EmptyCartReturned()
+    private async Task<(IHost server, CartServiceClient client)> StartAsync()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
+        var server = await _host.StartAsync();
         var httpClient = server.GetTestClient();
-
-        string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
         var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
         {
             HttpClient = httpClient
         });
+        return (server, new CartServiceClient(channel));
+    }
 
-        var cartClient = new CartServiceClient(channel);
+    [Fact]
+    public async Task GetItem_NoAddItemBefore_EmptyCartReturned()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
-        var request = new GetCartRequest
-        {
-            UserId = userId,
-        };
+        string userId = Guid.NewGuid().ToString();
 
-        var cart = await cartClient.GetCartAsync(request);
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
         Assert.NotNull(cart);
 
         // All grpc objects implement IEquitable, so we can compare equality with by-value semantics
         Assert.Equal(new Cart(), cart);
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
+    [Fact]
     public async Task AddItem_ItemExists_Updated()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
-        var httpClient = server.GetTestClient();
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
         string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
-        var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
-        {
-            HttpClient = httpClient
-        });
-
-        var client = new CartServiceClient(channel);
         var request = new AddItemRequest
         {
             UserId = userId,
@@ -86,11 +103,7 @@ public class CartServiceTests
         // Second add of existing product - quantity should be updated
         await client.AddItemAsync(request);
 
-        var getCartRequest = new GetCartRequest
-        {
-            UserId = userId
-        };
-        var cart = await client.GetCartAsync(getCartRequest);
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
         Assert.NotNull(cart);
         Assert.Equal(userId, cart.UserId);
         Assert.Single(cart.Items);
@@ -100,24 +113,13 @@ public class CartServiceTests
         await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
+    [Fact]
     public async Task AddItem_New_Inserted()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
-        var httpClient = server.GetTestClient();
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
         string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
-        var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
-        {
-            HttpClient = httpClient
-        });
-
-        // Create a proxy object to work with the server
-        var client = new CartServiceClient(channel);
-
         var request = new AddItemRequest
         {
             UserId = userId,
@@ -130,10 +132,7 @@ public class CartServiceTests
 
         await client.AddItemAsync(request);
 
-        var getCartRequest = new GetCartRequest
-        {
-            UserId = userId
-        };
+        var getCartRequest = new GetCartRequest { UserId = userId };
         var cart = await client.GetCartAsync(getCartRequest);
         Assert.NotNull(cart);
         Assert.Equal(userId, cart.UserId);
@@ -142,5 +141,67 @@ public class CartServiceTests
         await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
         cart = await client.GetCartAsync(getCartRequest);
         Assert.Empty(cart.Items);
+    }
+
+    [Fact]
+    public async Task AddItem_ConcurrentCallsSameProduct_NoLostUpdates()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
+
+        string userId = Guid.NewGuid().ToString();
+        const int concurrentCalls = 20;
+
+        var tasks = Enumerable.Range(0, concurrentCalls).Select(_ => client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "race-product", Quantity = 1 }
+        }).ResponseAsync);
+
+        await Task.WhenAll(tasks);
+
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
+        Assert.Single(cart.Items);
+        Assert.Equal(concurrentCalls, cart.Items[0].Quantity);
+
+        await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
+    }
+
+    [Fact]
+    public async Task AddItem_NegativeDeltaDuringCheckoutRace_OnlyRemovesOrderedQuantity()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
+
+        string userId = Guid.NewGuid().ToString();
+
+        // Simulates the state checkout observed via GetCart before placing the order.
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "ordered-product", Quantity = 2 }
+        });
+
+        // A concurrent AddItem lands in the window between checkout's GetCart and its
+        // post-order cart cleanup (e.g. a second browser tab, or a retried request).
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "concurrently-added-product", Quantity = 1 }
+        });
+
+        // Checkout removes exactly what it read and ordered, not the whole cart.
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "ordered-product", Quantity = -2 }
+        });
+
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
+        var remaining = Assert.Single(cart.Items);
+        Assert.Equal("concurrently-added-product", remaining.ProductId);
+        Assert.Equal(1, remaining.Quantity);
+
+        await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
     }
 }

--- a/src/cart/tests/CartServiceTests.cs
+++ b/src/cart/tests/CartServiceTests.cs
@@ -1,12 +1,20 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
 using Oteldemo;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenFeature;
 using Xunit;
+using cart.cartstore;
 using static Oteldemo.CartService;
 
 namespace cart.tests;
@@ -17,59 +25,68 @@ public class CartServiceTests
 
     public CartServiceTests()
     {
+        var valkeyAddress = Environment.GetEnvironmentVariable("VALKEY_ADDR") ?? "localhost:6379";
+
         _host = new HostBuilder().ConfigureWebHost(webBuilder =>
         {
             webBuilder
-                //  .UseStartup<Startup>()
-                .UseTestServer();
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddGrpc();
+                    services.AddSingleton<ICartStore>(_ =>
+                    {
+                        var store = new ValkeyCartStore(NullLogger<ValkeyCartStore>.Instance, valkeyAddress);
+                        store.Initialize();
+                        return store;
+                    });
+                    services.AddSingleton(sp =>
+                        new cart.services.CartService(
+                            sp.GetRequiredService<ICartStore>(),
+                            new ValkeyCartStore(NullLogger<ValkeyCartStore>.Instance, "badhost:1234"),
+                            Api.Instance.GetClient()));
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints => endpoints.MapGrpcService<cart.services.CartService>());
+                });
         });
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
-    public async Task GetItem_NoAddItemBefore_EmptyCartReturned()
+    private async Task<(IHost server, CartServiceClient client)> StartAsync()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
+        var server = await _host.StartAsync();
         var httpClient = server.GetTestClient();
-
-        string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
         var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
         {
             HttpClient = httpClient
         });
+        return (server, new CartServiceClient(channel));
+    }
 
-        var cartClient = new CartServiceClient(channel);
+    [Fact]
+    public async Task GetItem_NoAddItemBefore_EmptyCartReturned()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
-        var request = new GetCartRequest
-        {
-            UserId = userId,
-        };
+        string userId = Guid.NewGuid().ToString();
 
-        var cart = await cartClient.GetCartAsync(request);
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
         Assert.NotNull(cart);
 
         // All grpc objects implement IEquitable, so we can compare equality with by-value semantics
         Assert.Equal(new Cart(), cart);
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
+    [Fact]
     public async Task AddItem_ItemExists_Updated()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
-        var httpClient = server.GetTestClient();
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
         string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
-        var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
-        {
-            HttpClient = httpClient
-        });
-
-        var client = new CartServiceClient(channel);
         var request = new AddItemRequest
         {
             UserId = userId,
@@ -86,11 +103,7 @@ public class CartServiceTests
         // Second add of existing product - quantity should be updated
         await client.AddItemAsync(request);
 
-        var getCartRequest = new GetCartRequest
-        {
-            UserId = userId
-        };
-        var cart = await client.GetCartAsync(getCartRequest);
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
         Assert.NotNull(cart);
         Assert.Equal(userId, cart.UserId);
         Assert.Single(cart.Items);
@@ -100,24 +113,13 @@ public class CartServiceTests
         await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
     }
 
-    [Fact(Skip = "See https://github.com/open-telemetry/opentelemetry-demo/pull/746#discussion_r1107931240")]
+    [Fact]
     public async Task AddItem_New_Inserted()
     {
-        // Setup test server and client
-        using var server = await _host.StartAsync();
-        var httpClient = server.GetTestClient();
+        var (server, client) = await StartAsync();
+        using var _ = server;
 
         string userId = Guid.NewGuid().ToString();
-
-        // Create a GRPC communication channel between the client and the server
-        var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions
-        {
-            HttpClient = httpClient
-        });
-
-        // Create a proxy object to work with the server
-        var client = new CartServiceClient(channel);
-
         var request = new AddItemRequest
         {
             UserId = userId,
@@ -130,10 +132,7 @@ public class CartServiceTests
 
         await client.AddItemAsync(request);
 
-        var getCartRequest = new GetCartRequest
-        {
-            UserId = userId
-        };
+        var getCartRequest = new GetCartRequest { UserId = userId };
         var cart = await client.GetCartAsync(getCartRequest);
         Assert.NotNull(cart);
         Assert.Equal(userId, cart.UserId);
@@ -142,5 +141,63 @@ public class CartServiceTests
         await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
         cart = await client.GetCartAsync(getCartRequest);
         Assert.Empty(cart.Items);
+    }
+
+    [Fact]
+    public async Task AddItem_ConcurrentCallsSameProduct_NoLostUpdates()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
+
+        string userId = Guid.NewGuid().ToString();
+        const int concurrentCalls = 20;
+
+        var tasks = Enumerable.Range(0, concurrentCalls).Select(_ => client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "race-product", Quantity = 1 }
+        }).ResponseAsync);
+
+        await Task.WhenAll(tasks);
+
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
+        Assert.Single(cart.Items);
+        Assert.Equal(concurrentCalls, cart.Items[0].Quantity);
+
+        await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
+    }
+
+    [Fact]
+    public async Task AddItem_NegativeDeltaDuringCheckoutRace_OnlyRemovesOrderedQuantity()
+    {
+        var (server, client) = await StartAsync();
+        using var _ = server;
+
+        string userId = Guid.NewGuid().ToString();
+
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "ordered-product", Quantity = 2 }
+        });
+
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "concurrently-added-product", Quantity = 1 }
+        });
+
+        await client.AddItemAsync(new AddItemRequest
+        {
+            UserId = userId,
+            Item = new CartItem { ProductId = "ordered-product", Quantity = -2 }
+        });
+
+        var cart = await client.GetCartAsync(new GetCartRequest { UserId = userId });
+        var remaining = Assert.Single(cart.Items);
+        Assert.Equal("concurrently-added-product", remaining.ProductId);
+        Assert.Equal(1, remaining.Quantity);
+
+        await client.EmptyCartAsync(new EmptyCartRequest { UserId = userId });
     }
 }

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -373,7 +374,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	shippingTrackingAttribute := attribute.String("demo.shipping.tracking.id", shippingTrackingID)
 	span.AddEvent("shipped", trace.WithAttributes(shippingTrackingAttribute))
 
-	_ = cs.emptyUserCart(ctx, req.UserId)
+	_ = cs.removeOrderedItemsFromCart(ctx, req.UserId, prep.cartItems)
 
 	orderResult := &pb.OrderResult{
 		OrderId:            orderID.String(),
@@ -527,11 +528,20 @@ func (cs *checkout) getUserCart(ctx context.Context, userID string) ([]*pb.CartI
 	return cart.GetItems(), nil
 }
 
-func (cs *checkout) emptyUserCart(ctx context.Context, userID string) error {
-	if _, err := cs.cartSvcClient.EmptyCart(ctx, &pb.EmptyCartRequest{UserId: userID}); err != nil {
-		return fmt.Errorf("failed to empty user cart during checkout: %+v", err)
+func (cs *checkout) removeOrderedItemsFromCart(ctx context.Context, userID string, items []*pb.CartItem) error {
+	var errs []error
+	for _, item := range items {
+		if _, err := cs.cartSvcClient.AddItem(ctx, &pb.AddItemRequest{
+			UserId: userID,
+			Item: &pb.CartItem{
+				ProductId: item.GetProductId(),
+				Quantity:  -item.GetQuantity(),
+			},
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove product %q from cart during checkout: %+v", item.GetProductId(), err))
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (cs *checkout) prepOrderItems(ctx context.Context, items []*pb.CartItem, userCurrency string) ([]*pb.OrderItem, error) {

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -370,7 +371,7 @@ func (cs *checkout) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (
 	shippingTrackingAttribute := attribute.String("demo.shipping.tracking.id", shippingTrackingID)
 	span.AddEvent("shipped", trace.WithAttributes(shippingTrackingAttribute))
 
-	_ = cs.emptyUserCart(ctx, req.UserId)
+	_ = cs.removeOrderedItemsFromCart(ctx, req.UserId, prep.cartItems)
 
 	orderResult := &pb.OrderResult{
 		OrderId:            orderID.String(),
@@ -524,11 +525,24 @@ func (cs *checkout) getUserCart(ctx context.Context, userID string) ([]*pb.CartI
 	return cart.GetItems(), nil
 }
 
-func (cs *checkout) emptyUserCart(ctx context.Context, userID string) error {
-	if _, err := cs.cartSvcClient.EmptyCart(ctx, &pb.EmptyCartRequest{UserId: userID}); err != nil {
-		return fmt.Errorf("failed to empty user cart during checkout: %+v", err)
+// removeOrderedItemsFromCart removes exactly the items that were placed in this order, rather than
+// clearing the whole cart. Clearing unconditionally would silently discard anything the user added
+// to their cart in the window between prepareOrderItemsAndShippingQuoteFromCart's GetCart call and
+// this call (e.g. a second browser tab, a retried request, or the load generator).
+func (cs *checkout) removeOrderedItemsFromCart(ctx context.Context, userID string, items []*pb.CartItem) error {
+	var errs []error
+	for _, item := range items {
+		if _, err := cs.cartSvcClient.AddItem(ctx, &pb.AddItemRequest{
+			UserId: userID,
+			Item: &pb.CartItem{
+				ProductId: item.GetProductId(),
+				Quantity:  -item.GetQuantity(),
+			},
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove product %q from cart during checkout: %+v", item.GetProductId(), err))
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (cs *checkout) prepOrderItems(ctx context.Context, items []*pb.CartItem, userCurrency string) ([]*pb.OrderItem, error) {


### PR DESCRIPTION
# Changes

Fixes #3824

## Problem

`ValkeyCartStore` stored each cart as a single serialized blob and mutated it with an unprotected read -> modify -> write. Two concurrent `AddItem` calls for the same cart could silently lose one of the updates. Separately, `checkoutservice.PlaceOrder` called `EmptyCart` unconditionally after reading the cart, so an item added in the window between `GetCart` and `EmptyCart` (a second tab, a retried request, the load generator) was silently discarded — never ordered, never billed, and with no error or trace surfaced anywhere.

Repro steps for both failure modes are in the issue.

## Fix

- `AddItemAsync` now applies its mutation through an optimistic-concurrency retry loop: it reads the cart, applies the change, then writes it back in a Redis transaction conditioned on the hash field still matching what was read (`Condition.HashEqual`/`HashNotExists`). If another writer changed the cart in between, the condition fails, and we retry against the fresh state (bounded retries with jittered backoff) instead of overwriting the concurrent write.
- `AddItemAsync` also supports negative quantity deltas, removing the item once its quantity reaches zero or below.
- Checkout no longer calls `EmptyCart` after placing an order. It calls the existing `AddItem` RPC once per ordered item with a negative quantity, removing exactly what was ordered rather than clearing the whole cart. Anything added concurrently now survives instead of being silently wiped. This reuses the existing `AddItem` RPC/proto contract, so there's no wire-format change — `EmptyCart` is untouched and still used for the frontend's explicit "empty cart" action.

## Tests

- Re-enabled the three `CartServiceTests` that had been skipped since #746 (the test host wiring was incomplete — no `Configure`/`ConfigureServices` was ever registered, so nothing actually ran against a cart store). Fixed the host setup to stand up a real `CartService` backed by `ValkeyCartStore` against a Valkey instance.
- Added a concurrency test: 20 parallel `AddItem` calls for the same product sum to the correct total (previously would have lost updates).
- Added a test reproducing the checkout race: an item added concurrently between the "order read" and "order cleanup" steps is preserved, while the ordered item is removed.
- Added a `cart-unit-tests` CI job that dynamically uses the Valkey image from `.env` so these run on every PR going forward.

Verified locally: `dotnet test` (5/5 passing against a real Valkey container), `go build ./...` and `go vet ./...` for checkout.

## Merge Requirements

* [x] `CHANGELOG.md` updated to document the fix
* [ ] Appropriate documentation updates in the docs (not applicable, internal state consistency bug fix)
* [ ] Appropriate Helm chart updates (not applicable, no configuration surface changed)
