### PR TITLE
Adopt chloggen for changelog management to eliminate CHANGELOG.md merge conflicts

### DIFF
--- a/.chloggen/2375-flagd-ui-flag-scheduler.yaml
+++ b/.chloggen/2375-flagd-ui-flag-scheduler.yaml
@@ -1,0 +1,12 @@
+change_type: enhancement
+
+component: flagd-ui
+
+note: "Add a scheduler that periodically activates randomly picked feature flags for a random duration, so failure scenarios appear and disappear on their own without external tooling"
+
+issues: [2375]
+
+subtext: |-
+  Configurable interval, minimum and maximum hold duration, how many flags run
+  at once, per variant flag selection, and an optional seed for reproducible
+  patterns.

--- a/.chloggen/3656-cart-opamp-health.yaml
+++ b/.chloggen/3656-cart-opamp-health.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: cart
+
+note: "Report health to the demo's OpAMP server when running with the observability stack"
+
+issues: [3656]

--- a/.chloggen/3662-collector-redaction-example.yaml
+++ b/.chloggen/3662-collector-redaction-example.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: collector
+
+note: "Add a data redaction/deletion example: delete, hash, and partially mask sensitive attributes with the transform processor, plus a documented redaction-processor fallback"
+
+issues: [3662]

--- a/.chloggen/3754-react-native-checkout-city-state.yaml
+++ b/.chloggen/3754-react-native-checkout-city-state.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: react-native-app
+
+note: "Render missing `City` and `State` input fields in `CheckoutForm`"
+
+issues: [3754]

--- a/.chloggen/3758-payment-error-type-attr.yaml
+++ b/.chloggen/3758-payment-error-type-attr.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: payment
+
+note: "Add `error.type` attribute to error spans in `charge.js` and `index.js` to align with OpenTelemetry Semantic Conventions for errors"
+
+issues: [3758]

--- a/.chloggen/3760-react-native-place-order-error-toast.yaml
+++ b/.chloggen/3760-react-native-place-order-error-toast.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: react-native-app
+
+note: "Catch errors from `placeOrder` in the Cart screen and show an error toast so payment failures are visible to the user instead of being silently dropped"
+
+issues: [3760]

--- a/.chloggen/3765-react-native-session-await.yaml
+++ b/.chloggen/3765-react-native-session-await.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: react-native-app
+
+note: "Fix `SessionGateway.setSessionValue` to await `getSession()`, preventing stored session corruption and loss of `userId`"
+
+issues: [3765]

--- a/.chloggen/3808-chatbot-opamp-health.yaml
+++ b/.chloggen/3808-chatbot-opamp-health.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: chatbot
+
+note: "Report health to the demo's OpAMP server when running with the agentic and observability stacks"
+
+issues: [3808]

--- a/.chloggen/3844-payment-grpc-server-start.yaml
+++ b/.chloggen/3844-payment-grpc-server-start.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: payment
+
+note: "Fix gRPC server not starting by calling `server.start()` after `bindAsnc()`"
+
+issues: [3844]
+
+subtext: |-
+  The server bound to the port but was never started to accept connections,
+  causing the service to fail its health checks.

--- a/.chloggen/3873-load-generator-revert-k6.yaml
+++ b/.chloggen/3873-load-generator-revert-k6.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: load-generator
+
+note: "Revert #3564: replace k6 with the pre-k6 Locust-based load generator, removing the now-unused `loadGeneratorTraffic` and `loadGeneratorVUs` feature flags along with it"
+
+issues: [3873]

--- a/.chloggen/3877-shipping-quote-float-truncation.yaml
+++ b/.chloggen/3877-shipping-quote-float-truncation.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: shipping
+
+note: "Fix floating-point truncation in `create_quote_from_float` and add two-digit zero padding to `fmt::Display for Quote`"
+
+issues: [3877]

--- a/.chloggen/3901-checkout-product-catalog-contrib-bump.yaml
+++ b/.chloggen/3901-checkout-product-catalog-contrib-bump.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: "checkout, product-catalog"
+
+note: "Bump `go.opentelemetry.io/contrib` to the v1.46.0/v0.71.0 release line, picking up otelgrpc recording `error.type` on RPC duration metrics for failed calls"
+
+issues: [3901]

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. frontend, checkout, collector, load-generator)
+component:
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues or pull requests related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use a strip-chomping block scalar (|-) for multiline entries so no trailing
+# whitespace is emitted into CHANGELOG.md.
+subtext:

