### PR TITLE
fix(flagd): productCatalogFailure targeting rule always resolves to off

### DIFF
--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -150,7 +150,7 @@
               "OLJCESPC7Z"
             ]
           },
-          "off",
+          "on",
           "off"
         ]
       },


### PR DESCRIPTION
## Summary

The `productCatalogFailure` feature flag's targeting rule in `demo.flagd.json` has both branches returning `"off"`:

```json
"targeting": {
  "if": [
    { "==": [{"var": "product_id"}, "OLJCESPC7Z"] },
    "off",   // ← bug: should be "on"
    "off"
  ]
}
```

In flagd/OpenFeature, a defined `targeting` rule takes precedence over `defaultVariant` when the evaluation context resolves. Since `src/product-catalog/main.go:420` passes `product_id` in the evaluation context:

```go
func (p *productCatalog) checkProductFailure(ctx context.Context, id string) bool {
    return flags.ProductCatalogFailure.Value(ctx, openfeature.NewTargetlessEvaluationContext(map[string]any{"product_id": id}))
}
```

...the targeting rule **always fires** and the flag can never evaluate to `"on"`, regardless of what `defaultVariant` is set to. This makes the `productCatalogFailure` fault scenario physically un-injectable.

## Fix

Change the first branch (the "then" case when `product_id == "OLJCESPC7Z"`) from `"off"` to `"on"`.

**Before**: `if product_id == OLJCESPC7Z then "off" else "off"` → always off
**After**: `if product_id == OLJCESPC7Z then "on" else "off"` → fault activates for the target product only

## How I found this

While benchmarking an AI SRE agent against ORCA-bench (42 incident scenarios on the OpenTelemetry Demo), the `productCatalogFailure` scenario consistently scored 0/3 despite the agent running a thorough 41-call investigation. Session replay showed the agent correctly found **zero anomalies** — because the fault was never actually injected. The flag was toggled to `defaultVariant: "on"` by the benchmark harness, but `query_flags` still reported `OFF` at investigation time because the targeting rule silently overrode `defaultVariant`.

Patching this one line and re-running the identical scenario flipped the score from 0/3 to 3/3, confirming the fix.

## Note

No other flag in the file uses a `targeting` block — `cartFailure`, `recommendationCacheFailure`, `paymentFailure`, `adFailure` all have `targeting: null` and work correctly with `defaultVariant` toggling. This bug is specific to `productCatalogFailure` and appears to be present since the flag's original commit.

---

*Disclosure: Claude Code was used as a coding assistant for this contribution. The bug discovery, investigation, and verification were done by me using my own SRE tooling and session replay.*