### PR TITLE
Show service names in event volume table

### DIFF
--- a/.chloggen/3937-event-table-service-name.yaml
+++ b/.chloggen/3937-event-table-service-name.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: grafana
+
+note: Show service names in the event volume table.
+
+issues: [3937]
+
+subtext:

--- a/src/grafana/provisioning/dashboards/demo/events-by-name.json
+++ b/src/grafana/provisioning/dashboards/demo/events-by-name.json
@@ -26,7 +26,7 @@
         "type": "grafana-opensearch-datasource",
         "uid": "webstore-logs"
       },
-      "description": "Events grouped by their EventName, ordered by volume.",
+      "description": "Events grouped by service and EventName, ordered by volume.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -79,7 +79,7 @@
             "uid": "webstore-logs"
           },
           "format": "table",
-          "query": "source=otel-logs-*\n| where eventName != ''\n| where resource.service.name in (${service:singlequote})\n| where eventName in (${event_name:singlequote})\n| where severity.text in (${severity:singlequote})\n| stats count() as log_count by eventName\n| sort - log_count\n| head 20",
+          "query": "source=otel-logs-*\n| where eventName != ''\n| where resource.service.name in (${service:singlequote})\n| where eventName in (${event_name:singlequote})\n| where severity.text in (${severity:singlequote})\n| stats count() as log_count by resource.service.name, eventName\n| sort - log_count\n| head 20",
           "queryType": "PPL",
           "refId": "A",
           "timeField": "observedTimestamp"
@@ -93,10 +93,12 @@
             "excludeByName": {},
             "includeByName": {},
             "indexByName": {
-              "eventName": 0,
-              "log_count": 1
+              "resource.service.name": 0,
+              "eventName": 1,
+              "log_count": 2
             },
             "renameByName": {
+              "resource.service.name": "Service",
               "eventName": "Event Name",
               "log_count": "Events"
             }


### PR DESCRIPTION
## Changes

- Add the service name to the event volume table.
- Group event counts by service and event name.
<img width="877" height="671" alt="image" src="https://github.com/user-attachments/assets/b62474a8-63a4-41e6-8cf5-b8b9bab5b72b" />