--- a/.chloggen/adopt-chloggen.yaml
+++ b/.chloggen/adopt-chloggen.yaml
@@ -1,0 +1,12 @@
+change_type: enhancement
+
+component: repo
+
+note: Manage the changelog with per-PR `.chloggen` fragment files (chloggen) instead of hand-editing the shared `CHANGELOG.md` Unreleased section, eliminating changelog merge conflicts
+
+issues: [3926]
+
+subtext: |-
+  Contributors now run `make chlog-new` to add a fragment; fragments are folded
+  into CHANGELOG.md at release time with `make chlog-update VERSION=x.x.x`. See
+  CONTRIBUTING.md for the workflow.

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -1,0 +1,13 @@
+# chloggen configuration.
+# Use an ASCII summary template so generated CHANGELOG.md sections pass the
+# repository's ASCII-only sanity check (internal/tools/sanitycheck.py).
+summary_template: .chloggen/summary.tmpl
+
+# Single changelog, matching chloggen's built-in defaults. These must be set
+# explicitly here: when a config file is passed, chloggen v0.30.0 does not
+# backfill them (an omitted 'change_logs' also drops entries that have no
+# explicit 'change_logs' field).
+change_logs:
+  default: CHANGELOG.md
+default_change_logs:
+  - default

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,68 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+#{{ $issue }}
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### Breaking changes
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### Deprecations
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### New components
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### Enhancements
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### Bug fixes
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,6 +125,24 @@ jobs:
       - name: Run checklicense
         run: make checklicense
 
+  # Validates that every fragment in .chloggen/ is well-formed. This does not
+  # require a fragment to be present on a PR; the `Skip Changelog` label is
+  # documented as the convention for when/if presence enforcement is enabled.
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: '1.25.10'
+      - name: Validate changelog fragments
+        run: make chlog-validate
+
   weaver-check:
     name: Weaver check
     runs-on: ubuntu-latest
@@ -189,6 +207,7 @@ jobs:
       checklinks,
       sanity,
       checklicense,
+      changelog,
       weaver-check,
       react-native-build,
       codeql-analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,14 @@
 # Changelog
 
