### PR TITLE
fix(currency): gracefully shut down on termination

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -186,7 +186,6 @@ services:
         limits:
           memory: 20M
     restart: unless-stopped
-    stop_grace_period: 30s
     ports:
       - "${CURRENCY_PORT}"
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -186,6 +186,7 @@ services:
         limits:
           memory: 20M
     restart: unless-stopped
+    stop_grace_period: 30s
     ports:
       - "${CURRENCY_PORT}"
     environment:

--- a/src/currency/CMakeLists.txt
+++ b/src/currency/CMakeLists.txt
@@ -7,6 +7,7 @@ project(currency)
 find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(opentelemetry-cpp CONFIG REQUIRED)
+find_package(Threads REQUIRED)
 
 set(GENERATED_PROTOBUF_PATH "${CMAKE_BINARY_DIR}/generated/proto")
 
@@ -18,6 +19,6 @@ add_executable(currency src/server.cpp)
 add_dependencies(currency demo-proto)
 target_link_libraries(
     currency demo-proto protobuf::libprotobuf
-     ${OPENTELEMETRY_CPP_LIBRARIES} gRPC::grpc++)
+     ${OPENTELEMETRY_CPP_LIBRARIES} gRPC::grpc++ Threads::Threads)
 
 install(TARGETS currency DESTINATION bin)

--- a/src/currency/Dockerfile
+++ b/src/currency/Dockerfile
@@ -55,4 +55,4 @@ COPY --from=builder /usr/local /usr/local
 
 EXPOSE ${CURRENCY_PORT}
 
-ENTRYPOINT ["sh", "-c", "./usr/local/bin/currency ${CURRENCY_PORT}"]
+ENTRYPOINT ["sh", "-c", "exec /usr/local/bin/currency \"${CURRENCY_PORT}\""]

