### PR TITLE
ci: add Podman build validation for changed Dockerfiles

### DIFF
--- a/.github/workflows/podman-build-check.yml
+++ b/.github/workflows/podman-build-check.yml
@@ -1,0 +1,54 @@
+name: Podman Build Check
+
+on:
+  pull_request:
+    paths:
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
+      - '.github/workflows/podman-build-check.yml'
+
+jobs:
+  podman-build:
+    name: Build changed Dockerfiles with Podman
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Find changed Dockerfiles
+        id: changed-dockerfiles
+        run: |
+          git diff --name-only \
+            --diff-filter=ACMRT \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            | grep -E '(^|/)Dockerfile(\..*)?$' > changed-dockerfiles.txt || true
+
+          echo "Changed Dockerfiles:"
+          cat changed-dockerfiles.txt
+
+      - name: Build changed Dockerfiles
+        run: |
+          while IFS= read -r dockerfile; do
+            [ -z "$dockerfile" ] && continue
+
+            echo "::group::Building $dockerfile"
+            echo "Build context: ."
+
+            podman build \
+              --file "$dockerfile" \
+              .
+
+            echo "::endgroup::"
+          done < changed-dockerfiles.txt


### PR DESCRIPTION
# Changes

Added a dedicated GitHub Actions workflow to validate modified service Dockerfiles using `podman build`.

The workflow is scoped to Dockerfile changes so that only affected Dockerfiles are built instead of rebuilding the entire service image set.

### Implementation

* Added `.github/workflows/podman-build-check.yml`.
* Configured the workflow to trigger for changes to:

  * `**/Dockerfile`
  * `**/Dockerfile.*`
  * `.github/workflows/podman-build-check.yml`
* Added Podman installation to the CI runner.
* Detects Dockerfiles changed between the pull request base and head commits.
* Builds only the changed Dockerfiles using `podman build`.
* Uses the repository root as the build context.
* Supports both standard Dockerfiles and `Dockerfile.*` variants.
* A failed Podman build causes the CI job to fail, surfacing build compatibility issues in the pull request.

This keeps the Podman validation targeted to affected services and avoids the unnecessary CI overhead of building all service images on every pull request.

### Merge Requirements

The following requirements are intentionally left unchecked because this PR only introduces a GitHub Actions CI validation workflow and does **not** introduce a new feature, modify instrumentation, change documentation, or alter service deployment configuration:

* `CHANGELOG.md` does not require an update because this is a CI/infrastructure change and does not introduce a user-facing feature.
* No documentation update is required because the change only affects automated CI validation and does not change the Demo's usage or behavior.
* No Helm chart update is required because this PR does not modify `compose*.yaml`, `otelcol-config*.yml`, Grafana dashboards, or any service deployment configuration.

- [ ] `CHANGELOG.md` updated to document new feature additions
- [ ] Appropriate documentation updates in the [[docs](https://opentelemetry.io/docs/demo/)][]
- [ ] Appropriate Helm chart updates in the [[helm-charts](https://github.com/open-telemetry/opentelemetry-helm-charts)][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies compose*.yaml, otelcol-config*.yml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers)](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

Closes #3970 