### PR TITLE
[bug][Payment service] Fix payment service not starting and failing health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the release.
   ([#3656](https://github.com/open-telemetry/opentelemetry-demo/pull/3656))
 * [react-native-app] Render missing `City` and `State` input fields in `CheckoutForm`
   ([#3754](https://github.com/open-telemetry/opentelemetry-demo/issues/3754))
+* [payment] Fix gRPC server not starting by calling `server.start()` after `bindAsnc()`.
+  The server bound to the port but was never started to accept connections, causing
+  the service to fail its health checks.
+  ([#3844](https://github.com/open-telemetry/opentelemetry-demo/pull/3844))
 
 ## 3.0.0
 

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -60,6 +60,7 @@ server.bindAsync(address, grpc.ServerCredentials.createInsecure(), (err, port) =
     return logger.error({ err })
   }
 
+  server.start()
   logger.info(`payment gRPC server started on ${address}`)
 })
 


### PR DESCRIPTION
# Changes

The payment service failed to start the gRPC server due to not calling server.start(). The server bound to the port correctly but never started accepting connections, this caused its health check to fail.

Before this change when starting the otel-demo the payment service would fail to start:

```bash
opentelemetry-demo main ❯ make start-minimal
docker compose --env-file .env --env-file .env.override -f compose.yaml -f compose.observability.yaml -f compose.extras.yaml up --force-recreate --remove-orphans --detach
[+] up 26/26
 ✔ Network opentelemetry-demo Created                                                                                                                                             0.0s
 ✔ Container jaeger           Started                                                                                                                                             0.9s
 ✔ Container telemetry-docs   Started                                                                                                                                             1.0s
 ✔ Container valkey-cart      Healthy                                                                                                                                            11.8s
 ✔ Container prometheus       Started                                                                                                                                             1.1s
 ✔ Container opamp-server     Healthy                                                                                                                                            11.8s
 ✔ Container grafana          Started                                                                                                                                             1.0s
 ✔ Container opensearch       Healthy                                                                                                                                            11.1s
 ✔ Container astronomy-db     Healthy                                                                                                                                            11.8s
 ✔ Container flagd            Started                                                                                                                                             0.7s
 ✔ Container otel-collector   Started                                                                                                                                            11.1s
 ✔ Container product-catalog  Started                                                                                                                                            12.2s
 ✘ Container payment          Error dependency payment failed to start                                                                                                          223.3s
 ✔ Container cart             Started                                                                                                                                            12.3s
 ✔ Container quote            Started                                                                                                                                            11.6s
 ✔ Container email            Healthy                                                                                                                                            17.3s
 ✔ Container image-provider   Started                                                                                                                                            11.7s
 ✔ Container flagd-ui         Started                                                                                                                                            11.4s
 ✔ Container shipping         Started                                                                                                                                            12.1s
 ✔ Container currency         Healthy                                                                                                                                            16.8s
 ✔ Container ad               Started                                                                                                                                            11.9s
 ✔ Container recommendation   Started                                                                                                                                            12.6s
 ✔ Container checkout         Created                                                                                                                                             0.1s
 ✔ Container frontend         Created                                                                                                                                             0.0s
 ✔ Container frontend-proxy   Created                                                                                                                                             0.0s
 ✔ Container load-generator   Created                                                                                                                                             0.0s
dependency failed to start: container payment is unhealthy
make: *** [Makefile:291: start-minimal] Error 1
```

After this fix the payment service starts and passes its health checks correctly:

```bash
opentelemetry-demo main  ❯ make start-minimal
docker compose --env-file .env --env-file .env.override -f compose.yaml -f compose.observability.yaml -f compose.extras.yaml up --force-recreate --remove-orphans --detach
[+] up 26/26
 ✔ Network opentelemetry-demo Created                                                                                                                                             0.0s
 ✔ Container telemetry-docs   Healthy                                                                                                                                            20.4s
 ✔ Container astronomy-db     Healthy                                                                                                                                            12.2s
 ✔ Container grafana          Started                                                                                                                                             1.0s
 ✔ Container opamp-server     Healthy                                                                                                                                            20.4s
 ✔ Container jaeger           Started                                                                                                                                             0.7s
 ✔ Container opensearch       Healthy                                                                                                                                            11.5s
 ✔ Container prometheus       Started                                                                                                                                             0.9s
 ✔ Container valkey-cart      Healthy                                                                                                                                            12.2s
 ✔ Container flagd            Started                                                                                                                                             0.8s
 ✔ Container otel-collector   Started                                                                                                                                            11.6s
 ✔ Container currency         Healthy                                                                                                                                            19.4s
 ✔ Container quote            Healthy                                                                                                                                            19.4s
 ✔ Container payment          Healthy                                                                                                                                            18.6s
 ✔ Container flagd-ui         Healthy                                                                                                                                            20.3s
 ✔ Container cart             Started                                                                                                                                            12.6s
 ✔ Container product-catalog  Started                                                                                                                                            12.5s
 ✔ Container ad               Healthy                                                                                                                                            19.4s
 ✔ Container email            Healthy                                                                                                                                            17.6s
 ✔ Container image-provider   Healthy                                                                                                                                            19.4s
 ✔ Container shipping         Started                                                                                                                                            12.2s
 ✔ Container recommendation   Healthy                                                                                                                                            19.3s
 ✔ Container checkout         Started                                                                                                                                            18.8s
 ✔ Container frontend         Healthy                                                                                                                                            26.1s
 ✔ Container frontend-proxy   Healthy                                                                                                                                            36.0s
 ✔ Container load-generator   Started                                                                                                                                            36.6s

OpenTelemetry Demo in minimal mode is running.
Go to http://localhost:8080 for the demo UI.
Go to http://localhost:8080/jaeger/ui for the Jaeger UI.
Go to http://localhost:8080/grafana/ for the Grafana UI.
Go to http://localhost:8080/feature/ to change feature flags.
Go to http://localhost:8080/telemetry/ for the Weaver generated telemetry documentation.
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