--- a/src/currency/src/logger_common.h
+++ b/src/currency/src/logger_common.h
@@ -17,15 +17,18 @@ namespace logs_sdk  = opentelemetry::sdk::logs;
 
 namespace
 {
-  void initLogger() {
+  std::shared_ptr<logs_sdk::LoggerProvider> initLogger() {
     otlp::OtlpGrpcLogRecordExporterOptions loggerOptions;
     auto exporter  = otlp::OtlpGrpcLogRecordExporterFactory::Create(loggerOptions);
     auto processor = logs_sdk::BatchLogRecordProcessorFactory::Create(std::move(exporter), {});
     std::vector<std::unique_ptr<logs_sdk::LogRecordProcessor>> processors;
     processors.push_back(std::move(processor));
     auto context = logs_sdk::LoggerContextFactory::Create(std::move(processors));
-    std::shared_ptr<logs::LoggerProvider> provider = logs_sdk::LoggerProviderFactory::Create(std::move(context));
-    opentelemetry::logs::Provider::SetLoggerProvider(provider);
+    std::shared_ptr<logs_sdk::LoggerProvider> provider =
+        logs_sdk::LoggerProviderFactory::Create(std::move(context));
+    std::shared_ptr<logs::LoggerProvider> api_provider = provider;
+    opentelemetry::logs::Provider::SetLoggerProvider(api_provider);
+    return provider;
   }
 
   nostd::shared_ptr<opentelemetry::logs::Logger> getLogger(std::string name){

--- a/src/currency/src/meter_common.h
+++ b/src/currency/src/meter_common.h
@@ -16,7 +16,7 @@ namespace otlp_exporter = opentelemetry::exporter::otlp;
 
 namespace
 {
-  void initMeter() 
+  std::shared_ptr<metric_sdk::MeterProvider> initMeter()
   {
     // Build MetricExporter
     otlp_exporter::OtlpGrpcMetricExporterOptions otlpOptions;
@@ -26,10 +26,11 @@ namespace
     metric_sdk::PeriodicExportingMetricReaderOptions options;
     std::unique_ptr<metric_sdk::MetricReader> reader{
         new metric_sdk::PeriodicExportingMetricReader(std::move(exporter), options) };
-    auto provider = std::shared_ptr<metrics_api::MeterProvider>(new metric_sdk::MeterProvider());
-    auto p = std::static_pointer_cast<metric_sdk::MeterProvider>(provider);
-    p->AddMetricReader(std::move(reader));
-    metrics_api::Provider::SetMeterProvider(provider);
+    auto provider = std::make_shared<metric_sdk::MeterProvider>();
+    provider->AddMetricReader(std::move(reader));
+    std::shared_ptr<metrics_api::MeterProvider> api_provider = provider;
+    metrics_api::Provider::SetMeterProvider(api_provider);
+    return provider;
   }
 
   nostd::unique_ptr<metrics_api::Counter<uint64_t>> initIntCounter(std::string name, std::string version)

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -1,9 +1,14 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
+#include <cerrno>
+#include <csignal>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <math.h>
+#include <pthread.h>
 #include <demo.grpc.pb.h>
 #include <grpc/health/v1/health.grpc.pb.h>
 
@@ -48,6 +53,9 @@ using opentelemetry::logs::EventId;
 
 namespace
 {
+  constexpr auto server_shutdown_timeout = std::chrono::seconds(5);
+  constexpr auto telemetry_shutdown_timeout = std::chrono::seconds(5);
+
   EventId eventName(nostd::string_view name) {
     // The OTLP exporter ignores the numeric EventId and exports only the event name.
     // Use 0 to satisfy the C++ API; revisit when the C++ SDK provides guidance.
@@ -250,7 +258,7 @@ class CurrencyService final : public oteldemo::CurrencyService::Service
   }
 };
 
-void RunServer(uint16_t port)
+bool RunServer(uint16_t port, const sigset_t& shutdown_signals)
 {
   std::string ip("0.0.0.0");
 
@@ -274,15 +282,45 @@ void RunServer(uint16_t port)
   builder.AddListeningPort(address, grpc::InsecureServerCredentials());
 
   std::unique_ptr<Server> server(builder.BuildAndStart());
+  if (server == nullptr) {
+    std::cerr << "Failed to start Currency Server\n";
+    return false;
+  }
+
   logger->Info(eventName("currency.server.started"),
                "Currency Server started",
                opentelemetry::common::MakeAttributes({{"server.address", address.c_str()}}));
+
+  int received_signal = 0;
+  const int signal_error = sigwait(&shutdown_signals, &received_signal);
+  if (signal_error != 0) {
+    std::cerr << "Failed to wait for shutdown signal: " << std::strerror(signal_error) << "\n";
+  } else {
+    const char* signal_name = received_signal == SIGTERM ? "SIGTERM" : "SIGINT";
+    std::cout << "Received " << signal_name << ", shutting down Currency Server\n";
+  }
+
+  server->Shutdown(std::chrono::system_clock::now() + server_shutdown_timeout);
   server->Wait();
-  server->Shutdown();
+  return signal_error == 0;
 }
 }
 
 int main(int argc, char **argv) {
+
+  sigset_t shutdown_signals;
+  if (sigemptyset(&shutdown_signals) == -1 ||
+      sigaddset(&shutdown_signals, SIGINT) == -1 ||
+      sigaddset(&shutdown_signals, SIGTERM) == -1) {
+    std::cerr << "Failed to configure shutdown signals: " << std::strerror(errno) << "\n";
+    return 1;
+  }
+
+  const int signal_mask_error = pthread_sigmask(SIG_BLOCK, &shutdown_signals, nullptr);
+  if (signal_mask_error != 0) {
+    std::cerr << "Failed to block shutdown signals: " << std::strerror(signal_mask_error) << "\n";
+    return 1;
+  }
 
   if (argc < 2) {
     std::cout << "Usage: currency <port>";
@@ -291,12 +329,33 @@ int main(int argc, char **argv) {
 
   uint16_t port = atoi(argv[1]);
 
-  initTracer();
-  initMeter();
-  initLogger();
+  auto tracer_provider = initTracer();
+  auto meter_provider = initMeter();
+  auto logger_provider = initLogger();
   currency_counter = initIntCounter("demo.exchange.conversions", version);
   logger = getLogger(name);
-  RunServer(port);
 
-  return 0;
+  const bool server_shutdown = RunServer(port, shutdown_signals);
+  const bool tracer_shutdown = tracer_provider->Shutdown(telemetry_shutdown_timeout);
+  if (!tracer_shutdown) {
+    std::cerr << "Tracer provider shutdown failed\n";
+  }
+
+  const bool meter_flush = meter_provider->ForceFlush(telemetry_shutdown_timeout);
+  if (!meter_flush) {
+    std::cerr << "Meter provider flush failed\n";
+  }
+
+  const bool meter_shutdown = meter_provider->Shutdown(telemetry_shutdown_timeout);
+  if (!meter_shutdown) {
+    std::cerr << "Meter provider shutdown failed\n";
+  }
+
+  const bool logger_shutdown = logger_provider->Shutdown(telemetry_shutdown_timeout);
+  if (!logger_shutdown) {
+    std::cerr << "Logger provider shutdown failed\n";
+  }
+
+  return server_shutdown && tracer_shutdown && meter_flush && meter_shutdown && logger_shutdown ? 0
+                                                                                                : 1;
 }

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -55,6 +55,17 @@ namespace
 {
   constexpr auto shutdown_timeout = std::chrono::seconds(9);
 
+  struct ServerShutdownResult
+  {
+    bool succeeded;
+    std::chrono::steady_clock::time_point deadline;
+  };
+
+  ServerShutdownResult serverShutdownResult(bool succeeded)
+  {
+    return {succeeded, std::chrono::steady_clock::now() + shutdown_timeout};
+  }
+
   std::chrono::microseconds remainingShutdownTimeout(
       std::chrono::steady_clock::time_point shutdown_deadline)
   {
@@ -266,9 +277,7 @@ class CurrencyService final : public oteldemo::CurrencyService::Service
   }
 };
 
-bool RunServer(uint16_t port,
-               const sigset_t& shutdown_signals,
-               std::chrono::steady_clock::time_point& shutdown_deadline)
+ServerShutdownResult RunServer(uint16_t port, const sigset_t& shutdown_signals)
 {
   std::string ip("0.0.0.0");
 
@@ -294,7 +303,7 @@ bool RunServer(uint16_t port,
   std::unique_ptr<Server> server(builder.BuildAndStart());
   if (server == nullptr) {
     std::cerr << "Failed to start Currency Server\n";
-    return false;
+    return serverShutdownResult(false);
   }
 
   logger->Info(eventName("currency.server.started"),
@@ -307,14 +316,17 @@ bool RunServer(uint16_t port,
     std::cerr << "Failed to wait for shutdown signal: " << std::strerror(signal_error) << "\n";
   } else {
     const char* signal_name = received_signal == SIGTERM ? "SIGTERM" : "SIGINT";
-    std::cout << "Received " << signal_name << ", shutting down Currency Server\n";
+    const std::string shutdown_message =
+        std::string("Received ") + signal_name + ", shutting down Currency Server";
+    std::cout << shutdown_message << "\n";
+    logger->Info(eventName("currency.server.stopping"), shutdown_message);
   }
 
-  shutdown_deadline = std::chrono::steady_clock::now() + shutdown_timeout;
+  const auto result = serverShutdownResult(signal_error == 0);
   server->Shutdown(std::chrono::system_clock::now() +
-                   remainingShutdownTimeout(shutdown_deadline));
+                   remainingShutdownTimeout(result.deadline));
   server->Wait();
-  return signal_error == 0;
+  return result;
 }
 }
 
@@ -347,31 +359,30 @@ int main(int argc, char **argv) {
   currency_counter = initIntCounter("demo.exchange.conversions", version);
   logger = getLogger(name);
 
-  auto shutdown_deadline = std::chrono::steady_clock::now() + shutdown_timeout;
-  const bool server_shutdown = RunServer(port, shutdown_signals, shutdown_deadline);
+  const auto server_shutdown = RunServer(port, shutdown_signals);
   const bool tracer_shutdown =
-      tracer_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
+      tracer_provider->Shutdown(remainingShutdownTimeout(server_shutdown.deadline));
   if (!tracer_shutdown) {
     std::cerr << "Tracer provider shutdown failed\n";
   }
 
-  const bool meter_flush = meter_provider->ForceFlush(remainingShutdownTimeout(shutdown_deadline));
+  const bool meter_flush =
+      meter_provider->ForceFlush(remainingShutdownTimeout(server_shutdown.deadline));
   if (!meter_flush) {
     std::cerr << "Meter provider flush failed\n";
   }
 
   const bool meter_shutdown =
-      meter_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
+      meter_provider->Shutdown(remainingShutdownTimeout(server_shutdown.deadline));
   if (!meter_shutdown) {
     std::cerr << "Meter provider shutdown failed\n";
   }
 
   const bool logger_shutdown =
-      logger_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
+      logger_provider->Shutdown(remainingShutdownTimeout(server_shutdown.deadline));
   if (!logger_shutdown) {
     std::cerr << "Logger provider shutdown failed\n";
   }
 
-  return server_shutdown && tracer_shutdown && meter_flush && meter_shutdown && logger_shutdown ? 0
-                                                                                                : 1;
+  return server_shutdown.succeeded ? 0 : 1;
 }

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -54,6 +54,7 @@ using opentelemetry::logs::EventId;
 namespace
 {
   constexpr auto shutdown_timeout = std::chrono::seconds(9);
+  constexpr auto server_shutdown_timeout = std::chrono::seconds(4);
 
   struct ServerShutdownResult
   {
@@ -61,7 +62,7 @@ namespace
     std::chrono::steady_clock::time_point deadline;
   };
 
-  ServerShutdownResult serverShutdownResult(bool succeeded)
+  ServerShutdownResult makeServerShutdownResult(bool succeeded)
   {
     return {succeeded, std::chrono::steady_clock::now() + shutdown_timeout};
   }
@@ -303,7 +304,7 @@ ServerShutdownResult RunServer(uint16_t port, const sigset_t& shutdown_signals)
   std::unique_ptr<Server> server(builder.BuildAndStart());
   if (server == nullptr) {
     std::cerr << "Failed to start Currency Server\n";
-    return serverShutdownResult(false);
+    return makeServerShutdownResult(false);
   }
 
   logger->Info(eventName("currency.server.started"),
@@ -322,9 +323,8 @@ ServerShutdownResult RunServer(uint16_t port, const sigset_t& shutdown_signals)
     logger->Info(eventName("currency.server.stopping"), shutdown_message);
   }
 
-  const auto result = serverShutdownResult(signal_error == 0);
-  server->Shutdown(std::chrono::system_clock::now() +
-                   remainingShutdownTimeout(result.deadline));
+  const auto result = makeServerShutdownResult(signal_error == 0);
+  server->Shutdown(std::chrono::system_clock::now() + server_shutdown_timeout);
   server->Wait();
   return result;
 }

--- a/src/currency/src/server.cpp
+++ b/src/currency/src/server.cpp
@@ -53,8 +53,16 @@ using opentelemetry::logs::EventId;
 
 namespace
 {
-  constexpr auto server_shutdown_timeout = std::chrono::seconds(5);
-  constexpr auto telemetry_shutdown_timeout = std::chrono::seconds(5);
+  constexpr auto shutdown_timeout = std::chrono::seconds(9);
+
+  std::chrono::microseconds remainingShutdownTimeout(
+      std::chrono::steady_clock::time_point shutdown_deadline)
+  {
+    const auto remaining = std::chrono::duration_cast<std::chrono::microseconds>(
+        shutdown_deadline - std::chrono::steady_clock::now());
+    return remaining > std::chrono::microseconds::zero() ? remaining
+                                                          : std::chrono::microseconds(1);
+  }
 
   EventId eventName(nostd::string_view name) {
     // The OTLP exporter ignores the numeric EventId and exports only the event name.
@@ -258,7 +266,9 @@ class CurrencyService final : public oteldemo::CurrencyService::Service
   }
 };
 
-bool RunServer(uint16_t port, const sigset_t& shutdown_signals)
+bool RunServer(uint16_t port,
+               const sigset_t& shutdown_signals,
+               std::chrono::steady_clock::time_point& shutdown_deadline)
 {
   std::string ip("0.0.0.0");
 
@@ -300,7 +310,9 @@ bool RunServer(uint16_t port, const sigset_t& shutdown_signals)
     std::cout << "Received " << signal_name << ", shutting down Currency Server\n";
   }
 
-  server->Shutdown(std::chrono::system_clock::now() + server_shutdown_timeout);
+  shutdown_deadline = std::chrono::steady_clock::now() + shutdown_timeout;
+  server->Shutdown(std::chrono::system_clock::now() +
+                   remainingShutdownTimeout(shutdown_deadline));
   server->Wait();
   return signal_error == 0;
 }
@@ -335,23 +347,27 @@ int main(int argc, char **argv) {
   currency_counter = initIntCounter("demo.exchange.conversions", version);
   logger = getLogger(name);
 
-  const bool server_shutdown = RunServer(port, shutdown_signals);
-  const bool tracer_shutdown = tracer_provider->Shutdown(telemetry_shutdown_timeout);
+  auto shutdown_deadline = std::chrono::steady_clock::now() + shutdown_timeout;
+  const bool server_shutdown = RunServer(port, shutdown_signals, shutdown_deadline);
+  const bool tracer_shutdown =
+      tracer_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
   if (!tracer_shutdown) {
     std::cerr << "Tracer provider shutdown failed\n";
   }
 
-  const bool meter_flush = meter_provider->ForceFlush(telemetry_shutdown_timeout);
+  const bool meter_flush = meter_provider->ForceFlush(remainingShutdownTimeout(shutdown_deadline));
   if (!meter_flush) {
     std::cerr << "Meter provider flush failed\n";
   }
 
-  const bool meter_shutdown = meter_provider->Shutdown(telemetry_shutdown_timeout);
+  const bool meter_shutdown =
+      meter_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
   if (!meter_shutdown) {
     std::cerr << "Meter provider shutdown failed\n";
   }
 
-  const bool logger_shutdown = logger_provider->Shutdown(telemetry_shutdown_timeout);
+  const bool logger_shutdown =
+      logger_provider->Shutdown(remainingShutdownTimeout(shutdown_deadline));
   if (!logger_shutdown) {
     std::cerr << "Logger provider shutdown failed\n";
   }

--- a/src/currency/src/tracer_common.h
+++ b/src/currency/src/tracer_common.h
@@ -70,7 +70,7 @@ public:
   ServerContext *context_;
 };
 
-void initTracer()
+std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> initTracer()
 {
   auto exporter = opentelemetry::exporter::otlp::OtlpGrpcExporterFactory::Create();
   auto processor =
@@ -80,16 +80,19 @@ void initTracer()
 
   auto context =
       opentelemetry::sdk::trace::TracerContextFactory::Create(std::move(processors));
-  std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+  std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider =
       opentelemetry::sdk::trace::TracerProviderFactory::Create(std::move(context));
+  std::shared_ptr<opentelemetry::trace::TracerProvider> api_provider = provider;
 
   // Set the global trace provider
-  opentelemetry::trace::Provider::SetTracerProvider(provider);
+  opentelemetry::trace::Provider::SetTracerProvider(api_provider);
 
   // set global propagator
   opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
       opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
           new opentelemetry::trace::propagation::HttpTraceContext()));
+
+  return provider;
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> get_tracer(std::string tracer_name)


### PR DESCRIPTION
Currency currently blocks in Server::Wait() without initiating shutdown. During Docker or Kubernetes termination, SIGTERM therefore ends the process without draining gRPC requests or explicitly shutting down the OpenTelemetry providers, which can drop buffered telemetry.

This change handles SIGINT and SIGTERM using sigwait(), gracefully drains the gRPC server with a bounded deadline, explicitly flushes metrics, and shuts down the tracer, meter, and logger providers in order. It also makes Currency explicitly replace its entrypoint shell.

## Testing

Built the Currency image with docker compose build currency, then started Currency and the Collector using docker compose up -d --no-deps otel-collector currency and waited for Currency’s Docker health check to report healthy.

Verified /proc/1 inside the container was /usr/local/bin/currency 7001, confirming the application received container signals directly. Ran docker compose stop currency using the default Compose stop timeout and observed "Received SIGTERM, shutting down Currency Server". The container exited normally in one second with exit code 0, OOMKilled=false, and no provider flush/shutdown failures or exporter errors in the Currency logs.

This exercises signal delivery and the complete shutdown control flow against a live Collector. It does not simulate a deliberately long-running in-flight RPC.