### PR TITLE
ci: exclude cloud-native.slack.com from lychee link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -18,6 +18,7 @@ exclude = [
   "^https://www\\.robotstxt\\.org",
   "^https://community\\.splunk\\.com",
   "^https://hub\\.docker\\.com/r/otel/demo",
+  "^https://cloud-native\\.slack\\.com",
 ]
 
 exclude_path = [


### PR DESCRIPTION
The CNCF Slack workspace (cloud-native.slack.com) returns `403` Forbidden to lychee's automated requests, so the lychee link check fails on the Slack links in `README.md` and `CONTRIBUTING.md`. These links work fine in a browser. This excludes the host so the check stops failing on this false positive.

Open PRs currently blocked by this same failure: #3861, #3859, #3854, #3853, #3851, #3847, #3662, is also causing issues with the merge queue for green PRs 

alternative approach is to add `403` as acceptable status code in lychee config. 