### PR TITLE
fix: use self-repository workflow syntax

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,4 +18,4 @@ jobs:
       contents: read  # required by the component-build-images reusable workflow
       packages: write  # required to push built images to GHCR
     if: ${{ !github.event.repository.fork }}
-    uses: ./.github/workflows/component-build-images.yml
+    uses: $/.github/workflows/component-build-images.yml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:  # required by the reusable workflow
       contents: read  # required by the component-build-images reusable workflow
       packages: write  # required to push built images to GHCR
-    uses: ./.github/workflows/component-build-images.yml
+    uses: $/.github/workflows/component-build-images.yml
     with:
       push: ${{ github.event_name == 'push' }}
       force_build: ${{ github.event_name == 'push' }}
@@ -187,7 +187,7 @@ jobs:
   react-native-build:
     needs: check-react-native-changes
     if: needs.check-react-native-changes.outputs.should_build == 'true'
-    uses: ./.github/workflows/react-native-build.yml
+    uses: $/.github/workflows/react-native-build.yml
 
   codeql-analysis:
     name: CodeQL analysis
@@ -195,7 +195,7 @@ jobs:
       actions: read  # required to scan GitHub Actions workflows
       contents: read  # required to checkout the repository
       security-events: write  # required to upload CodeQL SARIF to code scanning
-    uses: ./.github/workflows/codeql-analysis.yml
+    uses: $/.github/workflows/codeql-analysis.yml
 
   build-test:
     name: build-test

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:  # required by the reusable workflow
       contents: read  # required by the component-build-images reusable workflow
       packages: write  # required to push built images to GHCR
-    uses: ./.github/workflows/component-build-images.yml
+    uses: $/.github/workflows/component-build-images.yml
     if: ${{ !github.event.repository.fork }}
     with:
       push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:  # required by the reusable workflow
       contents: read  # required by the component-build-images reusable workflow
       packages: write  # required to push built images to GHCR
-    uses: ./.github/workflows/component-build-images.yml
+    uses: $/.github/workflows/component-build-images.yml
     if: ${{ !github.event.repository.fork }}
     with:
       push: true


### PR DESCRIPTION
# Changes

Fixes new issues detected by zizmor.

Related to [github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)

Tested locally, with fixes not more zizmor findings

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* ~~[ ] `CHANGELOG.md` updated to document new feature additions~~
* ~~[ ] Appropriate documentation updates in the [docs][]~~
* ~~[ ] Appropriate Helm chart updates in the [helm-charts][]~~

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