-Please update changelog as part of any significant pull request. Place short
-description of your change into "Unreleased" section. As part of release
-process content of "Unreleased" section content will generate release notes for
-the release.
+Changelog entries are managed with individual fragment files under
+[`.chloggen`](./.chloggen), one per pull request. The unreleased changes are
+the set of fragment files currently in that directory. Do not edit released
+sections by hand; add a fragment instead (see the
+[contributing guide](./CONTRIBUTING.md#adding-a-changelog-entry)). At release
+time, `make chlog-update VERSION=x.x.x` folds those fragments into a new
+version section directly below the marker and deletes them.
 
-## Unreleased
-
-* [shipping] Fix floating-point truncation in `create_quote_from_float` and
-  add two-digit zero padding to `fmt::Display for Quote`
-  ([#3877](https://github.com/open-telemetry/opentelemetry-demo/issues/3877))
-* [load-generator] Revert #3564: replace k6 with the pre-k6 Locust-based load
-  generator, removing the now-unused `loadGeneratorTraffic` and
-  `loadGeneratorVUs` feature flags along with it
-  ([#3873](https://github.com/open-telemetry/opentelemetry-demo/pull/3873))
-* [react-native-app] Catch errors from `placeOrder` in the Cart screen and
-  show an error toast so payment failures are visible to the user instead of
-  being silently dropped
-  ([#3760](https://github.com/open-telemetry/opentelemetry-demo/issues/3760))
-* [checkout, product-catalog] Bump `go.opentelemetry.io/contrib` to the
-  v1.46.0/v0.71.0 release line, picking up otelgrpc recording `error.type`
-  on RPC duration metrics for failed calls
-  ([#3901](https://github.com/open-telemetry/opentelemetry-demo/issues/3901))
-* [collector] Add a data redaction/deletion example: delete, hash, and partially
-  mask sensitive attributes with the transform processor, plus a documented
-  redaction-processor fallback
-  ([#3662](https://github.com/open-telemetry/opentelemetry-demo/pull/3662))
-* [flagd-ui] Add a scheduler that periodically activates randomly picked feature
-  flags for a random duration, so failure scenarios appear and disappear on
-  their own without external tooling. Configurable interval, minimum and maximum
-  hold duration, how many flags run at once, per variant flag selection, and an
-  optional seed for reproducible patterns
-  ([#2375](https://github.com/open-telemetry/opentelemetry-demo/issues/2375))
-* [react-native-app] Fix `SessionGateway.setSessionValue` to await `getSession()`,
-  preventing stored session corruption and loss of `userId`
-  ([#3765](https://github.com/open-telemetry/opentelemetry-demo/issues/3765))
-* [cart] Report health to the demo's OpAMP server when running with the
-  observability stack.
-  ([#3656](https://github.com/open-telemetry/opentelemetry-demo/pull/3656))
-* [chatbot] Report health to the demo's OpAMP server when running with the
-  agentic and observability stacks.
-  ([#3808](https://github.com/open-telemetry/opentelemetry-demo/pull/3808))
-* [payment] Add `error.type` attribute to error spans in `charge.js` and
-  `index.js` to align with OpenTelemetry Semantic Conventions for errors
-  ([#3758](https://github.com/open-telemetry/opentelemetry-demo/issues/3758))
-* [react-native-app] Render missing `City` and `State` input fields in `CheckoutForm`
-  ([#3754](https://github.com/open-telemetry/opentelemetry-demo/issues/3754))
-* [payment] Fix gRPC server not starting by calling `server.start()` after `bindAsnc()`.
-  The server bound to the port but was never started to accept connections, causing
-  the service to fail its health checks.
-  ([#3844](https://github.com/open-telemetry/opentelemetry-demo/pull/3844))
+<!-- next version -->
 
 ## 3.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,11 +297,54 @@ Verify the change using the path that matches what you changed: the Webstore UI,
 direct service endpoints, container logs, Jaeger traces, Grafana dashboards, or
 other telemetry views as appropriate.
 
-Update the relevant [documentation][docs] and [Changelog](./CHANGELOG.md) before
-opening the PR for user-visible behavior, telemetry, configuration, or workflow
-changes.
+Update the relevant [documentation][docs] before opening the PR for user-visible
+behavior, telemetry, configuration, or workflow changes.
+
+#### Adding a changelog entry
+
+The `CHANGELOG.md` is generated from individual fragment files under
+[`.chloggen`](./.chloggen), one per pull request, using
+[chloggen](https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/chloggen).
+Because each PR adds its own file instead of editing a shared section, changelog
+merge conflicts are avoided.
+
+For any user-visible behavior, telemetry, configuration, or workflow change:
+
+1. Create a fragment for your branch: `make chlog-new`. This copies
+   [`.chloggen/TEMPLATE.yaml`](./.chloggen/TEMPLATE.yaml) to
+   `.chloggen/<your-branch>.yaml`.
+2. Fill in `change_type`, `component`, `note`, and `issues` (use your PR number
+   if there is no separate issue).
+3. Validate it: `make chlog-validate`. You can preview the rendered changelog
+   with `make chlog-preview`.
+4. Commit the fragment as part of your PR.
+
 Trivial typo, cosmetic, and purely internal cleanup changes may not need a
-changelog entry.
+changelog entry. If your PR does not require one, add the `Skip Changelog` label
+to indicate the omission is intentional.
+
+#### How fragments become the changelog at release time
+
+The fragments that accumulate in `.chloggen/` between releases are the
+"unreleased" changelog. During a release a maintainer runs
+`make chlog-update VERSION=x.x.x` (see [Making a new release](#making-a-new-release)),
+which collects every fragment, groups the entries by `change_type`, inserts a
+new `## x.x.x` section into `CHANGELOG.md` directly below the
+`<!-- next version -->` marker, and then deletes the consumed fragment files
+(leaving `TEMPLATE.yaml`). The marker stays in place for the next cycle.
+
+Within the new version section, entries are rendered under these fixed headings,
+in this order, and only headings that have entries appear:
+
+- `Breaking changes` (`breaking`)
+- `Deprecations` (`deprecation`)
+- `New components` (`new_component`)
+- `Enhancements` (`enhancement`)
+- `Bug fixes` (`bug_fix`)
+
+Each entry renders as `` - `component`: note (#issue) `` with any `subtext`
+indented beneath it. Run `make chlog-preview` at any time to see exactly what the
+next release section will look like without modifying any files.
 
 Open a pull request against the main `opentelemetry-demo` repo.
 
@@ -409,8 +452,14 @@ Maintainers can create a new release when desired by following these steps.
    generate release notes. Prepend a summary of the major changes to the release
    notes.
 3. After images for the new release are built and published, create a new Pull
-   Request that updates the `CHANGELOG.md` with the new version leaving the
-   `Unreleased` section for the next release. Merge the Pull Request.
+   Request that folds the changelog fragments into `CHANGELOG.md`. Optionally
+   run `make chlog-preview` first to review the generated notes, then run
+   `make chlog-update VERSION=x.x.x`. This inserts a new `## x.x.x` section
+   directly below the `<!-- next version -->` marker (entries grouped by
+   `change_type`) and deletes the consumed fragment files, leaving `.chloggen/`
+   empty aside from `TEMPLATE.yaml` for the next release. See
+   [How fragments become the changelog at release time](#how-fragments-become-the-changelog-at-release-time)
+   for the grouping details. Merge the Pull Request.
 4. Create a new Pull Request to update the deployment of the demo in the
    [OpenTelemetry Helm
    Charts](https://github.com/open-telemetry/opentelemetry-helm-charts) repo.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,15 @@ endif
 SEMCONVGEN_VERSION=0.11.0
 YAMLLINT_VERSION=1.30.0
 
+# Changelog fragment tooling (chloggen). Pinned to match the OpenTelemetry
+# Collector. Invoked from the repo root, which has no go.mod, so `go run` runs
+# the pinned tool without touching any local Go module.
+CHLOGGEN_VERSION=0.30.0
+CHLOGGEN_CONFIG=.chloggen/config.yaml
+CHLOGGEN=go run go.opentelemetry.io/build-tools/chloggen@v$(CHLOGGEN_VERSION)
+# Default changelog fragment filename is derived from the current branch name.
+FILENAME?=$(shell git branch --show-current | sed 's/[^a-zA-Z0-9]/_/g')
+
 .PHONY: all
 all: install-tools markdownlint misspell yamllint
 
@@ -87,6 +96,7 @@ checklicense:	$(ADDLICENSE)
 		-ignore node_modules/** \
 		-ignore .expo/** \
 		-ignore Pods/** \
+		-ignore ".chloggen/**" \
 		-ignore **/extras/** \
 		-ignore **/vendor/** \
 		-ignore **/.venv/** \
@@ -105,6 +115,7 @@ addlicense:	$(ADDLICENSE)
 		-ignore node_modules/** \
 		-ignore .expo/** \
 		-ignore Pods/** \
+		-ignore ".chloggen/**" \
 		-ignore **/extras/** \
 		-ignore **/vendor/** \
 		-ignore **/.venv/** \
@@ -123,13 +134,37 @@ checklinks:
 
 # Run all checks in order of speed / likely failure.
 .PHONY: check
-check: misspell markdownlint checklicense checklinks
+check: misspell markdownlint checklicense checklinks chlog-validate
 	@echo "All checks complete"
 
 # Attempt to fix issues / regenerate tables.
 .PHONY: fix
 fix: misspell-correction
 	@echo "All autofixes complete"
+
+# Changelog fragments (chloggen). See CONTRIBUTING.md for the workflow.
+# Create a new fragment for the current branch (edit the generated file after):
+#   make chlog-new
+.PHONY: chlog-new
+chlog-new:
+	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG) --filename $(FILENAME)
+
+# Validate that every fragment in .chloggen/ is well-formed. Run in CI.
+.PHONY: chlog-validate
+chlog-validate:
+	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+
+# Preview the CHANGELOG.md that the current fragments would produce.
+.PHONY: chlog-preview
+chlog-preview:
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+
+# Fold all fragments into CHANGELOG.md under the given version and delete them.
+# Run during the release process:
+#   make chlog-update VERSION=1.13.0
+.PHONY: chlog-update
+chlog-update:
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version $(VERSION)
 
 .PHONY: install-tools
 install-tools: $(MISSPELL) $(ADDLICENSE)


### PR DESCRIPTION
Fixes #3926. Today every PR edits the shared `## Unreleased` section of `CHANGELOG.md`, so PRs that stay open collide on the same lines and constantly need changelog rebases.

This adopts [chloggen](https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/chloggen), the same tooling used by `opentelemetry-collector` and `opentelemetry-collector-contrib`, so each PR adds its own fragment file under `.chloggen/` that is folded into `CHANGELOG.md` at release time. Because every PR creates a new file, changelog merge conflicts are eliminated by construction.

**What's included:**

- `.chloggen/TEMPLATE.yaml` plus `make chlog-new`/`chlog-validate`/`chlog-preview`/`chlog-update` (chloggen pinned to v0.30.0, matching the Collector).
- A `changelog` CI job running `make chlog-validate`, wired into the build gate.
- CONTRIBUTING and release-process docs updated to describe the fragment workflow.
- The 11 existing `## Unreleased` entries migrated into fragments (validated with `make chlog-validate` and previewed with `make chlog-preview`; yamllint and markdownlint also pass locally).

**Enforcement:** CI validates fragment syntax only and does not require a fragment per PR. The `Skip Changelog` label is documented as the convention for when/if the SIG decides to enforce fragment presence.

Opening as draft to get SIG feedback on the approach before finalizing.
